### PR TITLE
/search: use LocaleProvider and make lang parameter optional

### DIFF
--- a/docs/commands/search.md
+++ b/docs/commands/search.md
@@ -13,7 +13,7 @@ Find all information on a card! _This command is in development._
 Name | Required? | Description | Type
 --- | --- | --- | ---
 `input` | ✔ | The password, Konami ID, or name you're searching by. | text
-`lang` | ✔ | The query and result language. | one of "en", "fr", "de", "it", "pt"
+`lang` | ❌ | The result language. | one of "en", "fr", "de", "it", "pt"
 `type` | ❌ | Whether you're searching by password, Konami ID, or name. | one of "password", "kid", "name"
 
 ## Current behaviour
@@ -28,7 +28,10 @@ In the first two cases, a direct lookup of the card is performed using that pass
 In the latter case, an English-language fuzzy search is performed on the English card name.
 
 The public reply will either be a no-match message or the card information presented in
-Discord embeds, using the requested `lang`, falling back to English if not available.
+Discord embeds. This will be in the requested `lang` if specified, otherwise using the
+locale for the channel or server per [Bastion's locale setting](/docs/command/locale.md),
+and falling back to English if not available.
+
 The following information is displayed:
 
 - card name, hyperlinked to the [YGOPRODECK](https://db.ygoprodeck.com/) data source
@@ -62,7 +65,6 @@ In no particular order:
 - handle alternative artworks
 - add support for more languages (Spanish, Japanese, Korean, Chinese)
 - localize labels used in the embed
-- set default language per server or per channel, including direct messages
 - add a button to pull up more matches like the old `.match` or `.search`
 - depending on how alternative artworks are handled, add a button to display those too
 - support simple queries on other card properties

--- a/src/commands/locale.ts
+++ b/src/commands/locale.ts
@@ -1,5 +1,5 @@
 import { SlashCommandBuilder } from "@discordjs/builders";
-import { RESTPostAPIApplicationCommandsJSONBody, Snowflake } from "discord-api-types/v9";
+import { RESTPostAPIApplicationCommandsJSONBody } from "discord-api-types/v9";
 import { CommandInteraction } from "discord.js";
 import { inject, injectable } from "tsyringe";
 import { Command } from "../Command";
@@ -57,22 +57,11 @@ export class LocaleCommand extends Command {
 		return this.#logger;
 	}
 
-	/**
-	 * channel.parentId may refer to a category or a text channel. Return the parent text channel
-	 * for threads only, and the current channel otherwise.
-	 *
-	 * @param interaction
-	 * @returns The channel snowflake to use for setting locale
-	 */
-	private getChannel(interaction: CommandInteraction): Snowflake {
-		return (interaction.channel?.isThread() && interaction.channel.parentId) || interaction.channelId;
-	}
-
 	protected override async execute(interaction: CommandInteraction): Promise<number> {
 		let content: string;
 		if (interaction.options.getSubcommand() === "get") {
 			if (interaction.inGuild()) {
-				const channelOverride = await this.#locales.channel(this.getChannel(interaction));
+				const channelOverride = await this.#locales.channel(this.#locales.getChannel(interaction));
 				const guildOverride = await this.#locales.guild(interaction.guildId);
 				content = "";
 				if (channelOverride) {
@@ -97,7 +86,7 @@ export class LocaleCommand extends Command {
 				const scope = interaction.options.getString("scope", true);
 				if (scope === "channel") {
 					if (interaction.memberPermissions.has("MANAGE_CHANNELS")) {
-						const channel = this.getChannel(interaction);
+						const channel = this.#locales.getChannel(interaction);
 						if (locale !== "default") {
 							await this.#locales.setForChannel(channel, locale);
 							content = `Locale for current channel <#${channel}> overridden with ${locale}.`;


### PR DESCRIPTION
Now we'll make use of the `/locale` setting or the Discord-provided locale.

Convert LocaleProvider to abstract class and move convenience methods in

For #47