### PR TITLE
Improve latency calculations and never inadvertently fail a command due to network delays

### DIFF
--- a/docs/commands/search.md
+++ b/docs/commands/search.md
@@ -27,9 +27,9 @@ If `type` is unspecified, infers the type of `input` using these rules:
 In the first two cases, a direct lookup of the card is performed using that password or Konami ID.
 In the latter case, an English-language fuzzy search is performed on the English card name.
 
-If no match is found, an ephemeral reply informs only the caller. Otherwise, the card information is
-presented publicly in Discord embeds, using the requested `lang`, falling back to English if not
-available. The following information is displayed:
+The public reply will either be a no-match message or the card information presented in
+Discord embeds, using the requested `lang`, falling back to English if not available.
+The following information is displayed:
 
 - card name, hyperlinked to the [YGOPRODECK](https://db.ygoprodeck.com/) data source
 - frameless card artwork, if available

--- a/src/commands/id.ts
+++ b/src/commands/id.ts
@@ -87,25 +87,23 @@ export class IdCommand extends Command {
 				type = "name";
 			}
 		}
+		await interaction.deferReply({ ephemeral: true });
 		const card = await this.getCard(type, input);
+		let end: number;
 		if (!card) {
+			end = Date.now();
 			// TODO: include properly-named type in this message
-			await interaction.reply({ content: `Could not find a card matching \`${input}\`!`, ephemeral: true });
+			await interaction.editReply({ content: `Could not find a card matching \`${input}\`!` });
 		} else {
 			const embed = new MessageEmbed()
 				.setTitle(card?.en.name)
 				.addField("Password", `${card.password}`, true)
 				.addField("Konami ID", `${card.kid}`, true);
-			// TODO: decide on ephemerality
-			await interaction.reply({ embeds: addNotice(embed), ephemeral: true }); // Actually returns void
+			end = Date.now();
+			await interaction.editReply({ embeds: addNotice(embed) });
 		}
-		const reply = await interaction.fetchReply();
-		if ("createdTimestamp" in reply) {
-			const latency = reply.createdTimestamp - interaction.createdTimestamp;
-			return latency;
-		} else {
-			const latency = Number(reply.timestamp) - interaction.createdTimestamp;
-			return latency;
-		}
+		// When using deferReply, editedTimestamp is null, as if the reply was never edited, so provide a best estimate
+		const latency = end - interaction.createdTimestamp;
+		return latency;
 	}
 }

--- a/src/commands/link.ts
+++ b/src/commands/link.ts
@@ -5,6 +5,7 @@ import { inject, injectable } from "tsyringe";
 import { Command } from "../Command";
 import { getLogger, Logger } from "../logger";
 import { Metrics } from "../metrics";
+import { replyLatency } from "../utils";
 
 @injectable()
 export class LinkCommand extends Command {
@@ -93,15 +94,7 @@ export class LinkCommand extends Command {
 	protected override async execute(interaction: CommandInteraction): Promise<number> {
 		const key = interaction.options.getString("key", true);
 		const content = LinkCommand.links[key].result;
-		await interaction.reply(content); // Actually returns void
-		const reply = await interaction.fetchReply();
-		// return latency
-		if ("createdTimestamp" in reply) {
-			const latency = reply.createdTimestamp - interaction.createdTimestamp;
-			return latency;
-		} else {
-			const latency = Number(reply.timestamp) - interaction.createdTimestamp;
-			return latency;
-		}
+		const reply = await interaction.reply({ content, fetchReply: true });
+		return replyLatency(reply, interaction);
 	}
 }

--- a/src/commands/ping.ts
+++ b/src/commands/ping.ts
@@ -27,15 +27,15 @@ export class PingCommand extends Command {
 
 	protected override async execute(interaction: CommandInteraction): Promise<number> {
 		const content = `Average WebSocket ping (new instance): ${interaction.client.ws.ping} ms`;
-		await interaction.reply(content); // Actually returns void
-		const reply = await interaction.fetchReply();
+		const reply = await interaction.reply({ content, fetchReply: true });
 		if ("createdTimestamp" in reply) {
 			const latency = reply.createdTimestamp - interaction.createdTimestamp;
 			await interaction.editReply(`${content}\nTotal latency: ${latency} ms`);
 			return latency;
 		} else {
+			// This should never happen, as Bastion must be a member of its servers and also we are not using deferReply
 			const latency = Number(reply.timestamp) - interaction.createdTimestamp;
-			await interaction.editReply(`${content}\nTotal latency: ${latency} ms\nUnexpected response format`);
+			await interaction.editReply(`${content}\nTotal latency: ${latency} ms\nThis should never been seen.`);
 			return latency;
 		}
 	}

--- a/src/commands/search.ts
+++ b/src/commands/search.ts
@@ -99,23 +99,22 @@ export class SearchCommand extends Command {
 				type = "name";
 			}
 		}
+		await interaction.deferReply();
 		const card = await this.getCard(type, input);
+		let end: number;
 		if (!card) {
+			end = Date.now();
 			// TODO: include properly-named type in this message
-			await interaction.reply({ content: `Could not find a card matching \`${input}\`!`, ephemeral: true });
+			await interaction.editReply({ content: `Could not find a card matching \`${input}\`!` });
 		} else {
 			// eslint-disable-next-line @typescript-eslint/no-explicit-any
 			let embeds = createCardEmbed(card, interaction.options.getString("lang", true) as any);
 			embeds = addFunding(addNotice(embeds));
-			await interaction.reply({ embeds }); // Actually returns void
+			end = Date.now();
+			await interaction.editReply({ embeds }); // Actually returns void
 		}
-		const reply = await interaction.fetchReply();
-		if ("createdTimestamp" in reply) {
-			const latency = reply.createdTimestamp - interaction.createdTimestamp;
-			return latency;
-		} else {
-			const latency = Number(reply.timestamp) - interaction.createdTimestamp;
-			return latency;
-		}
+		// When using deferReply, editedTimestamp is null, as if the reply was never edited, so provide a best estimate
+		const latency = end - interaction.createdTimestamp;
+		return latency;
 	}
 }

--- a/src/commands/ygoprodeck.ts
+++ b/src/commands/ygoprodeck.ts
@@ -6,6 +6,7 @@ import { injectable } from "tsyringe";
 import { Command } from "../Command";
 import { getLogger, Logger } from "../logger";
 import { Metrics } from "../metrics";
+import { editLatency } from "../utils";
 
 @injectable()
 export class YGOPRODECKCommand extends Command {
@@ -45,16 +46,9 @@ export class YGOPRODECKCommand extends Command {
 
 	protected override async execute(interaction: CommandInteraction): Promise<number> {
 		const term = interaction.options.getString("term", true);
-		await interaction.reply(`Searching YGOPRODECK for \`${term}\`…`); // Actually returns void
+		await interaction.reply(`Searching YGOPRODECK for \`${term}\`…`);
 		const result = await this.search(term);
 		const reply = await interaction.editReply(result);
-		// return latency
-		if ("createdTimestamp" in reply) {
-			const latency = reply.createdTimestamp - interaction.createdTimestamp;
-			return latency;
-		} else {
-			const latency = Number(reply.timestamp) - interaction.createdTimestamp;
-			return latency;
-		}
+		return editLatency(reply, interaction);
 	}
 }

--- a/src/commands/yugipedia.ts
+++ b/src/commands/yugipedia.ts
@@ -6,6 +6,7 @@ import { injectable } from "tsyringe";
 import { Command } from "../Command";
 import { getLogger, Logger } from "../logger";
 import { Metrics } from "../metrics";
+import { editLatency } from "../utils";
 
 @injectable()
 export class YugiCommand extends Command {
@@ -56,17 +57,10 @@ export class YugiCommand extends Command {
 
 	protected override async execute(interaction: CommandInteraction): Promise<number> {
 		const page = interaction.options.getString("page", true);
-		await interaction.reply(`Searching Yugipedia for \`${page}\`…`); // Actually returns void
+		await interaction.reply(`Searching Yugipedia for \`${page}\`…`);
 		const link = await YugiCommand.getYugipediaPage(page);
 		const content = link || `Could not find a Yugipedia page named \`${page}\`.`; // TODO: externalise error message for translation/non-hardcoding?
 		const reply = await interaction.editReply(content);
-		// return latency
-		if ("createdTimestamp" in reply) {
-			const latency = reply.createdTimestamp - interaction.createdTimestamp;
-			return latency;
-		} else {
-			const latency = Number(reply.timestamp) - interaction.createdTimestamp;
-			return latency;
-		}
+		return editLatency(reply, interaction);
 	}
 }

--- a/src/utils.ts
+++ b/src/utils.ts
@@ -1,4 +1,4 @@
-import { CommandInteraction, Guild, MessageEmbed } from "discord.js";
+import { CacheType, CommandInteraction, Guild, GuildCacheMessage, MessageEmbed } from "discord.js";
 
 export function serializeServer(server: Guild): string {
 	if ("name" in server) {
@@ -66,4 +66,40 @@ export function addFunding(embeds: MessageEmbed | MessageEmbed[], chance = 0.25)
 		]);
 	}
 	return embeds;
+}
+
+/**
+ * Compute the interval from command invocation to response for a command based
+ * on the reply timestamp. Do not use when the reply must be edited to be considered
+ * complete, such as when using deferReply.
+ *
+ * @param reply The canonical reply to a Slash Command invocation.
+ * @param interaction The triggering command interaction.
+ * @returns latency in milliseconds
+ */
+export function replyLatency(reply: GuildCacheMessage<CacheType>, interaction: CommandInteraction): number {
+	if ("createdTimestamp" in reply) {
+		return reply.createdTimestamp - interaction.createdTimestamp;
+	} else {
+		// This should never happen, as Bastion must be a member of its servers.
+		return -1;
+	}
+}
+
+/**
+ * Compute the itnerval from command invocation to response last edited for a command.
+ * Do not use if the response is never edited, or when deferReply is used, since
+ * editedTimestamp will be null.
+ *
+ * @param reply The canonical reply to a Slash Command invocation that has been edited, excluding deferReply.
+ * @param interaction The triggering command interaction.
+ * @returns latency in milliseconds
+ */
+export function editLatency(reply: GuildCacheMessage<CacheType>, interaction: CommandInteraction): number {
+	if ("editedTimestamp" in reply && reply.editedTimestamp !== null) {
+		return reply.editedTimestamp - interaction.createdTimestamp;
+	} else {
+		// This should never happen, as Bastion must be a member of its servers.
+		return -1;
+	}
 }


### PR DESCRIPTION
Promise.any or Promise.race may be useful to defer/initial reply and send the API request simultaneously