### PR TITLE
Fix argument serialisation in metrics

### DIFF
--- a/src/metrics.ts
+++ b/src/metrics.ts
@@ -34,7 +34,7 @@ CREATE TABLE IF NOT EXISTS "commands" (
 		const channel = interaction.channel?.id;
 		const author = interaction.user.id;
 		const command = interaction.commandName;
-		const args = interaction.options.data.join();
+		const args = interaction.options.data.map(o => `${o.name}: ${o.value}`).join();
 		this.commandStatement.run(id, guild, channel, author, command, args, latency);
 	}
 

--- a/src/metrics.ts
+++ b/src/metrics.ts
@@ -34,7 +34,7 @@ CREATE TABLE IF NOT EXISTS "commands" (
 		const channel = interaction.channel?.id;
 		const author = interaction.user.id;
 		const command = interaction.commandName;
-		const args = interaction.options.data.map(o => `${o.name}: ${o.value}`).join();
+		const args = JSON.stringify(interaction.options.data);
 		this.commandStatement.run(id, guild, channel, author, command, args, latency);
 	}
 


### PR DESCRIPTION
Fix #10 

We were joining an array of objects, we now map those objects to strings first.

The format of the string we record is up for discussion. The initial implementation was a simple, human-readable option but something like JSON may be preferable for comprehensiveness and program-readability.