### PR TITLE
Add /id command

### DIFF
--- a/src/commands/deck.ts
+++ b/src/commands/deck.ts
@@ -8,7 +8,8 @@ import { Command } from "../Command";
 import { getLogger, Logger } from "../logger";
 import { Metrics } from "../metrics";
 
-interface APICard {
+// TODO: move somewhere central?
+export interface APICard {
 	kid: number;
 	password: number;
 	en: { name: string };

--- a/src/commands/id.ts
+++ b/src/commands/id.ts
@@ -1,0 +1,84 @@
+import { SlashCommandBuilder, SlashCommandStringOption } from "@discordjs/builders";
+import { RESTPostAPIApplicationCommandsJSONBody } from "discord-api-types/v9";
+import { CommandInteraction, MessageEmbed } from "discord.js";
+import { injectable } from "tsyringe";
+import { Command } from "../Command";
+import { getLogger, Logger } from "../logger";
+import { Metrics } from "../metrics";
+import { APICard } from "./deck";
+
+@injectable()
+export class IdCommand extends Command {
+	#logger = getLogger("command:id");
+
+	constructor(metrics: Metrics) {
+		super(metrics);
+	}
+
+	static override get meta(): RESTPostAPIApplicationCommandsJSONBody {
+		return new SlashCommandBuilder()
+			.setName("id")
+			.setDescription("Identify a card by password, Konami ID, or name.")
+			.addStringOption(
+				new SlashCommandStringOption()
+					.setName("type")
+					.setDescription("Whether you're searching by password, Konami ID, or name.")
+					.setRequired(true) // TODO: make optional and infer if missing
+					.addChoice("Password", "password")
+					.addChoice("Konami ID", "kid")
+					.addChoice("Name", "name")
+			)
+			.addStringOption(
+				new SlashCommandStringOption()
+					.setName("input")
+					.setDescription("The password, Konami ID, or name you're searching by.")
+					.setRequired(true)
+			)
+			.toJSON();
+	}
+
+	protected override get logger(): Logger {
+		return this.#logger;
+	}
+
+	async getCard(type: "password" | "kid" | "name", input: string): Promise<APICard | undefined> {
+		let url = `${process.env.SEARCH_API}`; // treated as string instead of string? without forbidden non-null check
+		if (type === "password") {
+			url += `/card/password/${input}`;
+		} else if (type === "kid") {
+			url += `/card/kid/${input}`;
+		} else {
+			url += `/search?name=${input}`;
+		}
+		const response = await fetch(url);
+		if (response.status === 404) {
+			return undefined;
+		}
+		return await response.json();
+	}
+
+	protected override async execute(interaction: CommandInteraction): Promise<number> {
+		const type = interaction.options.getString("type", true) as "password" | "kid" | "name";
+		const input = interaction.options.getString("input", true);
+		const card = await this.getCard(type, input);
+		if (!card) {
+			// TODO: include properly-named type in this message
+			await interaction.reply(`Could not find a card matching \`${input}\`!`);
+		} else {
+			const embed = new MessageEmbed()
+				.setTitle(card?.en.name)
+				.addField("Password", card.password.toString(), true)
+				.addField("Konami ID", card.kid.toString(), true);
+			// TODO: decide on ephemerality
+			await interaction.reply({ embeds: [embed], ephemeral: true }); // Actually returns void
+		}
+		const reply = await interaction.fetchReply();
+		if ("createdTimestamp" in reply) {
+			const latency = reply.createdTimestamp - interaction.createdTimestamp;
+			return latency;
+		} else {
+			const latency = Number(reply.timestamp) - interaction.createdTimestamp;
+			return latency;
+		}
+	}
+}

--- a/src/commands/id.ts
+++ b/src/commands/id.ts
@@ -44,6 +44,7 @@ export class IdCommand extends Command {
 
 	async getCard(type: "password" | "kid" | "name", input: string): Promise<APICard | undefined> {
 		let url = `${process.env.SEARCH_API}`; // treated as string instead of string? without forbidden non-null check
+		input = encodeURIComponent(input);
 		if (type === "password") {
 			url += `/card/password/${input}`;
 		} else if (type === "kid") {

--- a/src/commands/id.ts
+++ b/src/commands/id.ts
@@ -1,6 +1,7 @@
 import { SlashCommandBuilder, SlashCommandStringOption } from "@discordjs/builders";
 import { RESTPostAPIApplicationCommandsJSONBody } from "discord-api-types/v9";
 import { CommandInteraction, MessageEmbed } from "discord.js";
+import fetch from "node-fetch";
 import { injectable } from "tsyringe";
 import { Command } from "../Command";
 import { getLogger, Logger } from "../logger";
@@ -63,7 +64,7 @@ export class IdCommand extends Command {
 		const card = await this.getCard(type, input);
 		if (!card) {
 			// TODO: include properly-named type in this message
-			await interaction.reply(`Could not find a card matching \`${input}\`!`);
+			await interaction.reply({ content: `Could not find a card matching \`${input}\`!`, ephemeral: true });
 		} else {
 			const embed = new MessageEmbed()
 				.setTitle(card?.en.name)

--- a/src/commands/id.ts
+++ b/src/commands/id.ts
@@ -62,13 +62,14 @@ export class IdCommand extends Command {
 		let type = interaction.options.getString("type", false) as "password" | "kid" | "name" | undefined;
 		let input = interaction.options.getString("input", true);
 		if (!type) {
-			if (parseInt(input).toString() === input) {
+			// handle edge case for specific bad input
+			if (parseInt(input).toString() === input && input !== "NaN") {
 				// if its all digits, treat as password.
 				type = "password";
 			} else if (input.startsWith("#")) {
 				// initial # indicates KID, as long as the rest is digits
 				const kid = input.slice(1);
-				if (parseInt(kid).toString() === kid) {
+				if (parseInt(kid).toString() === kid && kid !== "NaN") {
 					type = "kid";
 					input = kid;
 				} else {

--- a/src/commands/id.ts
+++ b/src/commands/id.ts
@@ -53,10 +53,15 @@ export class IdCommand extends Command {
 			url += `/search?name=${input}`;
 		}
 		const response = await fetch(url);
-		if (response.status === 404) {
+		// 400: Bad syntax, 404: Not found
+		if (response.status === 400 || response.status === 404) {
 			return undefined;
 		}
-		return await response.json();
+		// 200: OK
+		if (response.status === 200) {
+			return await response.json();
+		}
+		throw new Error((await response.json()).message);
 	}
 
 	protected override async execute(interaction: CommandInteraction): Promise<number> {

--- a/src/commands/index.ts
+++ b/src/commands/index.ts
@@ -2,12 +2,13 @@ import { REST } from "@discordjs/rest";
 import { APIUser, Routes } from "discord-api-types/v9";
 import { ApplicationCommandData, ClientApplication, Guild, Snowflake } from "discord.js";
 import { DeckCommand } from "./deck";
+import { IdCommand } from "./id";
 import { LinkCommand } from "./link";
 import { PingCommand } from "./ping";
 import { YugiCommand } from "./yugipedia";
 
-export const classes = [DeckCommand, PingCommand, LinkCommand, YugiCommand];
-export { DeckCommand, PingCommand, LinkCommand, YugiCommand };
+export const classes = [DeckCommand, PingCommand, LinkCommand, YugiCommand, IdCommand];
+export { DeckCommand, PingCommand, LinkCommand, YugiCommand, IdCommand };
 
 interface LoggableCommandMetadata {
 	id: Snowflake;


### PR DESCRIPTION
Close #23.
The name need not be final, we no longer call passwords `ids` and it could be confused with the `kid`, but we *can* justify the name by saying it identifies cards?
Inference of the input type is not implemented yet. 