### PR TITLE
Add option to show deck profile publicly

### DIFF
--- a/src/commands/deck.ts
+++ b/src/commands/deck.ts
@@ -60,10 +60,13 @@ export class DeckCommand extends Command {
 		// populate the names into a Map to be fetched linearly
 		const nameMemo: Map<number, string> = new Map<number, string>();
 		cards.forEach(c => {
-			nameMemo.set(c.password, c.name_en);
+			// in case an API error returns a null response for a card, we don't record its name and a fallback will be triggered later
+			if (c) {
+				nameMemo.set(c.password, c.name_en);
+			}
 		});
 		// apply the names to the record of the deck
-		// toString is fallback for missing name, though in reality we'd run into an issue in the API first?
+		// toString is fallback for missing name, e.g. if an API error returns null
 		const getName = (password: number): string => nameMemo.get(password) || password.toString();
 		const namedDeck = {
 			main: [...deck.main].map(getName),

--- a/src/commands/deck.ts
+++ b/src/commands/deck.ts
@@ -30,6 +30,12 @@ export class DeckCommand extends Command {
 					name: "deck",
 					description: "The ydke:// URL of the deck you want to view.",
 					required: true
+				},
+				{
+					type: "BOOLEAN",
+					name: "public",
+					description: "Whether to display the deck details publicly in chat. This is false by default.",
+					required: false
 				}
 			]
 		};
@@ -115,8 +121,9 @@ export class DeckCommand extends Command {
 			// placeholder latency
 			return 0;
 		}
+		const isPublic = interaction.options.getBoolean("public", false) || false;
 		const content = await this.generateProfile(deck);
-		await interaction.reply({ embeds: [content], ephemeral: true }); // Actually returns void
+		await interaction.reply({ embeds: [content], ephemeral: !isPublic }); // Actually returns void
 
 		// placeholder latency value
 		return 0;


### PR DESCRIPTION
Uses new optional "public" parameter with default false to determine whether or not to use an ephemeral reply.

This option has arguable applicability to almost any command, but is particularly well-suited to deck profiles because they can be shared or kept private, and can clog the chat.