### PR TITLE
deck: Add new UI flourishes

### DIFF
--- a/src/commands/deck.ts
+++ b/src/commands/deck.ts
@@ -58,7 +58,7 @@ export class DeckCommand extends Command {
 		return this.#logger;
 	}
 
-	async generateProfile(deck: TypedDeck, isInline: boolean = true): Promise<MessageEmbed> {
+	async generateProfile(deck: TypedDeck, isInline = true): Promise<MessageEmbed> {
 		// use Set to remove duplicates from list of passwords to pass to API
 		const allUniqueCards = [...new Set([...deck.main, ...deck.extra, ...deck.side])];
 		// get names from API

--- a/src/commands/deck.ts
+++ b/src/commands/deck.ts
@@ -38,6 +38,13 @@ export class DeckCommand extends Command {
 					name: "public",
 					description: "Whether to display the deck details publicly in chat. This is false by default.",
 					required: false
+				},
+				{
+					type: "BOOLEAN",
+					name: "stacked",
+					description:
+						"Whether to display the Main, Side and Extra deck as one stacked column instead of side-by-side. This is false by default.",
+					required: false
 				}
 			]
 		};
@@ -51,7 +58,7 @@ export class DeckCommand extends Command {
 		return this.#logger;
 	}
 
-	async generateProfile(deck: TypedDeck): Promise<MessageEmbed> {
+	async generateProfile(deck: TypedDeck, isInline: boolean = true): Promise<MessageEmbed> {
 		// use Set to remove duplicates from list of passwords to pass to API
 		const allUniqueCards = [...new Set([...deck.main, ...deck.extra, ...deck.side])];
 		// get names from API
@@ -139,7 +146,8 @@ export class DeckCommand extends Command {
 			const headerParts = mainTypes.map(printTypeCount("main")).filter(t => !!t);
 			embed.addField(
 				`Main Deck (${sums.main} cards${headerParts.length > 0 ? ` - ${headerParts.join(", ")}` : ""})`,
-				content
+				content,
+				isInline
 			);
 		}
 		if (sums.extra > 0) {
@@ -147,7 +155,8 @@ export class DeckCommand extends Command {
 			const headerParts = extraTypes.map(printTypeCount("extra")).filter(t => !!t);
 			embed.addField(
 				`Extra Deck (${sums.extra} cards${headerParts.length > 0 ? ` - ${headerParts.join(", ")}` : ""})`,
-				content
+				content,
+				isInline
 			);
 		}
 		if (sums.side > 0) {
@@ -155,7 +164,8 @@ export class DeckCommand extends Command {
 			const headerParts = mainTypes.map(printTypeCount("side")).filter(t => !!t);
 			embed.addField(
 				`Side Deck (${sums.side} cards${headerParts.length > 0 ? ` - ${headerParts.join(", ")}` : ""})`,
-				content
+				content,
+				isInline
 			);
 		}
 		return embed;
@@ -175,8 +185,9 @@ export class DeckCommand extends Command {
 			// placeholder latency
 			return 0;
 		}
-		const isPublic = interaction.options.getBoolean("public", false) || false;
-		const content = await this.generateProfile(deck);
+		const isPublic = !!interaction.options.getBoolean("public", false);
+		const isStacked = !!interaction.options.getBoolean("stacked", false);
+		const content = await this.generateProfile(deck, !isStacked);
 		await interaction.reply({ embeds: [content], ephemeral: !isPublic }); // Actually returns void
 
 		// placeholder latency value

--- a/src/commands/deck.ts
+++ b/src/commands/deck.ts
@@ -177,12 +177,7 @@ export class DeckCommand extends Command {
 		}
 		const isPublic = interaction.options.getBoolean("public", false) || false;
 		const content = await this.generateProfile(deck);
-		content.setColor(16747347);
-		const test = new MessageEmbed();
-		test.setTitle("test");
-		test.addField("test", "test");
-		test.setColor(1941108);
-		await interaction.reply({ embeds: [content, test], ephemeral: !isPublic }); // Actually returns void
+		await interaction.reply({ embeds: [content], ephemeral: !isPublic }); // Actually returns void
 
 		// placeholder latency value
 		return 0;


### PR DESCRIPTION
Adds counts of Main and Extra deck categories to the section headers.
Adds the option to view sections as side-by-side columns.
Includes adaptations for updates to the API
A bunch of janky lambdas here to avoid code duplication between main/extra/side. This might not be it, chief.