### PR TITLE
/deck: support YDK files

### DIFF
--- a/docs/commands/deck.md
+++ b/docs/commands/deck.md
@@ -17,7 +17,7 @@ This command has two subcommands, `/deck url` and `/deck file`. They behave the 
 
 Name | Required? | Description | Type
 --- | --- | --- | ---
-`deck` | ✔ | See "Subcommands". | text or attachment
+`deck` | ✔ | See ["Subcommands"](#subcommands). | text or attachment
 `public` | ❌ | Whether to display the deck publicly, or only show it to yourself with an ephemeral reply. | boolean
 `stacked` | ❌ | Whether to display deck sections stacked on top of each other in one long column, or in seperate columns side-by-side. | boolean
 

--- a/docs/commands/deck.md
+++ b/docs/commands/deck.md
@@ -6,13 +6,18 @@ Display the contents of a deck in Discord! _This command is in development._
 
 **YDKE**: A storage format for Yu-Gi-Oh! decks that can be exported from various deck building applications. They look like URLs, beginning with `ydke://`. An example of a YDKE URL looks like this: `ydke://1xqfAdcanwHXGp8Bd+lHBHfpRwR36UcEX8ZAAl/GQAJfxkACYx3EAzA20AMwNtADMDbQA/liqgQk6AgEJOgIBCToCASxxDUDscQ1A7HENQPw6KgA8OioAPDoqADAqZQA/YmcBf2JnAX9iZwFppv0Aaab9AGmm/QBgAhAAsWp2gTvJf4EkWK+BZFivgWRYr4FBlTqBQZU6gUGVOoFPqRxAcLHcgHCx3IBwsdyAQ==!Vi0OBRXfCwVs1ZQA8GQuALiBCQPBGnIE/gDeA2jWawV9vZ8DoBOYBIPjPgI1tL4EhGVOAbXg4AQBroQB!sjLMBbIyzAWyMswFQ77dAEO+3QBDvt0AJpBCAyaQQgMmkEIDhCV+AIQlfgCEJX4Ab3bvAG927wCBFq4D!`.
 
+**YDK**: A storage format for Yu-Gi-Oh! decks that can be exported from various deck building applications. They are text files, ending in the `.ydk` extension.
+
 [**Boolean**](https://en.wikipedia.org/wiki/Boolean_data_type): A value of either `true`, meaning "yes", or `false`, meaning "no".
+
+## Subcommands
+This command has two subcommands, `/deck url` and `/deck file`. They behave the same, except for the type of the `deck` parameter. For `/deck url`, the `deck` parameter is the YDKE URL of the deck you want to display. For `/deck file`, the `deck` parameter is an attachment of a YDK file for the deck you want to display.
 
 ## Parameters
 
 Name | Required? | Description | Type
 --- | --- | --- | ---
-`deck` | ✔ | The YDKE URL of the deck you want to display. | text
+`deck` | ✔ | See "Subcommands". | text or attachment
 `public` | ❌ | Whether to display the deck publicly, or only show it to yourself with an ephemeral reply. | boolean
 `stacked` | ❌ | Whether to display deck sections stacked on top of each other in one long column, or in seperate columns side-by-side. | boolean
 
@@ -20,7 +25,7 @@ Name | Required? | Description | Type
 
 If `public` is unspecified, it defaults to false, meaning Bastion will use an ephemeral reply. If `stacked` is unspecified, it defaults to false, meaning Bastion will show sections of the deck in side-by-side columns.
 
-If `deck` is not a valid YDKE URL, Bastion will respond with an error message in an ephemeral reply.
+If `deck` is not a valid YDKE URL or YDK file, as appropriate, Bastion will respond with an error message in an ephemeral reply.
 
 If the deck is valid, Bastion will process its contents and present the contents of the deck in a Discord embed. Whether the reply is ephemeral or public depends on the `public` option. The Main Deck, Extra Deck, and Side Deck are seperated into their own sections, displayed in that respective order, arranged as per the `stacked` option. If the contents of a section exceed 1024 characters, that section is split further into multiple as needed.
 
@@ -28,13 +33,8 @@ The heading of each section contains a count of how many cards that section cont
 
 Duplicate cards in the deck are compressed into one line, counting how many times the card appears in the format `# Card Name`, for example, `3 Junk Synchron`.
 
+Bastion will upload an attachment containing the deck in YDK format, as well as printing the deck as a YDKE URL at the bottom of the output embed. This allows for conversion between the two formats, or if the reply is public, for other users to download the shared deck.
+
 ### Limitations
 
-- This command currently only displays card names in English.
-- Headings for the deck sections, and names for card types, also are only in English, and we do not have translations prepared.
-- Due to Discord limitations on Slash Command parameters, input of a `YDK` file is not supported.
 - With `stacked` false, the section headings overflow the width of a column and wrap, harming aesthetics and readability.
-
-## Next steps
-
-See [#22](https://github.com/DawnbrandBots/bastion-bot/issues/22).

--- a/docs/commands/deck.md
+++ b/docs/commands/deck.md
@@ -38,3 +38,4 @@ Bastion will upload an attachment containing the deck in YDK format, as well as 
 ### Limitations
 
 - With `stacked` false, the section headings overflow the width of a column and wrap, harming aesthetics and readability.
+- Error messages from the `ydeck` package are unclear and unlocalised

--- a/package.json
+++ b/package.json
@@ -34,6 +34,7 @@
 		"supports-color": "^9.2.2",
 		"tsyringe": "^4.7.0",
 		"ttag": "^1.7.24",
+		"ydeck": "^0.2.7",
 		"ydke": "^1.1.0"
 	},
 	"devDependencies": {

--- a/src/commands/deck.ts
+++ b/src/commands/deck.ts
@@ -16,7 +16,7 @@ import { CardSchema } from "../definitions/yaml-yugi";
 import { COMMAND_LOCALIZATIONS, Locale, LocaleProvider } from "../locale";
 import { getLogger, Logger } from "../logger";
 import { Metrics } from "../metrics";
-import { addNotice, replyLatency } from "../utils";
+import { addNotice } from "../utils";
 import { typedDeckToYdk, ydkToTypedDeck } from "ydeck";
 
 // Same hack as in card.ts
@@ -303,36 +303,36 @@ export class DeckCommand extends Command {
 				deck = parseURL(interaction.options.getString("deck", true));
 			} catch (e) {
 				// TODO: specifically catch error for bad input and respond more clearly?
-				const reply = await interaction.reply({
-					content: (e as Error).message,
-					ephemeral: true,
-					fetchReply: true
+				const end = Date.now();
+				await interaction.editReply({
+					content: (e as Error).message
 				});
-				return replyLatency(reply, interaction);
+				const latency = end - interaction.createdTimestamp;
+				return latency;
 			}
 		} else {
 			// subcommand === "file"
 			try {
 				deck = await this.parseFile(interaction.options.getAttachment("deck", true));
 			} catch (e) {
-				const reply = await interaction.reply({
-					content: (e as Error).message,
-					ephemeral: true,
-					fetchReply: true
+				const end = Date.now();
+				await interaction.editReply({
+					content: (e as Error).message
 				});
-				return replyLatency(reply, interaction);
+				const latency = end - interaction.createdTimestamp;
+				return latency;
 			}
 		}
 
 		// return error on empty deck
 		if (deck.main.length + deck.extra.length + deck.side.length < 1) {
 			useLocale(resultLanguage);
-			const reply = await interaction.reply({
-				content: t`Error: Your deck is empty.`,
-				ephemeral: true,
-				fetchReply: true
+			const end = Date.now();
+			await interaction.editReply({
+				content: t`Error: Your deck is empty.`
 			});
-			return replyLatency(reply, interaction);
+			const latency = end - interaction.createdTimestamp;
+			return latency;
 		}
 
 		// one of these two will be redundant with an input, but if it's the file then we'd have to download it again

--- a/translations/de.po
+++ b/translations/de.po
@@ -126,64 +126,64 @@ msgstr ""
 msgid "Could not find art for `${ name }`!"
 msgstr ""
 
-#: src\commands\deck.ts:153
+#: src\commands\deck.ts:198
 #, javascript-format
 msgid "${ counts.Monster } Monster"
 msgid_plural "${ counts.Monster } Monsters"
 msgstr[0] ""
 msgstr[1] ""
 
-#: src\commands\deck.ts:156
+#: src\commands\deck.ts:201
 msgid "${ counts.Spell } Spell"
 msgid_plural "${ counts.Spell } Spells"
 msgstr[0] ""
 msgstr[1] ""
 
-#: src\commands\deck.ts:159
+#: src\commands\deck.ts:204
 #, javascript-format
 msgid "${ counts.Trap } Trap"
 msgid_plural "${ counts.Trap } Traps"
 msgstr[0] ""
 msgstr[1] ""
 
-#: src\commands\deck.ts:187
+#: src\commands\deck.ts:232
 msgid "Your Deck"
 msgstr ""
 
-#: src\commands\deck.ts:192
+#: src\commands\deck.ts:237
 #, javascript-format
 msgid "Main Deck (${ deck.main.length } card — ${ countDetail })"
 msgid_plural "Main Deck (${ deck.main.length } cards — ${ countDetail })"
 msgstr[0] ""
 msgstr[1] ""
 
-#: src\commands\deck.ts:199
+#: src\commands\deck.ts:244
 msgid "Main Deck (continued)"
 msgstr ""
 
-#: src\commands\deck.ts:206
+#: src\commands\deck.ts:251
 #, javascript-format
 msgid "Extra Deck (${ deck.extra.length } card — ${ _countDetail })"
 msgid_plural "Extra Deck (${ deck.extra.length } cards — ${ _countDetail })"
 msgstr[0] ""
 msgstr[1] ""
 
-#: src\commands\deck.ts:213
+#: src\commands\deck.ts:258
 msgid "Extra Deck (continued)"
 msgstr ""
 
-#: src\commands\deck.ts:220
+#: src\commands\deck.ts:265
 #, javascript-format
 msgid "Side Deck (${ deck.side.length } card — ${ _countDetail2 })"
 msgid_plural "Side Deck (${ deck.side.length } cards — ${ _countDetail2 })"
 msgstr[0] ""
 msgstr[1] ""
 
-#: src\commands\deck.ts:227
+#: src\commands\deck.ts:272
 msgid "Side Deck (continued)"
 msgstr ""
 
-#: src\commands\deck.ts:285
+#: src\commands\deck.ts:331
 msgid "Error: Your deck is empty."
 msgstr ""
 
@@ -322,12 +322,16 @@ msgstr ""
 msgid "Revision: ${ process.env.BOT_REVISION }."
 msgstr ""
 
-#: src\commands\deck.ts:236
+#: src\commands\deck.ts:282
 msgid ".ydk files must have the .ydk extension!"
 msgstr ""
 
-#: src\commands\deck.ts:239
+#: src\commands\deck.ts:285
 msgid ".ydk files should not be larger than 1 KB!"
+msgstr ""
+
+#: src\commands\deck.ts:275
+msgid "ydke URL"
 msgstr ""
 
 #: src\card.ts:37
@@ -651,6 +655,32 @@ msgctxt "command-option"
 msgid "page"
 msgstr ""
 
+#: src\commands\deck.ts:74
+msgctxt "command-option"
+msgid "url"
+msgstr ""
+
+#: src\commands\deck.ts:80
+msgctxt "command-option"
+msgid "file"
+msgstr ""
+
+#: src\commands\deck.ts:86
+#: src\commands\deck.ts:92
+msgctxt "command-option"
+msgid "deck"
+msgstr ""
+
+#: src\commands\deck.ts:98
+msgctxt "command-option"
+msgid "public"
+msgstr ""
+
+#: src\commands\deck.ts:105
+msgctxt "command-option"
+msgid "stacked"
+msgstr ""
+
 #: src\locale.ts:50
 msgctxt "command-option-description"
 msgid "The output language for the card embed, overriding other settings."
@@ -681,6 +711,40 @@ msgctxt "command-option-description"
 msgid "The name of the Yugipedia page you want to search for."
 msgstr ""
 
+#: src\commands\deck.ts:77
+msgctxt "command-option-description"
+msgid "View a deck by entering a ydke:// URL."
+msgstr ""
+
+#: src\commands\deck.ts:83
+msgctxt "command-option-description"
+msgid "View a deck by uploading a .ydk file."
+msgstr ""
+
+#: src\commands\deck.ts:89
+msgctxt "command-option-description"
+msgid "The ydke:// URL of the deck you want to view."
+msgstr ""
+
+#: src\commands\deck.ts:95
+msgctxt "command-option-description"
+msgid "The .ydk file of the deck you want to view."
+msgstr ""
+
+#: src\commands\deck.ts:101
+msgctxt "command-option-description"
+msgid ""
+"Whether to display the deck details publicly in chat. This is false by "
+"default."
+msgstr ""
+
+#: src\commands\deck.ts:108
+msgctxt "command-option-description"
+msgid ""
+"Whether to display the deck sections as one stacked column. This is false "
+"(side-by-side) by default."
+msgstr ""
+
 #: src\commands\art.ts:35
 msgctxt "command-name"
 msgid "art"
@@ -706,6 +770,11 @@ msgctxt "command-name"
 msgid "yugipedia"
 msgstr ""
 
+#: src\commands\deck.ts:67
+msgctxt "command-name"
+msgid "deck"
+msgstr ""
+
 #: src\commands\art.ts:36
 msgctxt "command-description"
 msgid "Display the art for a card!"
@@ -729,4 +798,11 @@ msgstr ""
 #: src\commands\yugipedia.ts:37
 msgctxt "command-description"
 msgid "Search the Yugipedia wiki for a page and link to it."
+msgstr ""
+
+#: src\commands\deck.ts:70
+msgctxt "command-description"
+msgid ""
+"Display a deck list from ydke:// or .ydk format, exported from a number of "
+"deck building programs."
 msgstr ""

--- a/translations/de.po
+++ b/translations/de.po
@@ -31,7 +31,9 @@ msgstr "**Eigenschaft**: ${ AttributeIcon[card.attribute] } ${ localizedAttribut
 msgid ""
 "**Rank**: ${ Icon.Rank } ${ card.rank } **ATK**: ${ card.atk } **DEF**: ${ "
 "card.def }"
-msgstr "**Rang**: ${ Icon.Rank } ${ card.rank } **ATK**: ${ card.atk } **DEF**: ${ card.def }"
+msgstr ""
+"**Rang**: ${ Icon.Rank } ${ card.rank } **ATK**: ${ card.atk } **DEF**: ${ "
+"card.def }"
 
 #: src\card.ts:281
 #, javascript-format
@@ -44,7 +46,9 @@ msgstr ""
 msgid ""
 "**Level**: ${ Icon.Level } ${ card.level } **ATK**: ${ card.atk } **DEF**: "
 "${ card.def }"
-msgstr "**Stufe**: ${ Icon.Level } ${ card.level } **ATK**: ${ card.atk } **DEF**: ${ card.def }"
+msgstr ""
+"**Stufe**: ${ Icon.Level } ${ card.level } **ATK**: ${ card.atk } **DEF**: "
+"${ card.def }"
 
 #: src\card.ts:290
 #, javascript-format
@@ -122,64 +126,64 @@ msgstr ""
 msgid "Could not find art for `${ name }`!"
 msgstr ""
 
-#: src\commands\deck.ts:132
+#: src\commands\deck.ts:153
 #, javascript-format
 msgid "${ counts.Monster } Monster"
 msgid_plural "${ counts.Monster } Monsters"
 msgstr[0] ""
 msgstr[1] ""
 
-#: src\commands\deck.ts:135
+#: src\commands\deck.ts:156
 msgid "${ counts.Spell } Spell"
 msgid_plural "${ counts.Spell } Spells"
 msgstr[0] ""
 msgstr[1] ""
 
-#: src\commands\deck.ts:138
+#: src\commands\deck.ts:159
 #, javascript-format
 msgid "${ counts.Trap } Trap"
 msgid_plural "${ counts.Trap } Traps"
 msgstr[0] ""
 msgstr[1] ""
 
-#: src\commands\deck.ts:166
+#: src\commands\deck.ts:187
 msgid "Your Deck"
 msgstr ""
 
-#: src\commands\deck.ts:171
+#: src\commands\deck.ts:192
 #, javascript-format
 msgid "Main Deck (${ deck.main.length } card — ${ countDetail })"
 msgid_plural "Main Deck (${ deck.main.length } cards — ${ countDetail })"
 msgstr[0] ""
 msgstr[1] ""
 
-#: src\commands\deck.ts:178
+#: src\commands\deck.ts:199
 msgid "Main Deck (continued)"
 msgstr ""
 
-#: src\commands\deck.ts:185
+#: src\commands\deck.ts:206
 #, javascript-format
 msgid "Extra Deck (${ deck.extra.length } card — ${ _countDetail })"
 msgid_plural "Extra Deck (${ deck.extra.length } cards — ${ _countDetail })"
 msgstr[0] ""
 msgstr[1] ""
 
-#: src\commands\deck.ts:192
+#: src\commands\deck.ts:213
 msgid "Extra Deck (continued)"
 msgstr ""
 
-#: src\commands\deck.ts:199
+#: src\commands\deck.ts:220
 #, javascript-format
 msgid "Side Deck (${ deck.side.length } card — ${ _countDetail2 })"
 msgid_plural "Side Deck (${ deck.side.length } cards — ${ _countDetail2 })"
 msgstr[0] ""
 msgstr[1] ""
 
-#: src\commands\deck.ts:206
+#: src\commands\deck.ts:227
 msgid "Side Deck (continued)"
 msgstr ""
 
-#: src\commands\deck.ts:231
+#: src\commands\deck.ts:285
 msgid "Error: Your deck is empty."
 msgstr ""
 
@@ -316,6 +320,14 @@ msgstr ""
 #: src\events\message.ts:51
 #, javascript-format
 msgid "Revision: ${ process.env.BOT_REVISION }."
+msgstr ""
+
+#: src\commands\deck.ts:236
+msgid ".ydk files must have the .ydk extension!"
+msgstr ""
+
+#: src\commands\deck.ts:239
+msgid ".ydk files should not be larger than 1 KB!"
 msgstr ""
 
 #: src\card.ts:37

--- a/translations/es.po
+++ b/translations/es.po
@@ -31,7 +31,9 @@ msgstr "**Atributo**: ${ AttributeIcon[card.attribute] } ${ localizedAttribute }
 msgid ""
 "**Rank**: ${ Icon.Rank } ${ card.rank } **ATK**: ${ card.atk } **DEF**: ${ "
 "card.def }"
-msgstr "**Rango**: ${ Icon.Rank } ${ card.rank } **ATK**: ${ card.atk } **DEF**: ${ card.def }"
+msgstr ""
+"**Rango**: ${ Icon.Rank } ${ card.rank } **ATK**: ${ card.atk } **DEF**: ${ "
+"card.def }"
 
 #: src\card.ts:281
 #, javascript-format
@@ -44,7 +46,9 @@ msgstr ""
 msgid ""
 "**Level**: ${ Icon.Level } ${ card.level } **ATK**: ${ card.atk } **DEF**: "
 "${ card.def }"
-msgstr "**Nivel**: ${ Icon.Level } ${ card.level } **ATK**: ${ card.atk } **DEF**: ${ card.def }"
+msgstr ""
+"**Nivel**: ${ Icon.Level } ${ card.level } **ATK**: ${ card.atk } **DEF**: "
+"${ card.def }"
 
 #: src\card.ts:290
 #, javascript-format
@@ -122,64 +126,64 @@ msgstr ""
 msgid "Could not find art for `${ name }`!"
 msgstr ""
 
-#: src\commands\deck.ts:132
+#: src\commands\deck.ts:153
 #, javascript-format
 msgid "${ counts.Monster } Monster"
 msgid_plural "${ counts.Monster } Monsters"
 msgstr[0] ""
 msgstr[1] ""
 
-#: src\commands\deck.ts:135
+#: src\commands\deck.ts:156
 msgid "${ counts.Spell } Spell"
 msgid_plural "${ counts.Spell } Spells"
 msgstr[0] ""
 msgstr[1] ""
 
-#: src\commands\deck.ts:138
+#: src\commands\deck.ts:159
 #, javascript-format
 msgid "${ counts.Trap } Trap"
 msgid_plural "${ counts.Trap } Traps"
 msgstr[0] ""
 msgstr[1] ""
 
-#: src\commands\deck.ts:166
+#: src\commands\deck.ts:187
 msgid "Your Deck"
 msgstr ""
 
-#: src\commands\deck.ts:171
+#: src\commands\deck.ts:192
 #, javascript-format
 msgid "Main Deck (${ deck.main.length } card — ${ countDetail })"
 msgid_plural "Main Deck (${ deck.main.length } cards — ${ countDetail })"
 msgstr[0] ""
 msgstr[1] ""
 
-#: src\commands\deck.ts:178
+#: src\commands\deck.ts:199
 msgid "Main Deck (continued)"
 msgstr ""
 
-#: src\commands\deck.ts:185
+#: src\commands\deck.ts:206
 #, javascript-format
 msgid "Extra Deck (${ deck.extra.length } card — ${ _countDetail })"
 msgid_plural "Extra Deck (${ deck.extra.length } cards — ${ _countDetail })"
 msgstr[0] ""
 msgstr[1] ""
 
-#: src\commands\deck.ts:192
+#: src\commands\deck.ts:213
 msgid "Extra Deck (continued)"
 msgstr ""
 
-#: src\commands\deck.ts:199
+#: src\commands\deck.ts:220
 #, javascript-format
 msgid "Side Deck (${ deck.side.length } card — ${ _countDetail2 })"
 msgid_plural "Side Deck (${ deck.side.length } cards — ${ _countDetail2 })"
 msgstr[0] ""
 msgstr[1] ""
 
-#: src\commands\deck.ts:206
+#: src\commands\deck.ts:227
 msgid "Side Deck (continued)"
 msgstr ""
 
-#: src\commands\deck.ts:231
+#: src\commands\deck.ts:285
 msgid "Error: Your deck is empty."
 msgstr ""
 
@@ -316,6 +320,14 @@ msgstr ""
 #: src\events\message.ts:51
 #, javascript-format
 msgid "Revision: ${ process.env.BOT_REVISION }."
+msgstr ""
+
+#: src\commands\deck.ts:236
+msgid ".ydk files must have the .ydk extension!"
+msgstr ""
+
+#: src\commands\deck.ts:239
+msgid ".ydk files should not be larger than 1 KB!"
 msgstr ""
 
 #: src\card.ts:37

--- a/translations/es.po
+++ b/translations/es.po
@@ -126,64 +126,64 @@ msgstr ""
 msgid "Could not find art for `${ name }`!"
 msgstr ""
 
-#: src\commands\deck.ts:153
+#: src\commands\deck.ts:198
 #, javascript-format
 msgid "${ counts.Monster } Monster"
 msgid_plural "${ counts.Monster } Monsters"
 msgstr[0] ""
 msgstr[1] ""
 
-#: src\commands\deck.ts:156
+#: src\commands\deck.ts:201
 msgid "${ counts.Spell } Spell"
 msgid_plural "${ counts.Spell } Spells"
 msgstr[0] ""
 msgstr[1] ""
 
-#: src\commands\deck.ts:159
+#: src\commands\deck.ts:204
 #, javascript-format
 msgid "${ counts.Trap } Trap"
 msgid_plural "${ counts.Trap } Traps"
 msgstr[0] ""
 msgstr[1] ""
 
-#: src\commands\deck.ts:187
+#: src\commands\deck.ts:232
 msgid "Your Deck"
 msgstr ""
 
-#: src\commands\deck.ts:192
+#: src\commands\deck.ts:237
 #, javascript-format
 msgid "Main Deck (${ deck.main.length } card — ${ countDetail })"
 msgid_plural "Main Deck (${ deck.main.length } cards — ${ countDetail })"
 msgstr[0] ""
 msgstr[1] ""
 
-#: src\commands\deck.ts:199
+#: src\commands\deck.ts:244
 msgid "Main Deck (continued)"
 msgstr ""
 
-#: src\commands\deck.ts:206
+#: src\commands\deck.ts:251
 #, javascript-format
 msgid "Extra Deck (${ deck.extra.length } card — ${ _countDetail })"
 msgid_plural "Extra Deck (${ deck.extra.length } cards — ${ _countDetail })"
 msgstr[0] ""
 msgstr[1] ""
 
-#: src\commands\deck.ts:213
+#: src\commands\deck.ts:258
 msgid "Extra Deck (continued)"
 msgstr ""
 
-#: src\commands\deck.ts:220
+#: src\commands\deck.ts:265
 #, javascript-format
 msgid "Side Deck (${ deck.side.length } card — ${ _countDetail2 })"
 msgid_plural "Side Deck (${ deck.side.length } cards — ${ _countDetail2 })"
 msgstr[0] ""
 msgstr[1] ""
 
-#: src\commands\deck.ts:227
+#: src\commands\deck.ts:272
 msgid "Side Deck (continued)"
 msgstr ""
 
-#: src\commands\deck.ts:285
+#: src\commands\deck.ts:331
 msgid "Error: Your deck is empty."
 msgstr ""
 
@@ -322,12 +322,16 @@ msgstr ""
 msgid "Revision: ${ process.env.BOT_REVISION }."
 msgstr ""
 
-#: src\commands\deck.ts:236
+#: src\commands\deck.ts:282
 msgid ".ydk files must have the .ydk extension!"
 msgstr ""
 
-#: src\commands\deck.ts:239
+#: src\commands\deck.ts:285
 msgid ".ydk files should not be larger than 1 KB!"
+msgstr ""
+
+#: src\commands\deck.ts:275
+msgid "ydke URL"
 msgstr ""
 
 #: src\card.ts:37
@@ -651,6 +655,32 @@ msgctxt "command-option"
 msgid "page"
 msgstr ""
 
+#: src\commands\deck.ts:74
+msgctxt "command-option"
+msgid "url"
+msgstr ""
+
+#: src\commands\deck.ts:80
+msgctxt "command-option"
+msgid "file"
+msgstr ""
+
+#: src\commands\deck.ts:86
+#: src\commands\deck.ts:92
+msgctxt "command-option"
+msgid "deck"
+msgstr ""
+
+#: src\commands\deck.ts:98
+msgctxt "command-option"
+msgid "public"
+msgstr ""
+
+#: src\commands\deck.ts:105
+msgctxt "command-option"
+msgid "stacked"
+msgstr ""
+
 #: src\locale.ts:50
 msgctxt "command-option-description"
 msgid "The output language for the card embed, overriding other settings."
@@ -681,6 +711,40 @@ msgctxt "command-option-description"
 msgid "The name of the Yugipedia page you want to search for."
 msgstr ""
 
+#: src\commands\deck.ts:77
+msgctxt "command-option-description"
+msgid "View a deck by entering a ydke:// URL."
+msgstr ""
+
+#: src\commands\deck.ts:83
+msgctxt "command-option-description"
+msgid "View a deck by uploading a .ydk file."
+msgstr ""
+
+#: src\commands\deck.ts:89
+msgctxt "command-option-description"
+msgid "The ydke:// URL of the deck you want to view."
+msgstr ""
+
+#: src\commands\deck.ts:95
+msgctxt "command-option-description"
+msgid "The .ydk file of the deck you want to view."
+msgstr ""
+
+#: src\commands\deck.ts:101
+msgctxt "command-option-description"
+msgid ""
+"Whether to display the deck details publicly in chat. This is false by "
+"default."
+msgstr ""
+
+#: src\commands\deck.ts:108
+msgctxt "command-option-description"
+msgid ""
+"Whether to display the deck sections as one stacked column. This is false "
+"(side-by-side) by default."
+msgstr ""
+
 #: src\commands\art.ts:35
 msgctxt "command-name"
 msgid "art"
@@ -706,6 +770,11 @@ msgctxt "command-name"
 msgid "yugipedia"
 msgstr ""
 
+#: src\commands\deck.ts:67
+msgctxt "command-name"
+msgid "deck"
+msgstr ""
+
 #: src\commands\art.ts:36
 msgctxt "command-description"
 msgid "Display the art for a card!"
@@ -729,4 +798,11 @@ msgstr ""
 #: src\commands\yugipedia.ts:37
 msgctxt "command-description"
 msgid "Search the Yugipedia wiki for a page and link to it."
+msgstr ""
+
+#: src\commands\deck.ts:70
+msgctxt "command-description"
+msgid ""
+"Display a deck list from ydke:// or .ydk format, exported from a number of "
+"deck building programs."
 msgstr ""

--- a/translations/fr.po
+++ b/translations/fr.po
@@ -126,64 +126,64 @@ msgstr ""
 msgid "Could not find art for `${ name }`!"
 msgstr ""
 
-#: src\commands\deck.ts:153
+#: src\commands\deck.ts:198
 #, javascript-format
 msgid "${ counts.Monster } Monster"
 msgid_plural "${ counts.Monster } Monsters"
 msgstr[0] ""
 msgstr[1] ""
 
-#: src\commands\deck.ts:156
+#: src\commands\deck.ts:201
 msgid "${ counts.Spell } Spell"
 msgid_plural "${ counts.Spell } Spells"
 msgstr[0] ""
 msgstr[1] ""
 
-#: src\commands\deck.ts:159
+#: src\commands\deck.ts:204
 #, javascript-format
 msgid "${ counts.Trap } Trap"
 msgid_plural "${ counts.Trap } Traps"
 msgstr[0] ""
 msgstr[1] ""
 
-#: src\commands\deck.ts:187
+#: src\commands\deck.ts:232
 msgid "Your Deck"
 msgstr ""
 
-#: src\commands\deck.ts:192
+#: src\commands\deck.ts:237
 #, javascript-format
 msgid "Main Deck (${ deck.main.length } card — ${ countDetail })"
 msgid_plural "Main Deck (${ deck.main.length } cards — ${ countDetail })"
 msgstr[0] ""
 msgstr[1] ""
 
-#: src\commands\deck.ts:199
+#: src\commands\deck.ts:244
 msgid "Main Deck (continued)"
 msgstr ""
 
-#: src\commands\deck.ts:206
+#: src\commands\deck.ts:251
 #, javascript-format
 msgid "Extra Deck (${ deck.extra.length } card — ${ _countDetail })"
 msgid_plural "Extra Deck (${ deck.extra.length } cards — ${ _countDetail })"
 msgstr[0] ""
 msgstr[1] ""
 
-#: src\commands\deck.ts:213
+#: src\commands\deck.ts:258
 msgid "Extra Deck (continued)"
 msgstr ""
 
-#: src\commands\deck.ts:220
+#: src\commands\deck.ts:265
 #, javascript-format
 msgid "Side Deck (${ deck.side.length } card — ${ _countDetail2 })"
 msgid_plural "Side Deck (${ deck.side.length } cards — ${ _countDetail2 })"
 msgstr[0] ""
 msgstr[1] ""
 
-#: src\commands\deck.ts:227
+#: src\commands\deck.ts:272
 msgid "Side Deck (continued)"
 msgstr ""
 
-#: src\commands\deck.ts:285
+#: src\commands\deck.ts:331
 msgid "Error: Your deck is empty."
 msgstr ""
 
@@ -322,12 +322,16 @@ msgstr ""
 msgid "Revision: ${ process.env.BOT_REVISION }."
 msgstr ""
 
-#: src\commands\deck.ts:236
+#: src\commands\deck.ts:282
 msgid ".ydk files must have the .ydk extension!"
 msgstr ""
 
-#: src\commands\deck.ts:239
+#: src\commands\deck.ts:285
 msgid ".ydk files should not be larger than 1 KB!"
+msgstr ""
+
+#: src\commands\deck.ts:275
+msgid "ydke URL"
 msgstr ""
 
 #: src\card.ts:37
@@ -651,6 +655,32 @@ msgctxt "command-option"
 msgid "page"
 msgstr ""
 
+#: src\commands\deck.ts:74
+msgctxt "command-option"
+msgid "url"
+msgstr ""
+
+#: src\commands\deck.ts:80
+msgctxt "command-option"
+msgid "file"
+msgstr ""
+
+#: src\commands\deck.ts:86
+#: src\commands\deck.ts:92
+msgctxt "command-option"
+msgid "deck"
+msgstr ""
+
+#: src\commands\deck.ts:98
+msgctxt "command-option"
+msgid "public"
+msgstr ""
+
+#: src\commands\deck.ts:105
+msgctxt "command-option"
+msgid "stacked"
+msgstr ""
+
 #: src\locale.ts:50
 msgctxt "command-option-description"
 msgid "The output language for the card embed, overriding other settings."
@@ -681,6 +711,40 @@ msgctxt "command-option-description"
 msgid "The name of the Yugipedia page you want to search for."
 msgstr ""
 
+#: src\commands\deck.ts:77
+msgctxt "command-option-description"
+msgid "View a deck by entering a ydke:// URL."
+msgstr ""
+
+#: src\commands\deck.ts:83
+msgctxt "command-option-description"
+msgid "View a deck by uploading a .ydk file."
+msgstr ""
+
+#: src\commands\deck.ts:89
+msgctxt "command-option-description"
+msgid "The ydke:// URL of the deck you want to view."
+msgstr ""
+
+#: src\commands\deck.ts:95
+msgctxt "command-option-description"
+msgid "The .ydk file of the deck you want to view."
+msgstr ""
+
+#: src\commands\deck.ts:101
+msgctxt "command-option-description"
+msgid ""
+"Whether to display the deck details publicly in chat. This is false by "
+"default."
+msgstr ""
+
+#: src\commands\deck.ts:108
+msgctxt "command-option-description"
+msgid ""
+"Whether to display the deck sections as one stacked column. This is false "
+"(side-by-side) by default."
+msgstr ""
+
 #: src\commands\art.ts:35
 msgctxt "command-name"
 msgid "art"
@@ -706,6 +770,11 @@ msgctxt "command-name"
 msgid "yugipedia"
 msgstr ""
 
+#: src\commands\deck.ts:67
+msgctxt "command-name"
+msgid "deck"
+msgstr ""
+
 #: src\commands\art.ts:36
 msgctxt "command-description"
 msgid "Display the art for a card!"
@@ -729,4 +798,11 @@ msgstr ""
 #: src\commands\yugipedia.ts:37
 msgctxt "command-description"
 msgid "Search the Yugipedia wiki for a page and link to it."
+msgstr ""
+
+#: src\commands\deck.ts:70
+msgctxt "command-description"
+msgid ""
+"Display a deck list from ydke:// or .ydk format, exported from a number of "
+"deck building programs."
 msgstr ""

--- a/translations/fr.po
+++ b/translations/fr.po
@@ -31,7 +31,9 @@ msgstr "**Attribut**: ${ AttributeIcon[card.attribute] } ${ localizedAttribute }
 msgid ""
 "**Rank**: ${ Icon.Rank } ${ card.rank } **ATK**: ${ card.atk } **DEF**: ${ "
 "card.def }"
-msgstr "**Rang**: ${ Icon.Rank } ${ card.rank } **ATK**: ${ card.atk } **DEF**: ${ card.def }"
+msgstr ""
+"**Rang**: ${ Icon.Rank } ${ card.rank } **ATK**: ${ card.atk } **DEF**: ${ "
+"card.def }"
 
 #: src\card.ts:281
 #, javascript-format
@@ -44,7 +46,9 @@ msgstr ""
 msgid ""
 "**Level**: ${ Icon.Level } ${ card.level } **ATK**: ${ card.atk } **DEF**: "
 "${ card.def }"
-msgstr "**Niveau**: ${ Icon.Level } ${ card.level } **ATK**: ${ card.atk } **DEF**: ${ card.def }"
+msgstr ""
+"**Niveau**: ${ Icon.Level } ${ card.level } **ATK**: ${ card.atk } **DEF**: "
+"${ card.def }"
 
 #: src\card.ts:290
 #, javascript-format
@@ -122,64 +126,64 @@ msgstr ""
 msgid "Could not find art for `${ name }`!"
 msgstr ""
 
-#: src\commands\deck.ts:132
+#: src\commands\deck.ts:153
 #, javascript-format
 msgid "${ counts.Monster } Monster"
 msgid_plural "${ counts.Monster } Monsters"
 msgstr[0] ""
 msgstr[1] ""
 
-#: src\commands\deck.ts:135
+#: src\commands\deck.ts:156
 msgid "${ counts.Spell } Spell"
 msgid_plural "${ counts.Spell } Spells"
 msgstr[0] ""
 msgstr[1] ""
 
-#: src\commands\deck.ts:138
+#: src\commands\deck.ts:159
 #, javascript-format
 msgid "${ counts.Trap } Trap"
 msgid_plural "${ counts.Trap } Traps"
 msgstr[0] ""
 msgstr[1] ""
 
-#: src\commands\deck.ts:166
+#: src\commands\deck.ts:187
 msgid "Your Deck"
 msgstr ""
 
-#: src\commands\deck.ts:171
+#: src\commands\deck.ts:192
 #, javascript-format
 msgid "Main Deck (${ deck.main.length } card — ${ countDetail })"
 msgid_plural "Main Deck (${ deck.main.length } cards — ${ countDetail })"
 msgstr[0] ""
 msgstr[1] ""
 
-#: src\commands\deck.ts:178
+#: src\commands\deck.ts:199
 msgid "Main Deck (continued)"
 msgstr ""
 
-#: src\commands\deck.ts:185
+#: src\commands\deck.ts:206
 #, javascript-format
 msgid "Extra Deck (${ deck.extra.length } card — ${ _countDetail })"
 msgid_plural "Extra Deck (${ deck.extra.length } cards — ${ _countDetail })"
 msgstr[0] ""
 msgstr[1] ""
 
-#: src\commands\deck.ts:192
+#: src\commands\deck.ts:213
 msgid "Extra Deck (continued)"
 msgstr ""
 
-#: src\commands\deck.ts:199
+#: src\commands\deck.ts:220
 #, javascript-format
 msgid "Side Deck (${ deck.side.length } card — ${ _countDetail2 })"
 msgid_plural "Side Deck (${ deck.side.length } cards — ${ _countDetail2 })"
 msgstr[0] ""
 msgstr[1] ""
 
-#: src\commands\deck.ts:206
+#: src\commands\deck.ts:227
 msgid "Side Deck (continued)"
 msgstr ""
 
-#: src\commands\deck.ts:231
+#: src\commands\deck.ts:285
 msgid "Error: Your deck is empty."
 msgstr ""
 
@@ -316,6 +320,14 @@ msgstr ""
 #: src\events\message.ts:51
 #, javascript-format
 msgid "Revision: ${ process.env.BOT_REVISION }."
+msgstr ""
+
+#: src\commands\deck.ts:236
+msgid ".ydk files must have the .ydk extension!"
+msgstr ""
+
+#: src\commands\deck.ts:239
+msgid ".ydk files should not be larger than 1 KB!"
 msgstr ""
 
 #: src\card.ts:37

--- a/translations/it.po
+++ b/translations/it.po
@@ -31,7 +31,9 @@ msgstr "**Attributo**: ${ AttributeIcon[card.attribute] } ${ localizedAttribute 
 msgid ""
 "**Rank**: ${ Icon.Rank } ${ card.rank } **ATK**: ${ card.atk } **DEF**: ${ "
 "card.def }"
-msgstr "**Rango**: ${ Icon.Rank } ${ card.rank } **ATK**: ${ card.atk } **DEF**: ${ card.def }"
+msgstr ""
+"**Rango**: ${ Icon.Rank } ${ card.rank } **ATK**: ${ card.atk } **DEF**: ${ "
+"card.def }"
 
 #: src\card.ts:281
 #, javascript-format
@@ -44,7 +46,9 @@ msgstr ""
 msgid ""
 "**Level**: ${ Icon.Level } ${ card.level } **ATK**: ${ card.atk } **DEF**: "
 "${ card.def }"
-msgstr "Livello**: ${ Icon.Level } ${ card.level } **ATK**: ${ card.atk } **DEF**: ${ card.def }"
+msgstr ""
+"Livello**: ${ Icon.Level } ${ card.level } **ATK**: ${ card.atk } **DEF**: "
+"${ card.def }"
 
 #: src\card.ts:290
 #, javascript-format
@@ -122,64 +126,64 @@ msgstr ""
 msgid "Could not find art for `${ name }`!"
 msgstr ""
 
-#: src\commands\deck.ts:132
+#: src\commands\deck.ts:153
 #, javascript-format
 msgid "${ counts.Monster } Monster"
 msgid_plural "${ counts.Monster } Monsters"
 msgstr[0] ""
 msgstr[1] ""
 
-#: src\commands\deck.ts:135
+#: src\commands\deck.ts:156
 msgid "${ counts.Spell } Spell"
 msgid_plural "${ counts.Spell } Spells"
 msgstr[0] ""
 msgstr[1] ""
 
-#: src\commands\deck.ts:138
+#: src\commands\deck.ts:159
 #, javascript-format
 msgid "${ counts.Trap } Trap"
 msgid_plural "${ counts.Trap } Traps"
 msgstr[0] ""
 msgstr[1] ""
 
-#: src\commands\deck.ts:166
+#: src\commands\deck.ts:187
 msgid "Your Deck"
 msgstr ""
 
-#: src\commands\deck.ts:171
+#: src\commands\deck.ts:192
 #, javascript-format
 msgid "Main Deck (${ deck.main.length } card — ${ countDetail })"
 msgid_plural "Main Deck (${ deck.main.length } cards — ${ countDetail })"
 msgstr[0] ""
 msgstr[1] ""
 
-#: src\commands\deck.ts:178
+#: src\commands\deck.ts:199
 msgid "Main Deck (continued)"
 msgstr ""
 
-#: src\commands\deck.ts:185
+#: src\commands\deck.ts:206
 #, javascript-format
 msgid "Extra Deck (${ deck.extra.length } card — ${ _countDetail })"
 msgid_plural "Extra Deck (${ deck.extra.length } cards — ${ _countDetail })"
 msgstr[0] ""
 msgstr[1] ""
 
-#: src\commands\deck.ts:192
+#: src\commands\deck.ts:213
 msgid "Extra Deck (continued)"
 msgstr ""
 
-#: src\commands\deck.ts:199
+#: src\commands\deck.ts:220
 #, javascript-format
 msgid "Side Deck (${ deck.side.length } card — ${ _countDetail2 })"
 msgid_plural "Side Deck (${ deck.side.length } cards — ${ _countDetail2 })"
 msgstr[0] ""
 msgstr[1] ""
 
-#: src\commands\deck.ts:206
+#: src\commands\deck.ts:227
 msgid "Side Deck (continued)"
 msgstr ""
 
-#: src\commands\deck.ts:231
+#: src\commands\deck.ts:285
 msgid "Error: Your deck is empty."
 msgstr ""
 
@@ -316,6 +320,14 @@ msgstr ""
 #: src\events\message.ts:51
 #, javascript-format
 msgid "Revision: ${ process.env.BOT_REVISION }."
+msgstr ""
+
+#: src\commands\deck.ts:236
+msgid ".ydk files must have the .ydk extension!"
+msgstr ""
+
+#: src\commands\deck.ts:239
+msgid ".ydk files should not be larger than 1 KB!"
 msgstr ""
 
 #: src\card.ts:37

--- a/translations/it.po
+++ b/translations/it.po
@@ -126,64 +126,64 @@ msgstr ""
 msgid "Could not find art for `${ name }`!"
 msgstr ""
 
-#: src\commands\deck.ts:153
+#: src\commands\deck.ts:198
 #, javascript-format
 msgid "${ counts.Monster } Monster"
 msgid_plural "${ counts.Monster } Monsters"
 msgstr[0] ""
 msgstr[1] ""
 
-#: src\commands\deck.ts:156
+#: src\commands\deck.ts:201
 msgid "${ counts.Spell } Spell"
 msgid_plural "${ counts.Spell } Spells"
 msgstr[0] ""
 msgstr[1] ""
 
-#: src\commands\deck.ts:159
+#: src\commands\deck.ts:204
 #, javascript-format
 msgid "${ counts.Trap } Trap"
 msgid_plural "${ counts.Trap } Traps"
 msgstr[0] ""
 msgstr[1] ""
 
-#: src\commands\deck.ts:187
+#: src\commands\deck.ts:232
 msgid "Your Deck"
 msgstr ""
 
-#: src\commands\deck.ts:192
+#: src\commands\deck.ts:237
 #, javascript-format
 msgid "Main Deck (${ deck.main.length } card — ${ countDetail })"
 msgid_plural "Main Deck (${ deck.main.length } cards — ${ countDetail })"
 msgstr[0] ""
 msgstr[1] ""
 
-#: src\commands\deck.ts:199
+#: src\commands\deck.ts:244
 msgid "Main Deck (continued)"
 msgstr ""
 
-#: src\commands\deck.ts:206
+#: src\commands\deck.ts:251
 #, javascript-format
 msgid "Extra Deck (${ deck.extra.length } card — ${ _countDetail })"
 msgid_plural "Extra Deck (${ deck.extra.length } cards — ${ _countDetail })"
 msgstr[0] ""
 msgstr[1] ""
 
-#: src\commands\deck.ts:213
+#: src\commands\deck.ts:258
 msgid "Extra Deck (continued)"
 msgstr ""
 
-#: src\commands\deck.ts:220
+#: src\commands\deck.ts:265
 #, javascript-format
 msgid "Side Deck (${ deck.side.length } card — ${ _countDetail2 })"
 msgid_plural "Side Deck (${ deck.side.length } cards — ${ _countDetail2 })"
 msgstr[0] ""
 msgstr[1] ""
 
-#: src\commands\deck.ts:227
+#: src\commands\deck.ts:272
 msgid "Side Deck (continued)"
 msgstr ""
 
-#: src\commands\deck.ts:285
+#: src\commands\deck.ts:331
 msgid "Error: Your deck is empty."
 msgstr ""
 
@@ -322,12 +322,16 @@ msgstr ""
 msgid "Revision: ${ process.env.BOT_REVISION }."
 msgstr ""
 
-#: src\commands\deck.ts:236
+#: src\commands\deck.ts:282
 msgid ".ydk files must have the .ydk extension!"
 msgstr ""
 
-#: src\commands\deck.ts:239
+#: src\commands\deck.ts:285
 msgid ".ydk files should not be larger than 1 KB!"
+msgstr ""
+
+#: src\commands\deck.ts:275
+msgid "ydke URL"
 msgstr ""
 
 #: src\card.ts:37
@@ -651,6 +655,32 @@ msgctxt "command-option"
 msgid "page"
 msgstr ""
 
+#: src\commands\deck.ts:74
+msgctxt "command-option"
+msgid "url"
+msgstr ""
+
+#: src\commands\deck.ts:80
+msgctxt "command-option"
+msgid "file"
+msgstr ""
+
+#: src\commands\deck.ts:86
+#: src\commands\deck.ts:92
+msgctxt "command-option"
+msgid "deck"
+msgstr ""
+
+#: src\commands\deck.ts:98
+msgctxt "command-option"
+msgid "public"
+msgstr ""
+
+#: src\commands\deck.ts:105
+msgctxt "command-option"
+msgid "stacked"
+msgstr ""
+
 #: src\locale.ts:50
 msgctxt "command-option-description"
 msgid "The output language for the card embed, overriding other settings."
@@ -681,6 +711,40 @@ msgctxt "command-option-description"
 msgid "The name of the Yugipedia page you want to search for."
 msgstr ""
 
+#: src\commands\deck.ts:77
+msgctxt "command-option-description"
+msgid "View a deck by entering a ydke:// URL."
+msgstr ""
+
+#: src\commands\deck.ts:83
+msgctxt "command-option-description"
+msgid "View a deck by uploading a .ydk file."
+msgstr ""
+
+#: src\commands\deck.ts:89
+msgctxt "command-option-description"
+msgid "The ydke:// URL of the deck you want to view."
+msgstr ""
+
+#: src\commands\deck.ts:95
+msgctxt "command-option-description"
+msgid "The .ydk file of the deck you want to view."
+msgstr ""
+
+#: src\commands\deck.ts:101
+msgctxt "command-option-description"
+msgid ""
+"Whether to display the deck details publicly in chat. This is false by "
+"default."
+msgstr ""
+
+#: src\commands\deck.ts:108
+msgctxt "command-option-description"
+msgid ""
+"Whether to display the deck sections as one stacked column. This is false "
+"(side-by-side) by default."
+msgstr ""
+
 #: src\commands\art.ts:35
 msgctxt "command-name"
 msgid "art"
@@ -706,6 +770,11 @@ msgctxt "command-name"
 msgid "yugipedia"
 msgstr ""
 
+#: src\commands\deck.ts:67
+msgctxt "command-name"
+msgid "deck"
+msgstr ""
+
 #: src\commands\art.ts:36
 msgctxt "command-description"
 msgid "Display the art for a card!"
@@ -729,4 +798,11 @@ msgstr ""
 #: src\commands\yugipedia.ts:37
 msgctxt "command-description"
 msgid "Search the Yugipedia wiki for a page and link to it."
+msgstr ""
+
+#: src\commands\deck.ts:70
+msgctxt "command-description"
+msgid ""
+"Display a deck list from ydke:// or .ydk format, exported from a number of "
+"deck building programs."
 msgstr ""

--- a/translations/ja.po
+++ b/translations/ja.po
@@ -128,64 +128,64 @@ msgstr ""
 msgid "Could not find art for `${ name }`!"
 msgstr ""
 
-#: src\commands\deck.ts:153
+#: src\commands\deck.ts:198
 #, javascript-format
 msgid "${ counts.Monster } Monster"
 msgid_plural "${ counts.Monster } Monsters"
 msgstr[0] ""
 msgstr[1] ""
 
-#: src\commands\deck.ts:156
+#: src\commands\deck.ts:201
 msgid "${ counts.Spell } Spell"
 msgid_plural "${ counts.Spell } Spells"
 msgstr[0] ""
 msgstr[1] ""
 
-#: src\commands\deck.ts:159
+#: src\commands\deck.ts:204
 #, javascript-format
 msgid "${ counts.Trap } Trap"
 msgid_plural "${ counts.Trap } Traps"
 msgstr[0] ""
 msgstr[1] ""
 
-#: src\commands\deck.ts:187
+#: src\commands\deck.ts:232
 msgid "Your Deck"
 msgstr ""
 
-#: src\commands\deck.ts:192
+#: src\commands\deck.ts:237
 #, javascript-format
 msgid "Main Deck (${ deck.main.length } card — ${ countDetail })"
 msgid_plural "Main Deck (${ deck.main.length } cards — ${ countDetail })"
 msgstr[0] ""
 msgstr[1] ""
 
-#: src\commands\deck.ts:199
+#: src\commands\deck.ts:244
 msgid "Main Deck (continued)"
 msgstr ""
 
-#: src\commands\deck.ts:206
+#: src\commands\deck.ts:251
 #, javascript-format
 msgid "Extra Deck (${ deck.extra.length } card — ${ _countDetail })"
 msgid_plural "Extra Deck (${ deck.extra.length } cards — ${ _countDetail })"
 msgstr[0] ""
 msgstr[1] ""
 
-#: src\commands\deck.ts:213
+#: src\commands\deck.ts:258
 msgid "Extra Deck (continued)"
 msgstr ""
 
-#: src\commands\deck.ts:220
+#: src\commands\deck.ts:265
 #, javascript-format
 msgid "Side Deck (${ deck.side.length } card — ${ _countDetail2 })"
 msgid_plural "Side Deck (${ deck.side.length } cards — ${ _countDetail2 })"
 msgstr[0] ""
 msgstr[1] ""
 
-#: src\commands\deck.ts:227
+#: src\commands\deck.ts:272
 msgid "Side Deck (continued)"
 msgstr ""
 
-#: src\commands\deck.ts:285
+#: src\commands\deck.ts:331
 msgid "Error: Your deck is empty."
 msgstr ""
 
@@ -324,12 +324,16 @@ msgstr ""
 msgid "Revision: ${ process.env.BOT_REVISION }."
 msgstr ""
 
-#: src\commands\deck.ts:236
+#: src\commands\deck.ts:282
 msgid ".ydk files must have the .ydk extension!"
 msgstr ""
 
-#: src\commands\deck.ts:239
+#: src\commands\deck.ts:285
 msgid ".ydk files should not be larger than 1 KB!"
+msgstr ""
+
+#: src\commands\deck.ts:275
+msgid "ydke URL"
 msgstr ""
 
 #: src\card.ts:37
@@ -653,6 +657,32 @@ msgctxt "command-option"
 msgid "page"
 msgstr ""
 
+#: src\commands\deck.ts:74
+msgctxt "command-option"
+msgid "url"
+msgstr ""
+
+#: src\commands\deck.ts:80
+msgctxt "command-option"
+msgid "file"
+msgstr ""
+
+#: src\commands\deck.ts:86
+#: src\commands\deck.ts:92
+msgctxt "command-option"
+msgid "deck"
+msgstr ""
+
+#: src\commands\deck.ts:98
+msgctxt "command-option"
+msgid "public"
+msgstr ""
+
+#: src\commands\deck.ts:105
+msgctxt "command-option"
+msgid "stacked"
+msgstr ""
+
 #: src\locale.ts:50
 msgctxt "command-option-description"
 msgid "The output language for the card embed, overriding other settings."
@@ -683,6 +713,40 @@ msgctxt "command-option-description"
 msgid "The name of the Yugipedia page you want to search for."
 msgstr ""
 
+#: src\commands\deck.ts:77
+msgctxt "command-option-description"
+msgid "View a deck by entering a ydke:// URL."
+msgstr ""
+
+#: src\commands\deck.ts:83
+msgctxt "command-option-description"
+msgid "View a deck by uploading a .ydk file."
+msgstr ""
+
+#: src\commands\deck.ts:89
+msgctxt "command-option-description"
+msgid "The ydke:// URL of the deck you want to view."
+msgstr ""
+
+#: src\commands\deck.ts:95
+msgctxt "command-option-description"
+msgid "The .ydk file of the deck you want to view."
+msgstr ""
+
+#: src\commands\deck.ts:101
+msgctxt "command-option-description"
+msgid ""
+"Whether to display the deck details publicly in chat. This is false by "
+"default."
+msgstr ""
+
+#: src\commands\deck.ts:108
+msgctxt "command-option-description"
+msgid ""
+"Whether to display the deck sections as one stacked column. This is false "
+"(side-by-side) by default."
+msgstr ""
+
 #: src\commands\art.ts:35
 msgctxt "command-name"
 msgid "art"
@@ -708,6 +772,11 @@ msgctxt "command-name"
 msgid "yugipedia"
 msgstr ""
 
+#: src\commands\deck.ts:67
+msgctxt "command-name"
+msgid "deck"
+msgstr ""
+
 #: src\commands\art.ts:36
 msgctxt "command-description"
 msgid "Display the art for a card!"
@@ -731,4 +800,11 @@ msgstr ""
 #: src\commands\yugipedia.ts:37
 msgctxt "command-description"
 msgid "Search the Yugipedia wiki for a page and link to it."
+msgstr ""
+
+#: src\commands\deck.ts:70
+msgctxt "command-description"
+msgid ""
+"Display a deck list from ydke:// or .ydk format, exported from a number of "
+"deck building programs."
 msgstr ""

--- a/translations/ja.po
+++ b/translations/ja.po
@@ -31,20 +31,26 @@ msgstr "**属性**: ${ AttributeIcon[card.attribute] } ${ localizedAttribute }"
 msgid ""
 "**Rank**: ${ Icon.Rank } ${ card.rank } **ATK**: ${ card.atk } **DEF**: ${ "
 "card.def }"
-msgstr "**ランク**: ${ Icon.Rank } ${ card.rank } **攻撃力**: ${ card.atk } **守備力**: ${ card.def }"
+msgstr ""
+"**ランク**: ${ Icon.Rank } ${ card.rank } **攻撃力**: ${ card.atk } **守備力**: ${ "
+"card.def }"
 
 #: src\card.ts:281
 #, javascript-format
 msgid ""
 "**Link Rating**: ${ card.link_arrows.length } **ATK**: ${ card.atk } **Link "
 "Arrows**: ${ arrows }"
-msgstr "**リンクの数字分**: ${ card.link_arrows.length } **攻撃力**: ${ card.atk } **リンクマーカー**: ${ arrows }"
+msgstr ""
+"**リンクの数字分**: ${ card.link_arrows.length } **攻撃力**: ${ card.atk } "
+"**リンクマーカー**: ${ arrows }"
 
 #: src\card.ts:283
 msgid ""
 "**Level**: ${ Icon.Level } ${ card.level } **ATK**: ${ card.atk } **DEF**: "
 "${ card.def }"
-msgstr "**レベル**: ${ Icon.Level } ${ card.level } **攻撃力**: ${ card.atk } **守備力**: ${ card.def }"
+msgstr ""
+"**レベル**: ${ Icon.Level } ${ card.level } **攻撃力**: ${ card.atk } **守備力**: ${ "
+"card.def }"
 
 #: src\card.ts:290
 #, javascript-format
@@ -122,58 +128,64 @@ msgstr ""
 msgid "Could not find art for `${ name }`!"
 msgstr ""
 
-#: src\commands\deck.ts:132
+#: src\commands\deck.ts:153
 #, javascript-format
 msgid "${ counts.Monster } Monster"
 msgid_plural "${ counts.Monster } Monsters"
 msgstr[0] ""
+msgstr[1] ""
 
-#: src\commands\deck.ts:135
+#: src\commands\deck.ts:156
 msgid "${ counts.Spell } Spell"
 msgid_plural "${ counts.Spell } Spells"
 msgstr[0] ""
+msgstr[1] ""
 
-#: src\commands\deck.ts:138
+#: src\commands\deck.ts:159
 #, javascript-format
 msgid "${ counts.Trap } Trap"
 msgid_plural "${ counts.Trap } Traps"
 msgstr[0] ""
+msgstr[1] ""
 
-#: src\commands\deck.ts:166
+#: src\commands\deck.ts:187
 msgid "Your Deck"
 msgstr ""
 
-#: src\commands\deck.ts:171
+#: src\commands\deck.ts:192
 #, javascript-format
 msgid "Main Deck (${ deck.main.length } card — ${ countDetail })"
 msgid_plural "Main Deck (${ deck.main.length } cards — ${ countDetail })"
 msgstr[0] ""
+msgstr[1] ""
 
-#: src\commands\deck.ts:178
+#: src\commands\deck.ts:199
 msgid "Main Deck (continued)"
 msgstr ""
 
-#: src\commands\deck.ts:185
+#: src\commands\deck.ts:206
 #, javascript-format
 msgid "Extra Deck (${ deck.extra.length } card — ${ _countDetail })"
 msgid_plural "Extra Deck (${ deck.extra.length } cards — ${ _countDetail })"
 msgstr[0] ""
+msgstr[1] ""
 
-#: src\commands\deck.ts:192
+#: src\commands\deck.ts:213
 msgid "Extra Deck (continued)"
 msgstr ""
 
-#: src\commands\deck.ts:199
+#: src\commands\deck.ts:220
 #, javascript-format
 msgid "Side Deck (${ deck.side.length } card — ${ _countDetail2 })"
 msgid_plural "Side Deck (${ deck.side.length } cards — ${ _countDetail2 })"
 msgstr[0] ""
+msgstr[1] ""
 
-#: src\commands\deck.ts:206
+#: src\commands\deck.ts:227
 msgid "Side Deck (continued)"
 msgstr ""
 
-#: src\commands\deck.ts:231
+#: src\commands\deck.ts:285
 msgid "Error: Your deck is empty."
 msgstr ""
 
@@ -310,6 +322,14 @@ msgstr ""
 #: src\events\message.ts:51
 #, javascript-format
 msgid "Revision: ${ process.env.BOT_REVISION }."
+msgstr ""
+
+#: src\commands\deck.ts:236
+msgid ".ydk files must have the .ydk extension!"
+msgstr ""
+
+#: src\commands\deck.ts:239
+msgid ".ydk files should not be larger than 1 KB!"
 msgstr ""
 
 #: src\card.ts:37

--- a/translations/ja.po
+++ b/translations/ja.po
@@ -133,20 +133,17 @@ msgstr ""
 msgid "${ counts.Monster } Monster"
 msgid_plural "${ counts.Monster } Monsters"
 msgstr[0] ""
-msgstr[1] ""
 
 #: src\commands\deck.ts:201
 msgid "${ counts.Spell } Spell"
 msgid_plural "${ counts.Spell } Spells"
 msgstr[0] ""
-msgstr[1] ""
 
 #: src\commands\deck.ts:204
 #, javascript-format
 msgid "${ counts.Trap } Trap"
 msgid_plural "${ counts.Trap } Traps"
 msgstr[0] ""
-msgstr[1] ""
 
 #: src\commands\deck.ts:232
 msgid "Your Deck"
@@ -157,7 +154,6 @@ msgstr ""
 msgid "Main Deck (${ deck.main.length } card — ${ countDetail })"
 msgid_plural "Main Deck (${ deck.main.length } cards — ${ countDetail })"
 msgstr[0] ""
-msgstr[1] ""
 
 #: src\commands\deck.ts:244
 msgid "Main Deck (continued)"
@@ -168,7 +164,6 @@ msgstr ""
 msgid "Extra Deck (${ deck.extra.length } card — ${ _countDetail })"
 msgid_plural "Extra Deck (${ deck.extra.length } cards — ${ _countDetail })"
 msgstr[0] ""
-msgstr[1] ""
 
 #: src\commands\deck.ts:258
 msgid "Extra Deck (continued)"
@@ -179,7 +174,6 @@ msgstr ""
 msgid "Side Deck (${ deck.side.length } card — ${ _countDetail2 })"
 msgid_plural "Side Deck (${ deck.side.length } cards — ${ _countDetail2 })"
 msgstr[0] ""
-msgstr[1] ""
 
 #: src\commands\deck.ts:272
 msgid "Side Deck (continued)"

--- a/translations/ko.po
+++ b/translations/ko.po
@@ -243,64 +243,64 @@ msgstr "Yugipedia에서 `${ page }`을(를) 검색하는 중…"
 msgid "Could not find a Yugipedia page named `${ page }`."
 msgstr "일치하는 이름을 Yugipedia 페이지에서 찾을 수 없습니다. : `${ page }`."
 
-#: src\commands\deck.ts:153
+#: src\commands\deck.ts:198
 #, javascript-format
 msgid "${ counts.Monster } Monster"
 msgid_plural "${ counts.Monster } Monsters"
 msgstr[0] ""
 msgstr[1] ""
 
-#: src\commands\deck.ts:156
+#: src\commands\deck.ts:201
 msgid "${ counts.Spell } Spell"
 msgid_plural "${ counts.Spell } Spells"
 msgstr[0] ""
 msgstr[1] ""
 
-#: src\commands\deck.ts:159
+#: src\commands\deck.ts:204
 #, javascript-format
 msgid "${ counts.Trap } Trap"
 msgid_plural "${ counts.Trap } Traps"
 msgstr[0] ""
 msgstr[1] ""
 
-#: src\commands\deck.ts:187
+#: src\commands\deck.ts:232
 msgid "Your Deck"
 msgstr ""
 
-#: src\commands\deck.ts:192
+#: src\commands\deck.ts:237
 #, javascript-format
 msgid "Main Deck (${ deck.main.length } card — ${ countDetail })"
 msgid_plural "Main Deck (${ deck.main.length } cards — ${ countDetail })"
 msgstr[0] ""
 msgstr[1] ""
 
-#: src\commands\deck.ts:199
+#: src\commands\deck.ts:244
 msgid "Main Deck (continued)"
 msgstr ""
 
-#: src\commands\deck.ts:206
+#: src\commands\deck.ts:251
 #, javascript-format
 msgid "Extra Deck (${ deck.extra.length } card — ${ _countDetail })"
 msgid_plural "Extra Deck (${ deck.extra.length } cards — ${ _countDetail })"
 msgstr[0] ""
 msgstr[1] ""
 
-#: src\commands\deck.ts:213
+#: src\commands\deck.ts:258
 msgid "Extra Deck (continued)"
 msgstr ""
 
-#: src\commands\deck.ts:220
+#: src\commands\deck.ts:265
 #, javascript-format
 msgid "Side Deck (${ deck.side.length } card — ${ _countDetail2 })"
 msgid_plural "Side Deck (${ deck.side.length } cards — ${ _countDetail2 })"
 msgstr[0] ""
 msgstr[1] ""
 
-#: src\commands\deck.ts:227
+#: src\commands\deck.ts:272
 msgid "Side Deck (continued)"
 msgstr ""
 
-#: src\commands\deck.ts:285
+#: src\commands\deck.ts:331
 msgid "Error: Your deck is empty."
 msgstr ""
 
@@ -336,12 +336,16 @@ msgstr ""
 msgid "Revision: ${ process.env.BOT_REVISION }."
 msgstr ""
 
-#: src\commands\deck.ts:236
+#: src\commands\deck.ts:282
 msgid ".ydk files must have the .ydk extension!"
 msgstr ""
 
-#: src\commands\deck.ts:239
+#: src\commands\deck.ts:285
 msgid ".ydk files should not be larger than 1 KB!"
+msgstr ""
+
+#: src\commands\deck.ts:275
+msgid "ydke URL"
 msgstr ""
 
 #: src\card.ts:37
@@ -665,6 +669,32 @@ msgctxt "command-option"
 msgid "command"
 msgstr ""
 
+#: src\commands\deck.ts:74
+msgctxt "command-option"
+msgid "url"
+msgstr ""
+
+#: src\commands\deck.ts:80
+msgctxt "command-option"
+msgid "file"
+msgstr ""
+
+#: src\commands\deck.ts:86
+#: src\commands\deck.ts:92
+msgctxt "command-option"
+msgid "deck"
+msgstr ""
+
+#: src\commands\deck.ts:98
+msgctxt "command-option"
+msgid "public"
+msgstr ""
+
+#: src\commands\deck.ts:105
+msgctxt "command-option"
+msgid "stacked"
+msgstr ""
+
 #: src\locale.ts:50
 msgctxt "command-option-description"
 msgid "The output language for the card embed, overriding other settings."
@@ -695,6 +725,40 @@ msgctxt "command-option-description"
 msgid "The name of a specific Slash Command."
 msgstr ""
 
+#: src\commands\deck.ts:77
+msgctxt "command-option-description"
+msgid "View a deck by entering a ydke:// URL."
+msgstr ""
+
+#: src\commands\deck.ts:83
+msgctxt "command-option-description"
+msgid "View a deck by uploading a .ydk file."
+msgstr ""
+
+#: src\commands\deck.ts:89
+msgctxt "command-option-description"
+msgid "The ydke:// URL of the deck you want to view."
+msgstr ""
+
+#: src\commands\deck.ts:95
+msgctxt "command-option-description"
+msgid "The .ydk file of the deck you want to view."
+msgstr ""
+
+#: src\commands\deck.ts:101
+msgctxt "command-option-description"
+msgid ""
+"Whether to display the deck details publicly in chat. This is false by "
+"default."
+msgstr ""
+
+#: src\commands\deck.ts:108
+msgctxt "command-option-description"
+msgid ""
+"Whether to display the deck sections as one stacked column. This is false "
+"(side-by-side) by default."
+msgstr ""
+
 #: src\commands\art.ts:35
 msgctxt "command-name"
 msgid "art"
@@ -720,6 +784,11 @@ msgctxt "command-name"
 msgid "help"
 msgstr ""
 
+#: src\commands\deck.ts:67
+msgctxt "command-name"
+msgid "deck"
+msgstr ""
+
 #: src\commands\art.ts:36
 msgctxt "command-description"
 msgid "Display the art for a card!"
@@ -743,4 +812,11 @@ msgstr "Yugipedia에서 검색하고 링크를 출력합니다."
 #: src\commands\help.ts:49
 msgctxt "command-description"
 msgid "Get help with a Slash Command."
+msgstr ""
+
+#: src\commands\deck.ts:70
+msgctxt "command-description"
+msgid ""
+"Display a deck list from ydke:// or .ydk format, exported from a number of "
+"deck building programs."
 msgstr ""

--- a/translations/ko.po
+++ b/translations/ko.po
@@ -243,58 +243,64 @@ msgstr "Yugipedia에서 `${ page }`을(를) 검색하는 중…"
 msgid "Could not find a Yugipedia page named `${ page }`."
 msgstr "일치하는 이름을 Yugipedia 페이지에서 찾을 수 없습니다. : `${ page }`."
 
-#: src\commands\deck.ts:132
+#: src\commands\deck.ts:153
 #, javascript-format
 msgid "${ counts.Monster } Monster"
 msgid_plural "${ counts.Monster } Monsters"
 msgstr[0] ""
+msgstr[1] ""
 
-#: src\commands\deck.ts:135
+#: src\commands\deck.ts:156
 msgid "${ counts.Spell } Spell"
 msgid_plural "${ counts.Spell } Spells"
 msgstr[0] ""
+msgstr[1] ""
 
-#: src\commands\deck.ts:138
+#: src\commands\deck.ts:159
 #, javascript-format
 msgid "${ counts.Trap } Trap"
 msgid_plural "${ counts.Trap } Traps"
 msgstr[0] ""
+msgstr[1] ""
 
-#: src\commands\deck.ts:166
+#: src\commands\deck.ts:187
 msgid "Your Deck"
 msgstr ""
 
-#: src\commands\deck.ts:171
+#: src\commands\deck.ts:192
 #, javascript-format
 msgid "Main Deck (${ deck.main.length } card — ${ countDetail })"
 msgid_plural "Main Deck (${ deck.main.length } cards — ${ countDetail })"
 msgstr[0] ""
+msgstr[1] ""
 
-#: src\commands\deck.ts:178
+#: src\commands\deck.ts:199
 msgid "Main Deck (continued)"
 msgstr ""
 
-#: src\commands\deck.ts:185
+#: src\commands\deck.ts:206
 #, javascript-format
 msgid "Extra Deck (${ deck.extra.length } card — ${ _countDetail })"
 msgid_plural "Extra Deck (${ deck.extra.length } cards — ${ _countDetail })"
 msgstr[0] ""
+msgstr[1] ""
 
-#: src\commands\deck.ts:192
+#: src\commands\deck.ts:213
 msgid "Extra Deck (continued)"
 msgstr ""
 
-#: src\commands\deck.ts:199
+#: src\commands\deck.ts:220
 #, javascript-format
 msgid "Side Deck (${ deck.side.length } card — ${ _countDetail2 })"
 msgid_plural "Side Deck (${ deck.side.length } cards — ${ _countDetail2 })"
 msgstr[0] ""
+msgstr[1] ""
 
-#: src\commands\deck.ts:206
+#: src\commands\deck.ts:227
 msgid "Side Deck (continued)"
 msgstr ""
 
-#: src\commands\deck.ts:231
+#: src\commands\deck.ts:285
 msgid "Error: Your deck is empty."
 msgstr ""
 
@@ -328,6 +334,14 @@ msgstr ""
 #: src\events\message.ts:51
 #, javascript-format
 msgid "Revision: ${ process.env.BOT_REVISION }."
+msgstr ""
+
+#: src\commands\deck.ts:236
+msgid ".ydk files must have the .ydk extension!"
+msgstr ""
+
+#: src\commands\deck.ts:239
+msgid ".ydk files should not be larger than 1 KB!"
 msgstr ""
 
 #: src\card.ts:37
@@ -621,12 +635,12 @@ msgctxt "card-embed"
 msgid "Card Effect"
 msgstr "카드 효과"
 
-#: src\locale.ts:46
+#: src\locale.ts:47
 msgctxt "command-option"
 msgid "result-language"
 msgstr "출력언어"
 
-#: src\locale.ts:66
+#: src\locale.ts:67
 msgctxt "command-option"
 msgid "input-language"
 msgstr "입력언어"
@@ -651,12 +665,12 @@ msgctxt "command-option"
 msgid "command"
 msgstr ""
 
-#: src\locale.ts:49
+#: src\locale.ts:50
 msgctxt "command-option-description"
 msgid "The output language for the card embed, overriding other settings."
 msgstr "다른 설정을 재정의하는 카드 임베드의 출력 언어입니다."
 
-#: src\locale.ts:69
+#: src\locale.ts:70
 msgctxt "command-option-description"
 msgid "The language to search in, defaulting to the result language."
 msgstr "검색할 언어로, 기본적으로 출력 언어로 설정됩니다."

--- a/translations/ko.po
+++ b/translations/ko.po
@@ -248,20 +248,17 @@ msgstr "일치하는 이름을 Yugipedia 페이지에서 찾을 수 없습니다
 msgid "${ counts.Monster } Monster"
 msgid_plural "${ counts.Monster } Monsters"
 msgstr[0] ""
-msgstr[1] ""
 
 #: src\commands\deck.ts:201
 msgid "${ counts.Spell } Spell"
 msgid_plural "${ counts.Spell } Spells"
 msgstr[0] ""
-msgstr[1] ""
 
 #: src\commands\deck.ts:204
 #, javascript-format
 msgid "${ counts.Trap } Trap"
 msgid_plural "${ counts.Trap } Traps"
 msgstr[0] ""
-msgstr[1] ""
 
 #: src\commands\deck.ts:232
 msgid "Your Deck"
@@ -272,7 +269,6 @@ msgstr ""
 msgid "Main Deck (${ deck.main.length } card — ${ countDetail })"
 msgid_plural "Main Deck (${ deck.main.length } cards — ${ countDetail })"
 msgstr[0] ""
-msgstr[1] ""
 
 #: src\commands\deck.ts:244
 msgid "Main Deck (continued)"
@@ -283,7 +279,6 @@ msgstr ""
 msgid "Extra Deck (${ deck.extra.length } card — ${ _countDetail })"
 msgid_plural "Extra Deck (${ deck.extra.length } cards — ${ _countDetail })"
 msgstr[0] ""
-msgstr[1] ""
 
 #: src\commands\deck.ts:258
 msgid "Extra Deck (continued)"
@@ -294,7 +289,6 @@ msgstr ""
 msgid "Side Deck (${ deck.side.length } card — ${ _countDetail2 })"
 msgid_plural "Side Deck (${ deck.side.length } cards — ${ _countDetail2 })"
 msgstr[0] ""
-msgstr[1] ""
 
 #: src\commands\deck.ts:272
 msgid "Side Deck (continued)"

--- a/translations/pt.po
+++ b/translations/pt.po
@@ -15,9 +15,9 @@ msgstr ""
 msgid ""
 "[Official Konami DB](${ official }) | [OCG Rulings](${ rulings }) | "
 "[Yugipedia](${ yugipedia }) | [YGOPRODECK](${ ygoprodeck })"
-msgstr
-"[Database oficial da Konami](${ official }) | [Regras no OCG](${ rulings }) | "
-"[Yugipedia](${ yugipedia }) | [YGOPRODECK](${ ygoprodeck })"
+msgstr ""
+"[Database oficial da Konami](${ official }) | [Regras no OCG](${ rulings }) "
+"| [Yugipedia](${ yugipedia }) | [YGOPRODECK](${ ygoprodeck })"
 
 #: src\card.ts:272
 msgid "**Type**: ${ RaceIcon[race] } ${ localizedMonsterTypeLine }"
@@ -33,8 +33,9 @@ msgstr "**Atributo**: ${ AttributeIcon[card.attribute] } ${ localizedAttribute }
 msgid ""
 "**Rank**: ${ Icon.Rank } ${ card.rank } **ATK**: ${ card.atk } **DEF**: ${ "
 "card.def }"
-msgstr "**Classe**: ${ Icon.Rank } ${ card.rank } **ATK**: ${ card.atk } **DEF**: ${ "
-"card.def }"
+msgstr ""
+"**Classe**: ${ Icon.Rank } ${ card.rank } **ATK**: ${ card.atk } **DEF**: "
+"${ card.def }"
 
 #: src\card.ts:281
 #, javascript-format
@@ -44,11 +45,13 @@ msgid ""
 msgstr ""
 "**Valor Link**: ${ card.link_arrows.length } **ATK**: ${ card.atk } **Link "
 "Flechas Link**: ${ arrows }"
+
 #: src\card.ts:283
 msgid ""
 "**Level**: ${ Icon.Level } ${ card.level } **ATK**: ${ card.atk } **DEF**: "
 "${ card.def }"
-msgstr "**Nível**: ${ Icon.Level } ${ card.level } **ATK**: ${ card.atk } **DEF**: "
+msgstr ""
+"**Nível**: ${ Icon.Level } ${ card.level } **ATK**: ${ card.atk } **DEF**: "
 "${ card.def }"
 
 #: src\card.ts:290
@@ -72,8 +75,9 @@ msgid ""
 "tracker](https://github.com/DawnbrandBots/bastion-bot) or the [support "
 "server](https://discord.gg/4aFuPyuE96)!"
 msgstr ""
-":incoming_envelope: Por favor, envie um feedback para o "
-"[nosso Github](https://github.com/DawnbrandBots/bastion-bot)ou no nosso [servidor no Discord](https://discord.gg/4aFuPyuE96)!"
+":incoming_envelope: Por favor, envie um feedback para o [nosso "
+"Github](https://github.com/DawnbrandBots/bastion-bot)ou no nosso [servidor "
+"no Discord](https://discord.gg/4aFuPyuE96)!"
 
 #: src\utils.ts:45
 msgid "Please consider supporting us!"
@@ -129,64 +133,64 @@ msgstr "Não foi possível encontrar uma carta compatível com `${ input }`!"
 msgid "Could not find art for `${ name }`!"
 msgstr "Não foi possível encontrar uma arte para `${ name }`!"
 
-#: src\commands\deck.ts:132
+#: src\commands\deck.ts:153
 #, javascript-format
 msgid "${ counts.Monster } Monster"
 msgid_plural "${ counts.Monster } Monsters"
 msgstr[0] "${ counts.Monster } Monstro"
 msgstr[1] "${ counts.Monster } Monstros"
 
-#: src\commands\deck.ts:135
+#: src\commands\deck.ts:156
 msgid "${ counts.Spell } Spell"
 msgid_plural "${ counts.Spell } Spells"
 msgstr[0] "${ counts.Spell } Magia"
 msgstr[1] "${ counts.Spell } Magias"
 
-#: src\commands\deck.ts:138
+#: src\commands\deck.ts:159
 #, javascript-format
 msgid "${ counts.Trap } Trap"
 msgid_plural "${ counts.Trap } Traps"
 msgstr[0] "${ counts.Trap } Armadilha"
 msgstr[1] "${ counts.Trap } Armadilhas"
 
-#: src\commands\deck.ts:166
+#: src\commands\deck.ts:187
 msgid "Your Deck"
 msgstr "Seu Deck"
 
-#: src\commands\deck.ts:171
+#: src\commands\deck.ts:192
 #, javascript-format
 msgid "Main Deck (${ deck.main.length } card — ${ countDetail })"
 msgid_plural "Main Deck (${ deck.main.length } cards — ${ countDetail })"
 msgstr[0] "Deck Principal (${ deck.main.length } carta — ${ countDetail })"
 msgstr[1] "Deck Principal (${ deck.main.length } cartas — ${ countDetail })"
 
-#: src\commands\deck.ts:178
+#: src\commands\deck.ts:199
 msgid "Main Deck (continued)"
 msgstr "Deck Principal (continuação)"
 
-#: src\commands\deck.ts:185
+#: src\commands\deck.ts:206
 #, javascript-format
 msgid "Extra Deck (${ deck.extra.length } card — ${ _countDetail })"
 msgid_plural "Extra Deck (${ deck.extra.length } cards — ${ _countDetail })"
 msgstr[0] "Deck Adicional (${ deck.extra.length } carta — ${ _countDetail })"
 msgstr[1] "Deck Adicional (${ deck.extra.length } cartas — ${ _countDetail })"
 
-#: src\commands\deck.ts:192
+#: src\commands\deck.ts:213
 msgid "Extra Deck (continued)"
 msgstr "Deck Adicional (continuação)"
 
-#: src\commands\deck.ts:199
+#: src\commands\deck.ts:220
 #, javascript-format
 msgid "Side Deck (${ deck.side.length } card — ${ _countDetail2 })"
 msgid_plural "Side Deck (${ deck.side.length } cards — ${ _countDetail2 })"
 msgstr[0] "Deck Auxiliar (${ deck.side.length } carta — ${ _countDetail2 })"
 msgstr[1] "Deck Auxiliar (${ deck.side.length } cartas — ${ _countDetail2 })"
 
-#: src\commands\deck.ts:206
+#: src\commands\deck.ts:227
 msgid "Side Deck (continued)"
 msgstr "Deck Auxiliar (continuação)"
 
-#: src\commands\deck.ts:231
+#: src\commands\deck.ts:285
 msgid "Error: Your deck is empty."
 msgstr "Erro: Seu deck está vazio"
 
@@ -324,6 +328,14 @@ msgstr ""
 #, javascript-format
 msgid "Revision: ${ process.env.BOT_REVISION }."
 msgstr "Revisão: ${ process.env.BOT_REVISION }."
+
+#: src\commands\deck.ts:236
+msgid ".ydk files must have the .ydk extension!"
+msgstr ""
+
+#: src\commands\deck.ts:239
+msgid ".ydk files should not be larger than 1 KB!"
+msgstr ""
 
 #: src\card.ts:37
 msgctxt "monster-type-race"
@@ -616,12 +628,12 @@ msgctxt "card-embed"
 msgid "Card Effect"
 msgstr "Efeito da Carta"
 
-#: src\locale.ts:46
+#: src\locale.ts:47
 msgctxt "command-option"
 msgid "result-language"
 msgstr ""
 
-#: src\locale.ts:66
+#: src\locale.ts:67
 msgctxt "command-option"
 msgid "input-language"
 msgstr "idioma-de-entrada"
@@ -646,12 +658,12 @@ msgctxt "command-option"
 msgid "command"
 msgstr ""
 
-#: src\locale.ts:49
+#: src\locale.ts:50
 msgctxt "command-option-description"
 msgid "The output language for the card embed, overriding other settings."
 msgstr ""
 
-#: src\locale.ts:69
+#: src\locale.ts:70
 msgctxt "command-option-description"
 msgid "The language to search in, defaulting to the result language."
 msgstr "O idioma no qual procurar, tendo como padrão o idioma do resultado"

--- a/translations/pt.po
+++ b/translations/pt.po
@@ -133,64 +133,64 @@ msgstr "Não foi possível encontrar uma carta compatível com `${ input }`!"
 msgid "Could not find art for `${ name }`!"
 msgstr "Não foi possível encontrar uma arte para `${ name }`!"
 
-#: src\commands\deck.ts:153
+#: src\commands\deck.ts:198
 #, javascript-format
 msgid "${ counts.Monster } Monster"
 msgid_plural "${ counts.Monster } Monsters"
 msgstr[0] "${ counts.Monster } Monstro"
 msgstr[1] "${ counts.Monster } Monstros"
 
-#: src\commands\deck.ts:156
+#: src\commands\deck.ts:201
 msgid "${ counts.Spell } Spell"
 msgid_plural "${ counts.Spell } Spells"
 msgstr[0] "${ counts.Spell } Magia"
 msgstr[1] "${ counts.Spell } Magias"
 
-#: src\commands\deck.ts:159
+#: src\commands\deck.ts:204
 #, javascript-format
 msgid "${ counts.Trap } Trap"
 msgid_plural "${ counts.Trap } Traps"
 msgstr[0] "${ counts.Trap } Armadilha"
 msgstr[1] "${ counts.Trap } Armadilhas"
 
-#: src\commands\deck.ts:187
+#: src\commands\deck.ts:232
 msgid "Your Deck"
 msgstr "Seu Deck"
 
-#: src\commands\deck.ts:192
+#: src\commands\deck.ts:237
 #, javascript-format
 msgid "Main Deck (${ deck.main.length } card — ${ countDetail })"
 msgid_plural "Main Deck (${ deck.main.length } cards — ${ countDetail })"
 msgstr[0] "Deck Principal (${ deck.main.length } carta — ${ countDetail })"
 msgstr[1] "Deck Principal (${ deck.main.length } cartas — ${ countDetail })"
 
-#: src\commands\deck.ts:199
+#: src\commands\deck.ts:244
 msgid "Main Deck (continued)"
 msgstr "Deck Principal (continuação)"
 
-#: src\commands\deck.ts:206
+#: src\commands\deck.ts:251
 #, javascript-format
 msgid "Extra Deck (${ deck.extra.length } card — ${ _countDetail })"
 msgid_plural "Extra Deck (${ deck.extra.length } cards — ${ _countDetail })"
 msgstr[0] "Deck Adicional (${ deck.extra.length } carta — ${ _countDetail })"
 msgstr[1] "Deck Adicional (${ deck.extra.length } cartas — ${ _countDetail })"
 
-#: src\commands\deck.ts:213
+#: src\commands\deck.ts:258
 msgid "Extra Deck (continued)"
 msgstr "Deck Adicional (continuação)"
 
-#: src\commands\deck.ts:220
+#: src\commands\deck.ts:265
 #, javascript-format
 msgid "Side Deck (${ deck.side.length } card — ${ _countDetail2 })"
 msgid_plural "Side Deck (${ deck.side.length } cards — ${ _countDetail2 })"
 msgstr[0] "Deck Auxiliar (${ deck.side.length } carta — ${ _countDetail2 })"
 msgstr[1] "Deck Auxiliar (${ deck.side.length } cartas — ${ _countDetail2 })"
 
-#: src\commands\deck.ts:227
+#: src\commands\deck.ts:272
 msgid "Side Deck (continued)"
 msgstr "Deck Auxiliar (continuação)"
 
-#: src\commands\deck.ts:285
+#: src\commands\deck.ts:331
 msgid "Error: Your deck is empty."
 msgstr "Erro: Seu deck está vazio"
 
@@ -329,12 +329,16 @@ msgstr ""
 msgid "Revision: ${ process.env.BOT_REVISION }."
 msgstr "Revisão: ${ process.env.BOT_REVISION }."
 
-#: src\commands\deck.ts:236
+#: src\commands\deck.ts:282
 msgid ".ydk files must have the .ydk extension!"
 msgstr ""
 
-#: src\commands\deck.ts:239
+#: src\commands\deck.ts:285
 msgid ".ydk files should not be larger than 1 KB!"
+msgstr ""
+
+#: src\commands\deck.ts:275
+msgid "ydke URL"
 msgstr ""
 
 #: src\card.ts:37
@@ -658,6 +662,32 @@ msgctxt "command-option"
 msgid "command"
 msgstr ""
 
+#: src\commands\deck.ts:74
+msgctxt "command-option"
+msgid "url"
+msgstr ""
+
+#: src\commands\deck.ts:80
+msgctxt "command-option"
+msgid "file"
+msgstr ""
+
+#: src\commands\deck.ts:86
+#: src\commands\deck.ts:92
+msgctxt "command-option"
+msgid "deck"
+msgstr ""
+
+#: src\commands\deck.ts:98
+msgctxt "command-option"
+msgid "public"
+msgstr ""
+
+#: src\commands\deck.ts:105
+msgctxt "command-option"
+msgid "stacked"
+msgstr ""
+
 #: src\locale.ts:50
 msgctxt "command-option-description"
 msgid "The output language for the card embed, overriding other settings."
@@ -688,6 +718,40 @@ msgctxt "command-option-description"
 msgid "The name of a specific Slash Command."
 msgstr ""
 
+#: src\commands\deck.ts:77
+msgctxt "command-option-description"
+msgid "View a deck by entering a ydke:// URL."
+msgstr ""
+
+#: src\commands\deck.ts:83
+msgctxt "command-option-description"
+msgid "View a deck by uploading a .ydk file."
+msgstr ""
+
+#: src\commands\deck.ts:89
+msgctxt "command-option-description"
+msgid "The ydke:// URL of the deck you want to view."
+msgstr ""
+
+#: src\commands\deck.ts:95
+msgctxt "command-option-description"
+msgid "The .ydk file of the deck you want to view."
+msgstr ""
+
+#: src\commands\deck.ts:101
+msgctxt "command-option-description"
+msgid ""
+"Whether to display the deck details publicly in chat. This is false by "
+"default."
+msgstr ""
+
+#: src\commands\deck.ts:108
+msgctxt "command-option-description"
+msgid ""
+"Whether to display the deck sections as one stacked column. This is false "
+"(side-by-side) by default."
+msgstr ""
+
 #: src\commands\art.ts:35
 msgctxt "command-name"
 msgid "art"
@@ -713,6 +777,11 @@ msgctxt "command-name"
 msgid "help"
 msgstr ""
 
+#: src\commands\deck.ts:67
+msgctxt "command-name"
+msgid "deck"
+msgstr ""
+
 #: src\commands\art.ts:36
 msgctxt "command-description"
 msgid "Display the art for a card!"
@@ -736,4 +805,11 @@ msgstr "Procura uma página da wiki da Yugipedia e a linka"
 #: src\commands\help.ts:49
 msgctxt "command-description"
 msgid "Get help with a Slash Command."
+msgstr ""
+
+#: src\commands\deck.ts:70
+msgctxt "command-description"
+msgid ""
+"Display a deck list from ydke:// or .ydk format, exported from a number of "
+"deck building programs."
 msgstr ""

--- a/translations/zh-CN.po
+++ b/translations/zh-CN.po
@@ -231,58 +231,64 @@ msgstr "正在Yugipedia上搜索`${ page }`…"
 msgid "Could not find a Yugipedia page named `${ page }`."
 msgstr "Yugipedia上找不到`${ page }`"
 
-#: src\commands\deck.ts:132
+#: src\commands\deck.ts:153
 #, javascript-format
 msgid "${ counts.Monster } Monster"
 msgid_plural "${ counts.Monster } Monsters"
 msgstr[0] ""
+msgstr[1] ""
 
-#: src\commands\deck.ts:135
+#: src\commands\deck.ts:156
 msgid "${ counts.Spell } Spell"
 msgid_plural "${ counts.Spell } Spells"
 msgstr[0] ""
+msgstr[1] ""
 
-#: src\commands\deck.ts:138
+#: src\commands\deck.ts:159
 #, javascript-format
 msgid "${ counts.Trap } Trap"
 msgid_plural "${ counts.Trap } Traps"
 msgstr[0] ""
+msgstr[1] ""
 
-#: src\commands\deck.ts:166
+#: src\commands\deck.ts:187
 msgid "Your Deck"
 msgstr ""
 
-#: src\commands\deck.ts:171
+#: src\commands\deck.ts:192
 #, javascript-format
 msgid "Main Deck (${ deck.main.length } card — ${ countDetail })"
 msgid_plural "Main Deck (${ deck.main.length } cards — ${ countDetail })"
 msgstr[0] ""
+msgstr[1] ""
 
-#: src\commands\deck.ts:178
+#: src\commands\deck.ts:199
 msgid "Main Deck (continued)"
 msgstr ""
 
-#: src\commands\deck.ts:185
+#: src\commands\deck.ts:206
 #, javascript-format
 msgid "Extra Deck (${ deck.extra.length } card — ${ _countDetail })"
 msgid_plural "Extra Deck (${ deck.extra.length } cards — ${ _countDetail })"
 msgstr[0] ""
+msgstr[1] ""
 
-#: src\commands\deck.ts:192
+#: src\commands\deck.ts:213
 msgid "Extra Deck (continued)"
 msgstr ""
 
-#: src\commands\deck.ts:199
+#: src\commands\deck.ts:220
 #, javascript-format
 msgid "Side Deck (${ deck.side.length } card — ${ _countDetail2 })"
 msgid_plural "Side Deck (${ deck.side.length } cards — ${ _countDetail2 })"
 msgstr[0] ""
+msgstr[1] ""
 
-#: src\commands\deck.ts:206
+#: src\commands\deck.ts:227
 msgid "Side Deck (continued)"
 msgstr ""
 
-#: src\commands\deck.ts:231
+#: src\commands\deck.ts:285
 msgid "Error: Your deck is empty."
 msgstr ""
 
@@ -321,6 +327,14 @@ msgstr ""
 #: src\events\message.ts:51
 #, javascript-format
 msgid "Revision: ${ process.env.BOT_REVISION }."
+msgstr ""
+
+#: src\commands\deck.ts:236
+msgid ".ydk files must have the .ydk extension!"
+msgstr ""
+
+#: src\commands\deck.ts:239
+msgid ".ydk files should not be larger than 1 KB!"
 msgstr ""
 
 #: src\card.ts:37
@@ -614,12 +628,12 @@ msgctxt "card-embed"
 msgid "Card Effect"
 msgstr "卡片效果"
 
-#: src\locale.ts:46
+#: src\locale.ts:47
 msgctxt "command-option"
 msgid "result-language"
 msgstr "查询结果语言"
 
-#: src\locale.ts:66
+#: src\locale.ts:67
 msgctxt "command-option"
 msgid "input-language"
 msgstr "输入语言"
@@ -644,12 +658,12 @@ msgctxt "command-option"
 msgid "command"
 msgstr ""
 
-#: src\locale.ts:49
+#: src\locale.ts:50
 msgctxt "command-option-description"
 msgid "The output language for the card embed, overriding other settings."
 msgstr "卡片查询结果的语言，覆盖其他设置"
 
-#: src\locale.ts:69
+#: src\locale.ts:70
 msgctxt "command-option-description"
 msgid "The language to search in, defaulting to the result language."
 msgstr "查询用的语言，默认与查询结果语言相同"

--- a/translations/zh-CN.po
+++ b/translations/zh-CN.po
@@ -236,20 +236,17 @@ msgstr "Yugipedia上找不到`${ page }`"
 msgid "${ counts.Monster } Monster"
 msgid_plural "${ counts.Monster } Monsters"
 msgstr[0] ""
-msgstr[1] ""
 
 #: src\commands\deck.ts:201
 msgid "${ counts.Spell } Spell"
 msgid_plural "${ counts.Spell } Spells"
 msgstr[0] ""
-msgstr[1] ""
 
 #: src\commands\deck.ts:204
 #, javascript-format
 msgid "${ counts.Trap } Trap"
 msgid_plural "${ counts.Trap } Traps"
 msgstr[0] ""
-msgstr[1] ""
 
 #: src\commands\deck.ts:232
 msgid "Your Deck"
@@ -260,7 +257,6 @@ msgstr ""
 msgid "Main Deck (${ deck.main.length } card — ${ countDetail })"
 msgid_plural "Main Deck (${ deck.main.length } cards — ${ countDetail })"
 msgstr[0] ""
-msgstr[1] ""
 
 #: src\commands\deck.ts:244
 msgid "Main Deck (continued)"
@@ -271,7 +267,6 @@ msgstr ""
 msgid "Extra Deck (${ deck.extra.length } card — ${ _countDetail })"
 msgid_plural "Extra Deck (${ deck.extra.length } cards — ${ _countDetail })"
 msgstr[0] ""
-msgstr[1] ""
 
 #: src\commands\deck.ts:258
 msgid "Extra Deck (continued)"
@@ -282,7 +277,6 @@ msgstr ""
 msgid "Side Deck (${ deck.side.length } card — ${ _countDetail2 })"
 msgid_plural "Side Deck (${ deck.side.length } cards — ${ _countDetail2 })"
 msgstr[0] ""
-msgstr[1] ""
 
 #: src\commands\deck.ts:272
 msgid "Side Deck (continued)"

--- a/translations/zh-CN.po
+++ b/translations/zh-CN.po
@@ -231,64 +231,64 @@ msgstr "正在Yugipedia上搜索`${ page }`…"
 msgid "Could not find a Yugipedia page named `${ page }`."
 msgstr "Yugipedia上找不到`${ page }`"
 
-#: src\commands\deck.ts:153
+#: src\commands\deck.ts:198
 #, javascript-format
 msgid "${ counts.Monster } Monster"
 msgid_plural "${ counts.Monster } Monsters"
 msgstr[0] ""
 msgstr[1] ""
 
-#: src\commands\deck.ts:156
+#: src\commands\deck.ts:201
 msgid "${ counts.Spell } Spell"
 msgid_plural "${ counts.Spell } Spells"
 msgstr[0] ""
 msgstr[1] ""
 
-#: src\commands\deck.ts:159
+#: src\commands\deck.ts:204
 #, javascript-format
 msgid "${ counts.Trap } Trap"
 msgid_plural "${ counts.Trap } Traps"
 msgstr[0] ""
 msgstr[1] ""
 
-#: src\commands\deck.ts:187
+#: src\commands\deck.ts:232
 msgid "Your Deck"
 msgstr ""
 
-#: src\commands\deck.ts:192
+#: src\commands\deck.ts:237
 #, javascript-format
 msgid "Main Deck (${ deck.main.length } card — ${ countDetail })"
 msgid_plural "Main Deck (${ deck.main.length } cards — ${ countDetail })"
 msgstr[0] ""
 msgstr[1] ""
 
-#: src\commands\deck.ts:199
+#: src\commands\deck.ts:244
 msgid "Main Deck (continued)"
 msgstr ""
 
-#: src\commands\deck.ts:206
+#: src\commands\deck.ts:251
 #, javascript-format
 msgid "Extra Deck (${ deck.extra.length } card — ${ _countDetail })"
 msgid_plural "Extra Deck (${ deck.extra.length } cards — ${ _countDetail })"
 msgstr[0] ""
 msgstr[1] ""
 
-#: src\commands\deck.ts:213
+#: src\commands\deck.ts:258
 msgid "Extra Deck (continued)"
 msgstr ""
 
-#: src\commands\deck.ts:220
+#: src\commands\deck.ts:265
 #, javascript-format
 msgid "Side Deck (${ deck.side.length } card — ${ _countDetail2 })"
 msgid_plural "Side Deck (${ deck.side.length } cards — ${ _countDetail2 })"
 msgstr[0] ""
 msgstr[1] ""
 
-#: src\commands\deck.ts:227
+#: src\commands\deck.ts:272
 msgid "Side Deck (continued)"
 msgstr ""
 
-#: src\commands\deck.ts:285
+#: src\commands\deck.ts:331
 msgid "Error: Your deck is empty."
 msgstr ""
 
@@ -329,12 +329,16 @@ msgstr ""
 msgid "Revision: ${ process.env.BOT_REVISION }."
 msgstr ""
 
-#: src\commands\deck.ts:236
+#: src\commands\deck.ts:282
 msgid ".ydk files must have the .ydk extension!"
 msgstr ""
 
-#: src\commands\deck.ts:239
+#: src\commands\deck.ts:285
 msgid ".ydk files should not be larger than 1 KB!"
+msgstr ""
+
+#: src\commands\deck.ts:275
+msgid "ydke URL"
 msgstr ""
 
 #: src\card.ts:37
@@ -658,6 +662,32 @@ msgctxt "command-option"
 msgid "command"
 msgstr ""
 
+#: src\commands\deck.ts:74
+msgctxt "command-option"
+msgid "url"
+msgstr ""
+
+#: src\commands\deck.ts:80
+msgctxt "command-option"
+msgid "file"
+msgstr ""
+
+#: src\commands\deck.ts:86
+#: src\commands\deck.ts:92
+msgctxt "command-option"
+msgid "deck"
+msgstr ""
+
+#: src\commands\deck.ts:98
+msgctxt "command-option"
+msgid "public"
+msgstr ""
+
+#: src\commands\deck.ts:105
+msgctxt "command-option"
+msgid "stacked"
+msgstr ""
+
 #: src\locale.ts:50
 msgctxt "command-option-description"
 msgid "The output language for the card embed, overriding other settings."
@@ -688,6 +718,40 @@ msgctxt "command-option-description"
 msgid "The name of a specific Slash Command."
 msgstr ""
 
+#: src\commands\deck.ts:77
+msgctxt "command-option-description"
+msgid "View a deck by entering a ydke:// URL."
+msgstr ""
+
+#: src\commands\deck.ts:83
+msgctxt "command-option-description"
+msgid "View a deck by uploading a .ydk file."
+msgstr ""
+
+#: src\commands\deck.ts:89
+msgctxt "command-option-description"
+msgid "The ydke:// URL of the deck you want to view."
+msgstr ""
+
+#: src\commands\deck.ts:95
+msgctxt "command-option-description"
+msgid "The .ydk file of the deck you want to view."
+msgstr ""
+
+#: src\commands\deck.ts:101
+msgctxt "command-option-description"
+msgid ""
+"Whether to display the deck details publicly in chat. This is false by "
+"default."
+msgstr ""
+
+#: src\commands\deck.ts:108
+msgctxt "command-option-description"
+msgid ""
+"Whether to display the deck sections as one stacked column. This is false "
+"(side-by-side) by default."
+msgstr ""
+
 #: src\commands\art.ts:35
 msgctxt "command-name"
 msgid "art"
@@ -713,6 +777,11 @@ msgctxt "command-name"
 msgid "help"
 msgstr ""
 
+#: src\commands\deck.ts:67
+msgctxt "command-name"
+msgid "deck"
+msgstr ""
+
 #: src\commands\art.ts:36
 msgctxt "command-description"
 msgid "Display the art for a card!"
@@ -736,4 +805,11 @@ msgstr "搜索Yugipedia页面与链接"
 #: src\commands\help.ts:49
 msgctxt "command-description"
 msgid "Get help with a Slash Command."
+msgstr ""
+
+#: src\commands\deck.ts:70
+msgctxt "command-description"
+msgid ""
+"Display a deck list from ydke:// or .ydk format, exported from a number of "
+"deck building programs."
 msgstr ""

--- a/translations/zh-TW.po
+++ b/translations/zh-TW.po
@@ -231,20 +231,17 @@ msgstr ""
 msgid "${ counts.Monster } Monster"
 msgid_plural "${ counts.Monster } Monsters"
 msgstr[0] ""
-msgstr[1] ""
 
 #: src\commands\deck.ts:201
 msgid "${ counts.Spell } Spell"
 msgid_plural "${ counts.Spell } Spells"
 msgstr[0] ""
-msgstr[1] ""
 
 #: src\commands\deck.ts:204
 #, javascript-format
 msgid "${ counts.Trap } Trap"
 msgid_plural "${ counts.Trap } Traps"
 msgstr[0] ""
-msgstr[1] ""
 
 #: src\commands\deck.ts:232
 msgid "Your Deck"
@@ -255,7 +252,6 @@ msgstr ""
 msgid "Main Deck (${ deck.main.length } card — ${ countDetail })"
 msgid_plural "Main Deck (${ deck.main.length } cards — ${ countDetail })"
 msgstr[0] ""
-msgstr[1] ""
 
 #: src\commands\deck.ts:244
 msgid "Main Deck (continued)"
@@ -266,7 +262,6 @@ msgstr ""
 msgid "Extra Deck (${ deck.extra.length } card — ${ _countDetail })"
 msgid_plural "Extra Deck (${ deck.extra.length } cards — ${ _countDetail })"
 msgstr[0] ""
-msgstr[1] ""
 
 #: src\commands\deck.ts:258
 msgid "Extra Deck (continued)"
@@ -277,7 +272,6 @@ msgstr ""
 msgid "Side Deck (${ deck.side.length } card — ${ _countDetail2 })"
 msgid_plural "Side Deck (${ deck.side.length } cards — ${ _countDetail2 })"
 msgstr[0] ""
-msgstr[1] ""
 
 #: src\commands\deck.ts:272
 msgid "Side Deck (continued)"

--- a/translations/zh-TW.po
+++ b/translations/zh-TW.po
@@ -226,64 +226,64 @@ msgstr ""
 msgid "Could not find a Yugipedia page named `${ page }`."
 msgstr ""
 
-#: src\commands\deck.ts:153
+#: src\commands\deck.ts:198
 #, javascript-format
 msgid "${ counts.Monster } Monster"
 msgid_plural "${ counts.Monster } Monsters"
 msgstr[0] ""
 msgstr[1] ""
 
-#: src\commands\deck.ts:156
+#: src\commands\deck.ts:201
 msgid "${ counts.Spell } Spell"
 msgid_plural "${ counts.Spell } Spells"
 msgstr[0] ""
 msgstr[1] ""
 
-#: src\commands\deck.ts:159
+#: src\commands\deck.ts:204
 #, javascript-format
 msgid "${ counts.Trap } Trap"
 msgid_plural "${ counts.Trap } Traps"
 msgstr[0] ""
 msgstr[1] ""
 
-#: src\commands\deck.ts:187
+#: src\commands\deck.ts:232
 msgid "Your Deck"
 msgstr ""
 
-#: src\commands\deck.ts:192
+#: src\commands\deck.ts:237
 #, javascript-format
 msgid "Main Deck (${ deck.main.length } card — ${ countDetail })"
 msgid_plural "Main Deck (${ deck.main.length } cards — ${ countDetail })"
 msgstr[0] ""
 msgstr[1] ""
 
-#: src\commands\deck.ts:199
+#: src\commands\deck.ts:244
 msgid "Main Deck (continued)"
 msgstr ""
 
-#: src\commands\deck.ts:206
+#: src\commands\deck.ts:251
 #, javascript-format
 msgid "Extra Deck (${ deck.extra.length } card — ${ _countDetail })"
 msgid_plural "Extra Deck (${ deck.extra.length } cards — ${ _countDetail })"
 msgstr[0] ""
 msgstr[1] ""
 
-#: src\commands\deck.ts:213
+#: src\commands\deck.ts:258
 msgid "Extra Deck (continued)"
 msgstr ""
 
-#: src\commands\deck.ts:220
+#: src\commands\deck.ts:265
 #, javascript-format
 msgid "Side Deck (${ deck.side.length } card — ${ _countDetail2 })"
 msgid_plural "Side Deck (${ deck.side.length } cards — ${ _countDetail2 })"
 msgstr[0] ""
 msgstr[1] ""
 
-#: src\commands\deck.ts:227
+#: src\commands\deck.ts:272
 msgid "Side Deck (continued)"
 msgstr ""
 
-#: src\commands\deck.ts:285
+#: src\commands\deck.ts:331
 msgid "Error: Your deck is empty."
 msgstr ""
 
@@ -324,12 +324,16 @@ msgstr ""
 msgid "Revision: ${ process.env.BOT_REVISION }."
 msgstr ""
 
-#: src\commands\deck.ts:236
+#: src\commands\deck.ts:282
 msgid ".ydk files must have the .ydk extension!"
 msgstr ""
 
-#: src\commands\deck.ts:239
+#: src\commands\deck.ts:285
 msgid ".ydk files should not be larger than 1 KB!"
+msgstr ""
+
+#: src\commands\deck.ts:275
+msgid "ydke URL"
 msgstr ""
 
 #: src\card.ts:37
@@ -653,6 +657,32 @@ msgctxt "command-option"
 msgid "command"
 msgstr ""
 
+#: src\commands\deck.ts:74
+msgctxt "command-option"
+msgid "url"
+msgstr ""
+
+#: src\commands\deck.ts:80
+msgctxt "command-option"
+msgid "file"
+msgstr ""
+
+#: src\commands\deck.ts:86
+#: src\commands\deck.ts:92
+msgctxt "command-option"
+msgid "deck"
+msgstr ""
+
+#: src\commands\deck.ts:98
+msgctxt "command-option"
+msgid "public"
+msgstr ""
+
+#: src\commands\deck.ts:105
+msgctxt "command-option"
+msgid "stacked"
+msgstr ""
+
 #: src\locale.ts:50
 msgctxt "command-option-description"
 msgid "The output language for the card embed, overriding other settings."
@@ -683,6 +713,40 @@ msgctxt "command-option-description"
 msgid "The name of a specific Slash Command."
 msgstr ""
 
+#: src\commands\deck.ts:77
+msgctxt "command-option-description"
+msgid "View a deck by entering a ydke:// URL."
+msgstr ""
+
+#: src\commands\deck.ts:83
+msgctxt "command-option-description"
+msgid "View a deck by uploading a .ydk file."
+msgstr ""
+
+#: src\commands\deck.ts:89
+msgctxt "command-option-description"
+msgid "The ydke:// URL of the deck you want to view."
+msgstr ""
+
+#: src\commands\deck.ts:95
+msgctxt "command-option-description"
+msgid "The .ydk file of the deck you want to view."
+msgstr ""
+
+#: src\commands\deck.ts:101
+msgctxt "command-option-description"
+msgid ""
+"Whether to display the deck details publicly in chat. This is false by "
+"default."
+msgstr ""
+
+#: src\commands\deck.ts:108
+msgctxt "command-option-description"
+msgid ""
+"Whether to display the deck sections as one stacked column. This is false "
+"(side-by-side) by default."
+msgstr ""
+
 #: src\commands\art.ts:35
 msgctxt "command-name"
 msgid "art"
@@ -708,6 +772,11 @@ msgctxt "command-name"
 msgid "help"
 msgstr ""
 
+#: src\commands\deck.ts:67
+msgctxt "command-name"
+msgid "deck"
+msgstr ""
+
 #: src\commands\art.ts:36
 msgctxt "command-description"
 msgid "Display the art for a card!"
@@ -731,4 +800,11 @@ msgstr ""
 #: src\commands\help.ts:49
 msgctxt "command-description"
 msgid "Get help with a Slash Command."
+msgstr ""
+
+#: src\commands\deck.ts:70
+msgctxt "command-description"
+msgid ""
+"Display a deck list from ydke:// or .ydk format, exported from a number of "
+"deck building programs."
 msgstr ""

--- a/translations/zh-TW.po
+++ b/translations/zh-TW.po
@@ -226,58 +226,64 @@ msgstr ""
 msgid "Could not find a Yugipedia page named `${ page }`."
 msgstr ""
 
-#: src\commands\deck.ts:132
+#: src\commands\deck.ts:153
 #, javascript-format
 msgid "${ counts.Monster } Monster"
 msgid_plural "${ counts.Monster } Monsters"
 msgstr[0] ""
+msgstr[1] ""
 
-#: src\commands\deck.ts:135
+#: src\commands\deck.ts:156
 msgid "${ counts.Spell } Spell"
 msgid_plural "${ counts.Spell } Spells"
 msgstr[0] ""
+msgstr[1] ""
 
-#: src\commands\deck.ts:138
+#: src\commands\deck.ts:159
 #, javascript-format
 msgid "${ counts.Trap } Trap"
 msgid_plural "${ counts.Trap } Traps"
 msgstr[0] ""
+msgstr[1] ""
 
-#: src\commands\deck.ts:166
+#: src\commands\deck.ts:187
 msgid "Your Deck"
 msgstr ""
 
-#: src\commands\deck.ts:171
+#: src\commands\deck.ts:192
 #, javascript-format
 msgid "Main Deck (${ deck.main.length } card — ${ countDetail })"
 msgid_plural "Main Deck (${ deck.main.length } cards — ${ countDetail })"
 msgstr[0] ""
+msgstr[1] ""
 
-#: src\commands\deck.ts:178
+#: src\commands\deck.ts:199
 msgid "Main Deck (continued)"
 msgstr ""
 
-#: src\commands\deck.ts:185
+#: src\commands\deck.ts:206
 #, javascript-format
 msgid "Extra Deck (${ deck.extra.length } card — ${ _countDetail })"
 msgid_plural "Extra Deck (${ deck.extra.length } cards — ${ _countDetail })"
 msgstr[0] ""
+msgstr[1] ""
 
-#: src\commands\deck.ts:192
+#: src\commands\deck.ts:213
 msgid "Extra Deck (continued)"
 msgstr ""
 
-#: src\commands\deck.ts:199
+#: src\commands\deck.ts:220
 #, javascript-format
 msgid "Side Deck (${ deck.side.length } card — ${ _countDetail2 })"
 msgid_plural "Side Deck (${ deck.side.length } cards — ${ _countDetail2 })"
 msgstr[0] ""
+msgstr[1] ""
 
-#: src\commands\deck.ts:206
+#: src\commands\deck.ts:227
 msgid "Side Deck (continued)"
 msgstr ""
 
-#: src\commands\deck.ts:231
+#: src\commands\deck.ts:285
 msgid "Error: Your deck is empty."
 msgstr ""
 
@@ -316,6 +322,14 @@ msgstr ""
 #: src\events\message.ts:51
 #, javascript-format
 msgid "Revision: ${ process.env.BOT_REVISION }."
+msgstr ""
+
+#: src\commands\deck.ts:236
+msgid ".ydk files must have the .ydk extension!"
+msgstr ""
+
+#: src\commands\deck.ts:239
+msgid ".ydk files should not be larger than 1 KB!"
 msgstr ""
 
 #: src\card.ts:37
@@ -609,12 +623,12 @@ msgctxt "card-embed"
 msgid "Card Effect"
 msgstr "卡片效果"
 
-#: src\locale.ts:46
+#: src\locale.ts:47
 msgctxt "command-option"
 msgid "result-language"
 msgstr ""
 
-#: src\locale.ts:66
+#: src\locale.ts:67
 msgctxt "command-option"
 msgid "input-language"
 msgstr ""
@@ -639,12 +653,12 @@ msgctxt "command-option"
 msgid "command"
 msgstr ""
 
-#: src\locale.ts:49
+#: src\locale.ts:50
 msgctxt "command-option-description"
 msgid "The output language for the card embed, overriding other settings."
 msgstr ""
 
-#: src\locale.ts:69
+#: src\locale.ts:70
 msgctxt "command-option-description"
 msgid "The language to search in, defaulting to the result language."
 msgstr ""

--- a/yarn.lock
+++ b/yarn.lock
@@ -5333,6 +5333,13 @@ yargs@^17.3.1:
     y18n "^5.0.5"
     yargs-parser "^21.0.0"
 
+ydeck@^0.2.7:
+  version "0.2.7"
+  resolved "https://registry.yarnpkg.com/ydeck/-/ydeck-0.2.7.tgz#8a75e0042556570355188e50450c497f27742160"
+  integrity sha512-qxei1EGcadQe6qsXqVYu0dA9hmlrPuZwpxJUUAJN/5kHQVO91FCA3t9/gKx+ZRzmqfnTxZtAdCkL3nHpBAHjjg==
+  dependencies:
+    ydke "^1.1.0"
+
 ydke@^1.1.0:
   version "1.1.0"
   resolved "https://registry.yarnpkg.com/ydke/-/ydke-1.1.0.tgz#acfbe5fed8b82716c5280594f7f815eec34a9b1e"


### PR DESCRIPTION
# Features
- Add .ydk file support by splitting into subcommands
- Output ydke:// URL and .ydk file of the submitted deck
- The name and description for the command and its options have localisation support
- Closes #22 

# Notes
- I'm not sure what the process is for getting newly added text translated. This update adds new error messages, as well as the above-noted localisation support.
- Deck parsing is handled by the `ydeck` package, which has unlocalised and sometimes unclear error messages. More effort should be put in to intercept them and present them in a localised and user-friendly manner.
- Uploaded files are currently checked against guards for extension and file-size - these are based on Emcee's behaviour, but ultimately arbitrary, and we could choose to revise them before merging this PR. 