### PR TITLE
Prioritise YGOPRODECK URLs for card embeds

### DIFF
--- a/src/card.ts
+++ b/src/card.ts
@@ -251,10 +251,10 @@ export function createCardEmbed(card: Static<typeof CardSchema>, lang: Locale): 
 
 	const links = {
 		name: t`:link: Links`,
-		value: t`[Official Konami DB](${official}) | [OCG Rulings](${rulings}) | [YGOPRODECK](${ygoprodeck}) | [Yugipedia](${yugipedia})`
+		value: t`[Official Konami DB](${official}) | [OCG Rulings](${rulings}) | [Yugipedia](${yugipedia}) [YGOPRODECK](${ygoprodeck})`
 	};
 	if (card.konami_id === null) {
-		links.value = t`[YGOPRODECK](${ygoprodeck}) | [Yugipedia](${yugipedia})`;
+		links.value = t`[Yugipedia](${yugipedia}) | [YGOPRODECK](${ygoprodeck})`;
 	}
 
 	let description = "";

--- a/src/card.ts
+++ b/src/card.ts
@@ -251,7 +251,7 @@ export function createCardEmbed(card: Static<typeof CardSchema>, lang: Locale): 
 
 	const links = {
 		name: t`:link: Links`,
-		value: t`[Official Konami DB](${official}) | [OCG Rulings](${rulings}) | [Yugipedia](${yugipedia}) [YGOPRODECK](${ygoprodeck})`
+		value: t`[Official Konami DB](${official}) | [OCG Rulings](${rulings}) | [Yugipedia](${yugipedia}) | [YGOPRODECK](${ygoprodeck})`
 	};
 	if (card.konami_id === null) {
 		links.value = t`[Yugipedia](${yugipedia}) | [YGOPRODECK](${ygoprodeck})`;

--- a/src/card.ts
+++ b/src/card.ts
@@ -246,16 +246,15 @@ export function createCardEmbed(card: Static<typeof CardSchema>, lang: Locale): 
 
 	const embed = new EmbedBuilder()
 		.setTitle(formatCardName(card, lang))
-		// TODO: update when we start doing cards without Konami IDs
-		.setURL(yugipedia)
+		.setURL(ygoprodeck)
 		.setThumbnail(`${process.env.IMAGE_HOST}/${card.password}.png`);
 
 	const links = {
 		name: t`:link: Links`,
-		value: t`[Official Konami DB](${official}) | [OCG Rulings](${rulings}) | [Yugipedia](${yugipedia}) | [YGOPRODECK](${ygoprodeck})`
+		value: t`[Official Konami DB](${official}) | [OCG Rulings](${rulings}) | [YGOPRODECK](${ygoprodeck}) | [Yugipedia](${yugipedia})`
 	};
 	if (card.konami_id === null) {
-		links.value = t`[Yugipedia](${yugipedia}) | [YGOPRODECK](${ygoprodeck})`;
+		links.value = t`[YGOPRODECK](${ygoprodeck}) | [Yugipedia](${yugipedia})`;
 	}
 
 	let description = "";

--- a/translations/de.po
+++ b/translations/de.po
@@ -6,33 +6,33 @@ msgstr ""
 "MIME-Version: 1.0\n"
 "Content-Transfer-Encoding: 8bit\n"
 
-#: src\card.ts:254
+#: src\card.ts:253
 msgid ":link: Links"
 msgstr ""
 
-#: src\card.ts:255
+#: src\card.ts:254
 #, javascript-format
 msgid ""
 "[Official Konami DB](${ official }) | [OCG Rulings](${ rulings }) | "
 "[Yugipedia](${ yugipedia }) | [YGOPRODECK](${ ygoprodeck })"
 msgstr ""
 
-#: src\card.ts:258
+#: src\card.ts:257
 #, javascript-format
 msgid "[Yugipedia](${ yugipedia }) | [YGOPRODECK](${ ygoprodeck })"
 msgstr ""
 
-#: src\card.ts:318
+#: src\card.ts:317
 #, javascript-format
 msgid "**Type**: ${ RaceIcon[race] } ${ localizedMonsterTypeLine }"
 msgstr "**Typ**: ${ RaceIcon[race] } ${ localizedMonsterTypeLine }"
 
-#: src\card.ts:320
+#: src\card.ts:319
 #, javascript-format
 msgid "**Attribute**: ${ AttributeIcon[card.attribute] } ${ localizedAttribute }"
 msgstr "**Eigenschaft**: ${ AttributeIcon[card.attribute] } ${ localizedAttribute }"
 
-#: src\card.ts:324
+#: src\card.ts:323
 msgid ""
 "**Rank**: ${ Icon.Rank } ${ card.rank } **ATK**: ${ card.atk } **DEF**: ${ "
 "card.def }"
@@ -40,14 +40,14 @@ msgstr ""
 "**Rang**: ${ Icon.Rank } ${ card.rank } **ATK**: ${ card.atk } **DEF**: ${ "
 "card.def }"
 
-#: src\card.ts:327
+#: src\card.ts:326
 #, javascript-format
 msgid ""
 "**Link Rating**: ${ card.link_arrows.length } **ATK**: ${ card.atk } **Link "
 "Arrows**: ${ arrows }"
 msgstr ""
 
-#: src\card.ts:329
+#: src\card.ts:328
 #, javascript-format
 msgid ""
 "**Level**: ${ Icon.Level } ${ card.level } **ATK**: ${ card.atk } **DEF**: "
@@ -56,12 +56,12 @@ msgstr ""
 "**Stufe**: ${ Icon.Level } ${ card.level } **ATK**: ${ card.atk } **DEF**: "
 "${ card.def }"
 
-#: src\card.ts:336
+#: src\card.ts:335
 msgid "**Pendulum Scale**: ${ formattedScale }"
 msgstr "**Pendelbereich**: ${ formattedScale }"
 
-#: src\card.ts:356
-#: src\card.ts:374
+#: src\card.ts:355
+#: src\card.ts:373
 #, javascript-format
 msgid "Password: ${ card.password } | Konami ID #${ card.konami_id }"
 msgstr ""
@@ -122,7 +122,7 @@ msgid "Found what you were looking for? Consider supporting us!"
 msgstr ""
 
 #: src\commands\art.ts:97
-#: src\commands\price.ts:146
+#: src\commands\price.ts:148
 #: src\commands\search.ts:90
 #, javascript-format
 msgid "Could not find a card matching `${ input }`!"
@@ -271,7 +271,7 @@ msgid ""
 "setting is ${ interaction.locale }."
 msgstr ""
 
-#: src\commands\ping.ts:35
+#: src\commands\ping.ts:36
 #: src\events\message.ts:28
 #, javascript-format
 msgid "Average WebSocket ping (new instance): ${ ping } ms"
@@ -341,7 +341,7 @@ msgstr ""
 msgid "ydke URL"
 msgstr ""
 
-#: src\card.ts:292
+#: src\card.ts:291
 #. Forbidden/Limited Lists or Limit Regulations in the OCG
 msgid "**Limit**: ${ limitRegulationDisplay }"
 msgstr ""
@@ -359,22 +359,21 @@ msgid "CoolStuffInc"
 msgstr ""
 
 #: src\commands\price.ts:118
-#. note: this is about our database, not the user input. Could clarify.
-#. unsure where, how or if to localise this error. Will it even come up?
+#. TODO: future, determine localisation and relevance status of this error
 msgid "Sorry, I can't find the price for a card with no English name!"
 msgstr ""
 
-#: src\commands\price.ts:158
+#: src\commands\price.ts:159
 msgid "No market price"
 msgstr ""
 
-#: src\commands\price.ts:164
+#: src\commands\price.ts:167
 #, javascript-format
-msgid "Prices for ${ card.name[resultLanguage] }"
+msgid "Prices for ${ card.name[resultLanguage] } - ${ vendorName }"
 msgstr ""
 
-#: src\commands\price.ts:172
-msgid "Could not find prices for `${ _name }`!"
+#: src\commands\price.ts:181
+msgid "Could not find prices for `${ name }`!"
 msgstr ""
 
 #: src\card.ts:37
@@ -652,18 +651,18 @@ msgctxt "attribute"
 msgid "DIVINE"
 msgstr "GÖTTLICH"
 
-#: src\card.ts:342
-#: src\card.ts:353
+#: src\card.ts:341
+#: src\card.ts:352
 msgctxt "card-embed"
 msgid "Card Text"
 msgstr "Kartentext"
 
-#: src\card.ts:347
+#: src\card.ts:346
 msgctxt "card-embed"
 msgid "Pendulum Effect"
 msgstr "Pendeleffekt"
 
-#: src\card.ts:369
+#: src\card.ts:368
 msgctxt "card-embed"
 msgid "Card Effect"
 msgstr ""
@@ -691,7 +690,7 @@ msgctxt "command-option"
 msgid "input"
 msgstr ""
 
-#: src\commands\help.ts:51
+#: src\commands\help.ts:52
 msgctxt "command-option"
 msgid "command"
 msgstr ""
@@ -788,7 +787,7 @@ msgctxt "command-option-description"
 msgid "The language to search in, defaulting to the result language."
 msgstr ""
 
-#: src\commands\help.ts:54
+#: src\commands\help.ts:55
 msgctxt "command-option-description"
 msgid "The name of a specific Slash Command."
 msgstr ""
@@ -933,12 +932,12 @@ msgctxt "command-name"
 msgid "art"
 msgstr ""
 
-#: src\commands\help.ts:48
+#: src\commands\help.ts:49
 msgctxt "command-name"
 msgid "help"
 msgstr ""
 
-#: src\commands\ping.ts:22
+#: src\commands\ping.ts:23
 msgctxt "command-name"
 msgid "ping"
 msgstr ""
@@ -983,12 +982,12 @@ msgctxt "command-description"
 msgid "Display the art for a card!"
 msgstr ""
 
-#: src\commands\help.ts:49
+#: src\commands\help.ts:50
 msgctxt "command-description"
 msgid "Get help with a Slash Command."
 msgstr ""
 
-#: src\commands\ping.ts:23
+#: src\commands\ping.ts:24
 msgctxt "command-description"
 msgid "Test latency to the new bot instance."
 msgstr ""

--- a/translations/es.po
+++ b/translations/es.po
@@ -6,33 +6,33 @@ msgstr ""
 "MIME-Version: 1.0\n"
 "Content-Transfer-Encoding: 8bit\n"
 
-#: src\card.ts:254
+#: src\card.ts:253
 msgid ":link: Links"
 msgstr ""
 
-#: src\card.ts:255
+#: src\card.ts:254
 #, javascript-format
 msgid ""
 "[Official Konami DB](${ official }) | [OCG Rulings](${ rulings }) | "
 "[Yugipedia](${ yugipedia }) | [YGOPRODECK](${ ygoprodeck })"
 msgstr ""
 
-#: src\card.ts:258
+#: src\card.ts:257
 #, javascript-format
 msgid "[Yugipedia](${ yugipedia }) | [YGOPRODECK](${ ygoprodeck })"
 msgstr ""
 
-#: src\card.ts:318
+#: src\card.ts:317
 #, javascript-format
 msgid "**Type**: ${ RaceIcon[race] } ${ localizedMonsterTypeLine }"
 msgstr "**Tipo**: ${ RaceIcon[race] } ${ localizedMonsterTypeLine }"
 
-#: src\card.ts:320
+#: src\card.ts:319
 #, javascript-format
 msgid "**Attribute**: ${ AttributeIcon[card.attribute] } ${ localizedAttribute }"
 msgstr "**Atributo**: ${ AttributeIcon[card.attribute] } ${ localizedAttribute }"
 
-#: src\card.ts:324
+#: src\card.ts:323
 msgid ""
 "**Rank**: ${ Icon.Rank } ${ card.rank } **ATK**: ${ card.atk } **DEF**: ${ "
 "card.def }"
@@ -40,14 +40,14 @@ msgstr ""
 "**Rango**: ${ Icon.Rank } ${ card.rank } **ATK**: ${ card.atk } **DEF**: ${ "
 "card.def }"
 
-#: src\card.ts:327
+#: src\card.ts:326
 #, javascript-format
 msgid ""
 "**Link Rating**: ${ card.link_arrows.length } **ATK**: ${ card.atk } **Link "
 "Arrows**: ${ arrows }"
 msgstr ""
 
-#: src\card.ts:329
+#: src\card.ts:328
 #, javascript-format
 msgid ""
 "**Level**: ${ Icon.Level } ${ card.level } **ATK**: ${ card.atk } **DEF**: "
@@ -56,12 +56,12 @@ msgstr ""
 "**Nivel**: ${ Icon.Level } ${ card.level } **ATK**: ${ card.atk } **DEF**: "
 "${ card.def }"
 
-#: src\card.ts:336
+#: src\card.ts:335
 msgid "**Pendulum Scale**: ${ formattedScale }"
 msgstr "**Escala de Péndulo**: ${ formattedScale }"
 
-#: src\card.ts:356
-#: src\card.ts:374
+#: src\card.ts:355
+#: src\card.ts:373
 #, javascript-format
 msgid "Password: ${ card.password } | Konami ID #${ card.konami_id }"
 msgstr ""
@@ -122,7 +122,7 @@ msgid "Found what you were looking for? Consider supporting us!"
 msgstr ""
 
 #: src\commands\art.ts:97
-#: src\commands\price.ts:146
+#: src\commands\price.ts:148
 #: src\commands\search.ts:90
 #, javascript-format
 msgid "Could not find a card matching `${ input }`!"
@@ -271,7 +271,7 @@ msgid ""
 "setting is ${ interaction.locale }."
 msgstr ""
 
-#: src\commands\ping.ts:35
+#: src\commands\ping.ts:36
 #: src\events\message.ts:28
 #, javascript-format
 msgid "Average WebSocket ping (new instance): ${ ping } ms"
@@ -341,7 +341,7 @@ msgstr ""
 msgid "ydke URL"
 msgstr ""
 
-#: src\card.ts:292
+#: src\card.ts:291
 #. Forbidden/Limited Lists or Limit Regulations in the OCG
 msgid "**Limit**: ${ limitRegulationDisplay }"
 msgstr ""
@@ -359,22 +359,21 @@ msgid "CoolStuffInc"
 msgstr ""
 
 #: src\commands\price.ts:118
-#. note: this is about our database, not the user input. Could clarify.
-#. unsure where, how or if to localise this error. Will it even come up?
+#. TODO: future, determine localisation and relevance status of this error
 msgid "Sorry, I can't find the price for a card with no English name!"
 msgstr ""
 
-#: src\commands\price.ts:158
+#: src\commands\price.ts:159
 msgid "No market price"
 msgstr ""
 
-#: src\commands\price.ts:164
+#: src\commands\price.ts:167
 #, javascript-format
-msgid "Prices for ${ card.name[resultLanguage] }"
+msgid "Prices for ${ card.name[resultLanguage] } - ${ vendorName }"
 msgstr ""
 
-#: src\commands\price.ts:172
-msgid "Could not find prices for `${ _name }`!"
+#: src\commands\price.ts:181
+msgid "Could not find prices for `${ name }`!"
 msgstr ""
 
 #: src\card.ts:37
@@ -652,18 +651,18 @@ msgctxt "attribute"
 msgid "DIVINE"
 msgstr "DIVINIDAD"
 
-#: src\card.ts:342
-#: src\card.ts:353
+#: src\card.ts:341
+#: src\card.ts:352
 msgctxt "card-embed"
 msgid "Card Text"
 msgstr "Texto de carta"
 
-#: src\card.ts:347
+#: src\card.ts:346
 msgctxt "card-embed"
 msgid "Pendulum Effect"
 msgstr "Efecto de Péndulo"
 
-#: src\card.ts:369
+#: src\card.ts:368
 msgctxt "card-embed"
 msgid "Card Effect"
 msgstr ""
@@ -691,7 +690,7 @@ msgctxt "command-option"
 msgid "input"
 msgstr ""
 
-#: src\commands\help.ts:51
+#: src\commands\help.ts:52
 msgctxt "command-option"
 msgid "command"
 msgstr ""
@@ -788,7 +787,7 @@ msgctxt "command-option-description"
 msgid "The language to search in, defaulting to the result language."
 msgstr ""
 
-#: src\commands\help.ts:54
+#: src\commands\help.ts:55
 msgctxt "command-option-description"
 msgid "The name of a specific Slash Command."
 msgstr ""
@@ -933,12 +932,12 @@ msgctxt "command-name"
 msgid "art"
 msgstr ""
 
-#: src\commands\help.ts:48
+#: src\commands\help.ts:49
 msgctxt "command-name"
 msgid "help"
 msgstr ""
 
-#: src\commands\ping.ts:22
+#: src\commands\ping.ts:23
 msgctxt "command-name"
 msgid "ping"
 msgstr ""
@@ -983,12 +982,12 @@ msgctxt "command-description"
 msgid "Display the art for a card!"
 msgstr ""
 
-#: src\commands\help.ts:49
+#: src\commands\help.ts:50
 msgctxt "command-description"
 msgid "Get help with a Slash Command."
 msgstr ""
 
-#: src\commands\ping.ts:23
+#: src\commands\ping.ts:24
 msgctxt "command-description"
 msgid "Test latency to the new bot instance."
 msgstr ""

--- a/translations/fr.po
+++ b/translations/fr.po
@@ -6,33 +6,33 @@ msgstr ""
 "MIME-Version: 1.0\n"
 "Content-Transfer-Encoding: 8bit\n"
 
-#: src\card.ts:254
+#: src\card.ts:253
 msgid ":link: Links"
 msgstr ""
 
-#: src\card.ts:255
+#: src\card.ts:254
 #, javascript-format
 msgid ""
 "[Official Konami DB](${ official }) | [OCG Rulings](${ rulings }) | "
 "[Yugipedia](${ yugipedia }) | [YGOPRODECK](${ ygoprodeck })"
 msgstr ""
 
-#: src\card.ts:258
+#: src\card.ts:257
 #, javascript-format
 msgid "[Yugipedia](${ yugipedia }) | [YGOPRODECK](${ ygoprodeck })"
 msgstr ""
 
-#: src\card.ts:318
+#: src\card.ts:317
 #, javascript-format
 msgid "**Type**: ${ RaceIcon[race] } ${ localizedMonsterTypeLine }"
 msgstr "**Type**: ${ RaceIcon[race] } ${ localizedMonsterTypeLine }"
 
-#: src\card.ts:320
+#: src\card.ts:319
 #, javascript-format
 msgid "**Attribute**: ${ AttributeIcon[card.attribute] } ${ localizedAttribute }"
 msgstr "**Attribut**: ${ AttributeIcon[card.attribute] } ${ localizedAttribute }"
 
-#: src\card.ts:324
+#: src\card.ts:323
 msgid ""
 "**Rank**: ${ Icon.Rank } ${ card.rank } **ATK**: ${ card.atk } **DEF**: ${ "
 "card.def }"
@@ -40,14 +40,14 @@ msgstr ""
 "**Rang**: ${ Icon.Rank } ${ card.rank } **ATK**: ${ card.atk } **DEF**: ${ "
 "card.def }"
 
-#: src\card.ts:327
+#: src\card.ts:326
 #, javascript-format
 msgid ""
 "**Link Rating**: ${ card.link_arrows.length } **ATK**: ${ card.atk } **Link "
 "Arrows**: ${ arrows }"
 msgstr ""
 
-#: src\card.ts:329
+#: src\card.ts:328
 #, javascript-format
 msgid ""
 "**Level**: ${ Icon.Level } ${ card.level } **ATK**: ${ card.atk } **DEF**: "
@@ -56,12 +56,12 @@ msgstr ""
 "**Niveau**: ${ Icon.Level } ${ card.level } **ATK**: ${ card.atk } **DEF**: "
 "${ card.def }"
 
-#: src\card.ts:336
+#: src\card.ts:335
 msgid "**Pendulum Scale**: ${ formattedScale }"
 msgstr "**Échelle Pendule**: ${ formattedScale }"
 
-#: src\card.ts:356
-#: src\card.ts:374
+#: src\card.ts:355
+#: src\card.ts:373
 #, javascript-format
 msgid "Password: ${ card.password } | Konami ID #${ card.konami_id }"
 msgstr ""
@@ -122,7 +122,7 @@ msgid "Found what you were looking for? Consider supporting us!"
 msgstr ""
 
 #: src\commands\art.ts:97
-#: src\commands\price.ts:146
+#: src\commands\price.ts:148
 #: src\commands\search.ts:90
 #, javascript-format
 msgid "Could not find a card matching `${ input }`!"
@@ -271,7 +271,7 @@ msgid ""
 "setting is ${ interaction.locale }."
 msgstr ""
 
-#: src\commands\ping.ts:35
+#: src\commands\ping.ts:36
 #: src\events\message.ts:28
 #, javascript-format
 msgid "Average WebSocket ping (new instance): ${ ping } ms"
@@ -341,7 +341,7 @@ msgstr ""
 msgid "ydke URL"
 msgstr ""
 
-#: src\card.ts:292
+#: src\card.ts:291
 #. Forbidden/Limited Lists or Limit Regulations in the OCG
 msgid "**Limit**: ${ limitRegulationDisplay }"
 msgstr ""
@@ -359,22 +359,21 @@ msgid "CoolStuffInc"
 msgstr ""
 
 #: src\commands\price.ts:118
-#. note: this is about our database, not the user input. Could clarify.
-#. unsure where, how or if to localise this error. Will it even come up?
+#. TODO: future, determine localisation and relevance status of this error
 msgid "Sorry, I can't find the price for a card with no English name!"
 msgstr ""
 
-#: src\commands\price.ts:158
+#: src\commands\price.ts:159
 msgid "No market price"
 msgstr ""
 
-#: src\commands\price.ts:164
+#: src\commands\price.ts:167
 #, javascript-format
-msgid "Prices for ${ card.name[resultLanguage] }"
+msgid "Prices for ${ card.name[resultLanguage] } - ${ vendorName }"
 msgstr ""
 
-#: src\commands\price.ts:172
-msgid "Could not find prices for `${ _name }`!"
+#: src\commands\price.ts:181
+msgid "Could not find prices for `${ name }`!"
 msgstr ""
 
 #: src\card.ts:37
@@ -652,18 +651,18 @@ msgctxt "attribute"
 msgid "DIVINE"
 msgstr "DIVIN"
 
-#: src\card.ts:342
-#: src\card.ts:353
+#: src\card.ts:341
+#: src\card.ts:352
 msgctxt "card-embed"
 msgid "Card Text"
 msgstr "Texte de carte"
 
-#: src\card.ts:347
+#: src\card.ts:346
 msgctxt "card-embed"
 msgid "Pendulum Effect"
 msgstr "Effet Pendule"
 
-#: src\card.ts:369
+#: src\card.ts:368
 msgctxt "card-embed"
 msgid "Card Effect"
 msgstr ""
@@ -691,7 +690,7 @@ msgctxt "command-option"
 msgid "input"
 msgstr ""
 
-#: src\commands\help.ts:51
+#: src\commands\help.ts:52
 msgctxt "command-option"
 msgid "command"
 msgstr ""
@@ -788,7 +787,7 @@ msgctxt "command-option-description"
 msgid "The language to search in, defaulting to the result language."
 msgstr ""
 
-#: src\commands\help.ts:54
+#: src\commands\help.ts:55
 msgctxt "command-option-description"
 msgid "The name of a specific Slash Command."
 msgstr ""
@@ -933,12 +932,12 @@ msgctxt "command-name"
 msgid "art"
 msgstr ""
 
-#: src\commands\help.ts:48
+#: src\commands\help.ts:49
 msgctxt "command-name"
 msgid "help"
 msgstr ""
 
-#: src\commands\ping.ts:22
+#: src\commands\ping.ts:23
 msgctxt "command-name"
 msgid "ping"
 msgstr ""
@@ -983,12 +982,12 @@ msgctxt "command-description"
 msgid "Display the art for a card!"
 msgstr ""
 
-#: src\commands\help.ts:49
+#: src\commands\help.ts:50
 msgctxt "command-description"
 msgid "Get help with a Slash Command."
 msgstr ""
 
-#: src\commands\ping.ts:23
+#: src\commands\ping.ts:24
 msgctxt "command-description"
 msgid "Test latency to the new bot instance."
 msgstr ""

--- a/translations/it.po
+++ b/translations/it.po
@@ -6,33 +6,33 @@ msgstr ""
 "MIME-Version: 1.0\n"
 "Content-Transfer-Encoding: 8bit\n"
 
-#: src\card.ts:254
+#: src\card.ts:253
 msgid ":link: Links"
 msgstr ""
 
-#: src\card.ts:255
+#: src\card.ts:254
 #, javascript-format
 msgid ""
 "[Official Konami DB](${ official }) | [OCG Rulings](${ rulings }) | "
 "[Yugipedia](${ yugipedia }) | [YGOPRODECK](${ ygoprodeck })"
 msgstr ""
 
-#: src\card.ts:258
+#: src\card.ts:257
 #, javascript-format
 msgid "[Yugipedia](${ yugipedia }) | [YGOPRODECK](${ ygoprodeck })"
 msgstr ""
 
-#: src\card.ts:318
+#: src\card.ts:317
 #, javascript-format
 msgid "**Type**: ${ RaceIcon[race] } ${ localizedMonsterTypeLine }"
 msgstr "**Tipo**: ${ RaceIcon[race] } ${ localizedMonsterTypeLine }"
 
-#: src\card.ts:320
+#: src\card.ts:319
 #, javascript-format
 msgid "**Attribute**: ${ AttributeIcon[card.attribute] } ${ localizedAttribute }"
 msgstr "**Attributo**: ${ AttributeIcon[card.attribute] } ${ localizedAttribute }"
 
-#: src\card.ts:324
+#: src\card.ts:323
 msgid ""
 "**Rank**: ${ Icon.Rank } ${ card.rank } **ATK**: ${ card.atk } **DEF**: ${ "
 "card.def }"
@@ -40,14 +40,14 @@ msgstr ""
 "**Rango**: ${ Icon.Rank } ${ card.rank } **ATK**: ${ card.atk } **DEF**: ${ "
 "card.def }"
 
-#: src\card.ts:327
+#: src\card.ts:326
 #, javascript-format
 msgid ""
 "**Link Rating**: ${ card.link_arrows.length } **ATK**: ${ card.atk } **Link "
 "Arrows**: ${ arrows }"
 msgstr ""
 
-#: src\card.ts:329
+#: src\card.ts:328
 #, javascript-format
 msgid ""
 "**Level**: ${ Icon.Level } ${ card.level } **ATK**: ${ card.atk } **DEF**: "
@@ -56,12 +56,12 @@ msgstr ""
 "Livello**: ${ Icon.Level } ${ card.level } **ATK**: ${ card.atk } **DEF**: "
 "${ card.def }"
 
-#: src\card.ts:336
+#: src\card.ts:335
 msgid "**Pendulum Scale**: ${ formattedScale }"
 msgstr "**Valore Pendulum**: ${ formattedScale }"
 
-#: src\card.ts:356
-#: src\card.ts:374
+#: src\card.ts:355
+#: src\card.ts:373
 #, javascript-format
 msgid "Password: ${ card.password } | Konami ID #${ card.konami_id }"
 msgstr ""
@@ -122,7 +122,7 @@ msgid "Found what you were looking for? Consider supporting us!"
 msgstr ""
 
 #: src\commands\art.ts:97
-#: src\commands\price.ts:146
+#: src\commands\price.ts:148
 #: src\commands\search.ts:90
 #, javascript-format
 msgid "Could not find a card matching `${ input }`!"
@@ -271,7 +271,7 @@ msgid ""
 "setting is ${ interaction.locale }."
 msgstr ""
 
-#: src\commands\ping.ts:35
+#: src\commands\ping.ts:36
 #: src\events\message.ts:28
 #, javascript-format
 msgid "Average WebSocket ping (new instance): ${ ping } ms"
@@ -341,7 +341,7 @@ msgstr ""
 msgid "ydke URL"
 msgstr ""
 
-#: src\card.ts:292
+#: src\card.ts:291
 #. Forbidden/Limited Lists or Limit Regulations in the OCG
 msgid "**Limit**: ${ limitRegulationDisplay }"
 msgstr ""
@@ -359,22 +359,21 @@ msgid "CoolStuffInc"
 msgstr ""
 
 #: src\commands\price.ts:118
-#. note: this is about our database, not the user input. Could clarify.
-#. unsure where, how or if to localise this error. Will it even come up?
+#. TODO: future, determine localisation and relevance status of this error
 msgid "Sorry, I can't find the price for a card with no English name!"
 msgstr ""
 
-#: src\commands\price.ts:158
+#: src\commands\price.ts:159
 msgid "No market price"
 msgstr ""
 
-#: src\commands\price.ts:164
+#: src\commands\price.ts:167
 #, javascript-format
-msgid "Prices for ${ card.name[resultLanguage] }"
+msgid "Prices for ${ card.name[resultLanguage] } - ${ vendorName }"
 msgstr ""
 
-#: src\commands\price.ts:172
-msgid "Could not find prices for `${ _name }`!"
+#: src\commands\price.ts:181
+msgid "Could not find prices for `${ name }`!"
 msgstr ""
 
 #: src\card.ts:37
@@ -652,18 +651,18 @@ msgctxt "attribute"
 msgid "DIVINE"
 msgstr "DIVINO"
 
-#: src\card.ts:342
-#: src\card.ts:353
+#: src\card.ts:341
+#: src\card.ts:352
 msgctxt "card-embed"
 msgid "Card Text"
 msgstr "Testo carta"
 
-#: src\card.ts:347
+#: src\card.ts:346
 msgctxt "card-embed"
 msgid "Pendulum Effect"
 msgstr "Effetto Pendulum"
 
-#: src\card.ts:369
+#: src\card.ts:368
 msgctxt "card-embed"
 msgid "Card Effect"
 msgstr ""
@@ -691,7 +690,7 @@ msgctxt "command-option"
 msgid "input"
 msgstr ""
 
-#: src\commands\help.ts:51
+#: src\commands\help.ts:52
 msgctxt "command-option"
 msgid "command"
 msgstr ""
@@ -788,7 +787,7 @@ msgctxt "command-option-description"
 msgid "The language to search in, defaulting to the result language."
 msgstr ""
 
-#: src\commands\help.ts:54
+#: src\commands\help.ts:55
 msgctxt "command-option-description"
 msgid "The name of a specific Slash Command."
 msgstr ""
@@ -933,12 +932,12 @@ msgctxt "command-name"
 msgid "art"
 msgstr ""
 
-#: src\commands\help.ts:48
+#: src\commands\help.ts:49
 msgctxt "command-name"
 msgid "help"
 msgstr ""
 
-#: src\commands\ping.ts:22
+#: src\commands\ping.ts:23
 msgctxt "command-name"
 msgid "ping"
 msgstr ""
@@ -983,12 +982,12 @@ msgctxt "command-description"
 msgid "Display the art for a card!"
 msgstr ""
 
-#: src\commands\help.ts:49
+#: src\commands\help.ts:50
 msgctxt "command-description"
 msgid "Get help with a Slash Command."
 msgstr ""
 
-#: src\commands\ping.ts:23
+#: src\commands\ping.ts:24
 msgctxt "command-description"
 msgid "Test latency to the new bot instance."
 msgstr ""

--- a/translations/ja.po
+++ b/translations/ja.po
@@ -6,33 +6,33 @@ msgstr ""
 "MIME-Version: 1.0\n"
 "Content-Transfer-Encoding: 8bit\n"
 
-#: src\card.ts:254
+#: src\card.ts:253
 msgid ":link: Links"
 msgstr ""
 
-#: src\card.ts:255
+#: src\card.ts:254
 #, javascript-format
 msgid ""
 "[Official Konami DB](${ official }) | [OCG Rulings](${ rulings }) | "
 "[Yugipedia](${ yugipedia }) | [YGOPRODECK](${ ygoprodeck })"
 msgstr ""
 
-#: src\card.ts:258
+#: src\card.ts:257
 #, javascript-format
 msgid "[Yugipedia](${ yugipedia }) | [YGOPRODECK](${ ygoprodeck })"
 msgstr ""
 
-#: src\card.ts:318
+#: src\card.ts:317
 #, javascript-format
 msgid "**Type**: ${ RaceIcon[race] } ${ localizedMonsterTypeLine }"
 msgstr "**種族**: ${ RaceIcon[race] } ${ localizedMonsterTypeLine }"
 
-#: src\card.ts:320
+#: src\card.ts:319
 #, javascript-format
 msgid "**Attribute**: ${ AttributeIcon[card.attribute] } ${ localizedAttribute }"
 msgstr "**属性**: ${ AttributeIcon[card.attribute] } ${ localizedAttribute }"
 
-#: src\card.ts:324
+#: src\card.ts:323
 msgid ""
 "**Rank**: ${ Icon.Rank } ${ card.rank } **ATK**: ${ card.atk } **DEF**: ${ "
 "card.def }"
@@ -40,7 +40,7 @@ msgstr ""
 "**ランク**: ${ Icon.Rank } ${ card.rank } **攻撃力**: ${ card.atk } **守備力**: ${ "
 "card.def }"
 
-#: src\card.ts:327
+#: src\card.ts:326
 #, javascript-format
 msgid ""
 "**Link Rating**: ${ card.link_arrows.length } **ATK**: ${ card.atk } **Link "
@@ -49,7 +49,7 @@ msgstr ""
 "**リンクの数字分**: ${ card.link_arrows.length } **攻撃力**: ${ card.atk } "
 "**リンクマーカー**: ${ arrows }"
 
-#: src\card.ts:329
+#: src\card.ts:328
 #, javascript-format
 msgid ""
 "**Level**: ${ Icon.Level } ${ card.level } **ATK**: ${ card.atk } **DEF**: "
@@ -58,12 +58,12 @@ msgstr ""
 "**レベル**: ${ Icon.Level } ${ card.level } **攻撃力**: ${ card.atk } **守備力**: ${ "
 "card.def }"
 
-#: src\card.ts:336
+#: src\card.ts:335
 msgid "**Pendulum Scale**: ${ formattedScale }"
 msgstr "**ペンデュラムスケール**: ${ formattedScale }"
 
-#: src\card.ts:356
-#: src\card.ts:374
+#: src\card.ts:355
+#: src\card.ts:373
 #, javascript-format
 msgid "Password: ${ card.password } | Konami ID #${ card.konami_id }"
 msgstr ""
@@ -124,7 +124,7 @@ msgid "Found what you were looking for? Consider supporting us!"
 msgstr ""
 
 #: src\commands\art.ts:97
-#: src\commands\price.ts:146
+#: src\commands\price.ts:148
 #: src\commands\search.ts:90
 #, javascript-format
 msgid "Could not find a card matching `${ input }`!"
@@ -267,7 +267,7 @@ msgid ""
 "setting is ${ interaction.locale }."
 msgstr ""
 
-#: src\commands\ping.ts:35
+#: src\commands\ping.ts:36
 #: src\events\message.ts:28
 #, javascript-format
 msgid "Average WebSocket ping (new instance): ${ ping } ms"
@@ -337,7 +337,7 @@ msgstr ""
 msgid "ydke URL"
 msgstr ""
 
-#: src\card.ts:292
+#: src\card.ts:291
 #. Forbidden/Limited Lists or Limit Regulations in the OCG
 msgid "**Limit**: ${ limitRegulationDisplay }"
 msgstr ""
@@ -355,22 +355,21 @@ msgid "CoolStuffInc"
 msgstr ""
 
 #: src\commands\price.ts:118
-#. note: this is about our database, not the user input. Could clarify.
-#. unsure where, how or if to localise this error. Will it even come up?
+#. TODO: future, determine localisation and relevance status of this error
 msgid "Sorry, I can't find the price for a card with no English name!"
 msgstr ""
 
-#: src\commands\price.ts:158
+#: src\commands\price.ts:159
 msgid "No market price"
 msgstr ""
 
-#: src\commands\price.ts:164
+#: src\commands\price.ts:167
 #, javascript-format
-msgid "Prices for ${ card.name[resultLanguage] }"
+msgid "Prices for ${ card.name[resultLanguage] } - ${ vendorName }"
 msgstr ""
 
-#: src\commands\price.ts:172
-msgid "Could not find prices for `${ _name }`!"
+#: src\commands\price.ts:181
+msgid "Could not find prices for `${ name }`!"
 msgstr ""
 
 #: src\card.ts:37
@@ -648,18 +647,18 @@ msgctxt "attribute"
 msgid "DIVINE"
 msgstr "神"
 
-#: src\card.ts:342
-#: src\card.ts:353
+#: src\card.ts:341
+#: src\card.ts:352
 msgctxt "card-embed"
 msgid "Card Text"
 msgstr "カードテキスト"
 
-#: src\card.ts:347
+#: src\card.ts:346
 msgctxt "card-embed"
 msgid "Pendulum Effect"
 msgstr "ペンデュラム効果"
 
-#: src\card.ts:369
+#: src\card.ts:368
 msgctxt "card-embed"
 msgid "Card Effect"
 msgstr ""
@@ -687,7 +686,7 @@ msgctxt "command-option"
 msgid "input"
 msgstr ""
 
-#: src\commands\help.ts:51
+#: src\commands\help.ts:52
 msgctxt "command-option"
 msgid "command"
 msgstr ""
@@ -784,7 +783,7 @@ msgctxt "command-option-description"
 msgid "The language to search in, defaulting to the result language."
 msgstr ""
 
-#: src\commands\help.ts:54
+#: src\commands\help.ts:55
 msgctxt "command-option-description"
 msgid "The name of a specific Slash Command."
 msgstr ""
@@ -929,12 +928,12 @@ msgctxt "command-name"
 msgid "art"
 msgstr ""
 
-#: src\commands\help.ts:48
+#: src\commands\help.ts:49
 msgctxt "command-name"
 msgid "help"
 msgstr ""
 
-#: src\commands\ping.ts:22
+#: src\commands\ping.ts:23
 msgctxt "command-name"
 msgid "ping"
 msgstr ""
@@ -979,12 +978,12 @@ msgctxt "command-description"
 msgid "Display the art for a card!"
 msgstr ""
 
-#: src\commands\help.ts:49
+#: src\commands\help.ts:50
 msgctxt "command-description"
 msgid "Get help with a Slash Command."
 msgstr ""
 
-#: src\commands\ping.ts:23
+#: src\commands\ping.ts:24
 msgctxt "command-description"
 msgid "Test latency to the new bot instance."
 msgstr ""

--- a/translations/ko.po
+++ b/translations/ko.po
@@ -6,11 +6,11 @@ msgstr ""
 "MIME-Version: 1.0\n"
 "Content-Transfer-Encoding: 8bit\n"
 
-#: src\card.ts:254
+#: src\card.ts:253
 msgid ":link: Links"
 msgstr ":link: 링크"
 
-#: src\card.ts:255
+#: src\card.ts:254
 #, javascript-format
 msgid ""
 "[Official Konami DB](${ official }) | [OCG Rulings](${ rulings }) | "
@@ -19,22 +19,22 @@ msgstr ""
 "[공식 코나미 DB](${ official }) | [OCG 규칙](${ rulings }) | [Yugipedia](${ "
 "yugipedia }) | [YGOPRODECK](${ ygoprodeck })"
 
-#: src\card.ts:258
+#: src\card.ts:257
 #, javascript-format
 msgid "[Yugipedia](${ yugipedia }) | [YGOPRODECK](${ ygoprodeck })"
 msgstr "[Yugipedia](${ yugipedia }) | [YGOPRODECK](${ ygoprodeck })"
 
-#: src\card.ts:318
+#: src\card.ts:317
 #, javascript-format
 msgid "**Type**: ${ RaceIcon[race] } ${ localizedMonsterTypeLine }"
 msgstr "**종족**: ${ RaceIcon[race] } ${ localizedMonsterTypeLine }"
 
-#: src\card.ts:320
+#: src\card.ts:319
 #, javascript-format
 msgid "**Attribute**: ${ AttributeIcon[card.attribute] } ${ localizedAttribute }"
 msgstr "**속성**: ${ AttributeIcon[card.attribute] } ${ localizedAttribute }"
 
-#: src\card.ts:324
+#: src\card.ts:323
 msgid ""
 "**Rank**: ${ Icon.Rank } ${ card.rank } **ATK**: ${ card.atk } **DEF**: ${ "
 "card.def }"
@@ -42,7 +42,7 @@ msgstr ""
 "**랭크**: ${ Icon.Rank } ${ card.rank } **공격력**: ${ card.atk } **수비력**: ${ "
 "card.def }"
 
-#: src\card.ts:327
+#: src\card.ts:326
 #, javascript-format
 msgid ""
 "**Link Rating**: ${ card.link_arrows.length } **ATK**: ${ card.atk } **Link "
@@ -51,7 +51,7 @@ msgstr ""
 "**LINK**: ${ card.link_arrows.length } **공격력**: ${ card.atk } **링크 마커**: ${ "
 "arrows }"
 
-#: src\card.ts:329
+#: src\card.ts:328
 #, javascript-format
 msgid ""
 "**Level**: ${ Icon.Level } ${ card.level } **ATK**: ${ card.atk } **DEF**: "
@@ -60,12 +60,12 @@ msgstr ""
 "**레벨**: ${ Icon.Level } ${ card.level } **공격력**: ${ card.atk } **수비력**: ${ "
 "card.def }"
 
-#: src\card.ts:336
+#: src\card.ts:335
 msgid "**Pendulum Scale**: ${ formattedScale }"
 msgstr "**펜듈럼 스케일**: ${ formattedScale }"
 
-#: src\card.ts:356
-#: src\card.ts:374
+#: src\card.ts:355
+#: src\card.ts:373
 #, javascript-format
 msgid "Password: ${ card.password } | Konami ID #${ card.konami_id }"
 msgstr "패스워드: ${ card.password } | 코나미 ID #${ card.konami_id }"
@@ -128,7 +128,7 @@ msgid "Found what you were looking for? Consider supporting us!"
 msgstr "찾으시려던 것을 찾으셨나요? 저희를 지원해 주시는 건 어떤가요?"
 
 #: src\commands\art.ts:97
-#: src\commands\price.ts:146
+#: src\commands\price.ts:148
 #: src\commands\search.ts:90
 #, javascript-format
 msgid "Could not find a card matching `${ input }`!"
@@ -224,7 +224,7 @@ msgstr ""
 "해당 다이렉트 메시지의 로케일은 디스코드 기본값으로 초기화됩니다. 당신의 디스코드 설정은 ${ interaction.locale } "
 "입니다."
 
-#: src\commands\ping.ts:35
+#: src\commands\ping.ts:36
 #: src\events\message.ts:28
 #, javascript-format
 msgid "Average WebSocket ping (new instance): ${ ping } ms"
@@ -349,7 +349,7 @@ msgstr ""
 msgid "ydke URL"
 msgstr ""
 
-#: src\card.ts:292
+#: src\card.ts:291
 #. Forbidden/Limited Lists or Limit Regulations in the OCG
 msgid "**Limit**: ${ limitRegulationDisplay }"
 msgstr ""
@@ -367,22 +367,21 @@ msgid "CoolStuffInc"
 msgstr ""
 
 #: src\commands\price.ts:118
-#. note: this is about our database, not the user input. Could clarify.
-#. unsure where, how or if to localise this error. Will it even come up?
+#. TODO: future, determine localisation and relevance status of this error
 msgid "Sorry, I can't find the price for a card with no English name!"
 msgstr ""
 
-#: src\commands\price.ts:158
+#: src\commands\price.ts:159
 msgid "No market price"
 msgstr ""
 
-#: src\commands\price.ts:164
+#: src\commands\price.ts:167
 #, javascript-format
-msgid "Prices for ${ card.name[resultLanguage] }"
+msgid "Prices for ${ card.name[resultLanguage] } - ${ vendorName }"
 msgstr ""
 
-#: src\commands\price.ts:172
-msgid "Could not find prices for `${ _name }`!"
+#: src\commands\price.ts:181
+msgid "Could not find prices for `${ name }`!"
 msgstr ""
 
 #: src\card.ts:37
@@ -660,18 +659,18 @@ msgctxt "attribute"
 msgid "DIVINE"
 msgstr "신"
 
-#: src\card.ts:342
-#: src\card.ts:353
+#: src\card.ts:341
+#: src\card.ts:352
 msgctxt "card-embed"
 msgid "Card Text"
 msgstr "카드 텍스트"
 
-#: src\card.ts:347
+#: src\card.ts:346
 msgctxt "card-embed"
 msgid "Pendulum Effect"
 msgstr "펜듈럼 효과"
 
-#: src\card.ts:369
+#: src\card.ts:368
 msgctxt "card-embed"
 msgid "Card Effect"
 msgstr "카드 효과"
@@ -709,7 +708,7 @@ msgctxt "command-option"
 msgid "page"
 msgstr "페이지"
 
-#: src\commands\help.ts:51
+#: src\commands\help.ts:52
 msgctxt "command-option"
 msgid "command"
 msgstr ""
@@ -806,7 +805,7 @@ msgctxt "command-option-description"
 msgid "The name of the Yugipedia page you want to search for."
 msgstr "검색할 Yugipedia 페이지의 이름입니다."
 
-#: src\commands\help.ts:54
+#: src\commands\help.ts:55
 msgctxt "command-option-description"
 msgid "The name of a specific Slash Command."
 msgstr ""
@@ -941,7 +940,7 @@ msgctxt "command-name"
 msgid "art"
 msgstr "일러스트"
 
-#: src\commands\ping.ts:22
+#: src\commands\ping.ts:23
 msgctxt "command-name"
 msgid "ping"
 msgstr "핑"
@@ -956,7 +955,7 @@ msgctxt "command-name"
 msgid "yugipedia"
 msgstr ""
 
-#: src\commands\help.ts:48
+#: src\commands\help.ts:49
 msgctxt "command-name"
 msgid "help"
 msgstr ""
@@ -991,7 +990,7 @@ msgctxt "command-description"
 msgid "Display the art for a card!"
 msgstr "카드의 일러스트를 표시합니다."
 
-#: src\commands\ping.ts:23
+#: src\commands\ping.ts:24
 msgctxt "command-description"
 msgid "Test latency to the new bot instance."
 msgstr "새로운 봇 인스턴스의 지연 시간을 테스트합니다."
@@ -1006,7 +1005,7 @@ msgctxt "command-description"
 msgid "Search the Yugipedia wiki for a page and link to it."
 msgstr "Yugipedia에서 검색하고 링크를 출력합니다."
 
-#: src\commands\help.ts:49
+#: src\commands\help.ts:50
 msgctxt "command-description"
 msgid "Get help with a Slash Command."
 msgstr ""

--- a/translations/pt.po
+++ b/translations/pt.po
@@ -6,11 +6,11 @@ msgstr ""
 "MIME-Version: 1.0\n"
 "Content-Transfer-Encoding: 8bit\n"
 
-#: src\card.ts:254
+#: src\card.ts:253
 msgid ":link: Links"
 msgstr ""
 
-#: src\card.ts:255
+#: src\card.ts:254
 #, javascript-format
 msgid ""
 "[Official Konami DB](${ official }) | [OCG Rulings](${ rulings }) | "
@@ -19,22 +19,22 @@ msgstr ""
 "[Database oficial da Konami](${ official }) | [Regras no OCG](${ rulings }) "
 "| [Yugipedia](${ yugipedia }) | [YGOPRODECK](${ ygoprodeck })"
 
-#: src\card.ts:258
+#: src\card.ts:257
 #, javascript-format
 msgid "[Yugipedia](${ yugipedia }) | [YGOPRODECK](${ ygoprodeck })"
 msgstr ""
 
-#: src\card.ts:318
+#: src\card.ts:317
 #, javascript-format
 msgid "**Type**: ${ RaceIcon[race] } ${ localizedMonsterTypeLine }"
 msgstr "**Tipo**: ${ RaceIcon[race] } ${ localizedMonsterTypeLine }"
 
-#: src\card.ts:320
+#: src\card.ts:319
 #, javascript-format
 msgid "**Attribute**: ${ AttributeIcon[card.attribute] } ${ localizedAttribute }"
 msgstr "**Atributo**: ${ AttributeIcon[card.attribute] } ${ localizedAttribute }"
 
-#: src\card.ts:324
+#: src\card.ts:323
 msgid ""
 "**Rank**: ${ Icon.Rank } ${ card.rank } **ATK**: ${ card.atk } **DEF**: ${ "
 "card.def }"
@@ -42,7 +42,7 @@ msgstr ""
 "**Classe**: ${ Icon.Rank } ${ card.rank } **ATK**: ${ card.atk } **DEF**: "
 "${ card.def }"
 
-#: src\card.ts:327
+#: src\card.ts:326
 #, javascript-format
 msgid ""
 "**Link Rating**: ${ card.link_arrows.length } **ATK**: ${ card.atk } **Link "
@@ -51,7 +51,7 @@ msgstr ""
 "**Valor Link**: ${ card.link_arrows.length } **ATK**: ${ card.atk } **Link "
 "Flechas Link**: ${ arrows }"
 
-#: src\card.ts:329
+#: src\card.ts:328
 #, javascript-format
 msgid ""
 "**Level**: ${ Icon.Level } ${ card.level } **ATK**: ${ card.atk } **DEF**: "
@@ -60,12 +60,12 @@ msgstr ""
 "**Nível**: ${ Icon.Level } ${ card.level } **ATK**: ${ card.atk } **DEF**: "
 "${ card.def }"
 
-#: src\card.ts:336
+#: src\card.ts:335
 msgid "**Pendulum Scale**: ${ formattedScale }"
 msgstr "**Escala Pêndulo**: ${ formattedScale }"
 
-#: src\card.ts:356
-#: src\card.ts:374
+#: src\card.ts:355
+#: src\card.ts:373
 #, javascript-format
 msgid "Password: ${ card.password } | Konami ID #${ card.konami_id }"
 msgstr "Senha: ${ card.password } | Konami ID #${ card.konami_id }"
@@ -129,7 +129,7 @@ msgid "Found what you were looking for? Consider supporting us!"
 msgstr "Você encontrou o que procurava? Considere nos apoiar!"
 
 #: src\commands\art.ts:97
-#: src\commands\price.ts:146
+#: src\commands\price.ts:148
 #: src\commands\search.ts:90
 #, javascript-format
 msgid "Could not find a card matching `${ input }`!"
@@ -278,7 +278,7 @@ msgid ""
 "setting is ${ interaction.locale }."
 msgstr ""
 
-#: src\commands\ping.ts:35
+#: src\commands\ping.ts:36
 #: src\events\message.ts:28
 #, javascript-format
 msgid "Average WebSocket ping (new instance): ${ ping } ms"
@@ -348,7 +348,7 @@ msgstr ""
 msgid "ydke URL"
 msgstr ""
 
-#: src\card.ts:292
+#: src\card.ts:291
 #. Forbidden/Limited Lists or Limit Regulations in the OCG
 msgid "**Limit**: ${ limitRegulationDisplay }"
 msgstr ""
@@ -366,22 +366,21 @@ msgid "CoolStuffInc"
 msgstr ""
 
 #: src\commands\price.ts:118
-#. note: this is about our database, not the user input. Could clarify.
-#. unsure where, how or if to localise this error. Will it even come up?
+#. TODO: future, determine localisation and relevance status of this error
 msgid "Sorry, I can't find the price for a card with no English name!"
 msgstr ""
 
-#: src\commands\price.ts:158
+#: src\commands\price.ts:159
 msgid "No market price"
 msgstr ""
 
-#: src\commands\price.ts:164
+#: src\commands\price.ts:167
 #, javascript-format
-msgid "Prices for ${ card.name[resultLanguage] }"
+msgid "Prices for ${ card.name[resultLanguage] } - ${ vendorName }"
 msgstr ""
 
-#: src\commands\price.ts:172
-msgid "Could not find prices for `${ _name }`!"
+#: src\commands\price.ts:181
+msgid "Could not find prices for `${ name }`!"
 msgstr ""
 
 #: src\card.ts:37
@@ -659,18 +658,18 @@ msgctxt "attribute"
 msgid "DIVINE"
 msgstr "DIVINO"
 
-#: src\card.ts:342
-#: src\card.ts:353
+#: src\card.ts:341
+#: src\card.ts:352
 msgctxt "card-embed"
 msgid "Card Text"
 msgstr "Texto da carta"
 
-#: src\card.ts:347
+#: src\card.ts:346
 msgctxt "card-embed"
 msgid "Pendulum Effect"
 msgstr "Efeito Pêndulo"
 
-#: src\card.ts:369
+#: src\card.ts:368
 msgctxt "card-embed"
 msgid "Card Effect"
 msgstr "Efeito da Carta"
@@ -708,7 +707,7 @@ msgctxt "command-option"
 msgid "page"
 msgstr "página"
 
-#: src\commands\help.ts:51
+#: src\commands\help.ts:52
 msgctxt "command-option"
 msgid "command"
 msgstr ""
@@ -805,7 +804,7 @@ msgctxt "command-option-description"
 msgid "The name of the Yugipedia page you want to search for."
 msgstr "O nome da página da Yugipedia que você gostaria de procurar"
 
-#: src\commands\help.ts:54
+#: src\commands\help.ts:55
 msgctxt "command-option-description"
 msgid "The name of a specific Slash Command."
 msgstr ""
@@ -940,7 +939,7 @@ msgctxt "command-name"
 msgid "art"
 msgstr "arte"
 
-#: src\commands\ping.ts:22
+#: src\commands\ping.ts:23
 msgctxt "command-name"
 msgid "ping"
 msgstr "ping"
@@ -955,7 +954,7 @@ msgctxt "command-name"
 msgid "yugipedia"
 msgstr "yugipedia"
 
-#: src\commands\help.ts:48
+#: src\commands\help.ts:49
 msgctxt "command-name"
 msgid "help"
 msgstr ""
@@ -990,7 +989,7 @@ msgctxt "command-description"
 msgid "Display the art for a card!"
 msgstr "Mostra a arte de uma carta!"
 
-#: src\commands\ping.ts:23
+#: src\commands\ping.ts:24
 msgctxt "command-description"
 msgid "Test latency to the new bot instance."
 msgstr "Testa a latência para uma nova instância do bot"
@@ -1005,7 +1004,7 @@ msgctxt "command-description"
 msgid "Search the Yugipedia wiki for a page and link to it."
 msgstr "Procura uma página da wiki da Yugipedia e a linka"
 
-#: src\commands\help.ts:49
+#: src\commands\help.ts:50
 msgctxt "command-description"
 msgid "Get help with a Slash Command."
 msgstr ""

--- a/translations/zh-CN.po
+++ b/translations/zh-CN.po
@@ -6,11 +6,11 @@ msgstr ""
 "MIME-Version: 1.0\n"
 "Content-Transfer-Encoding: 8bit\n"
 
-#: src\card.ts:254
+#: src\card.ts:253
 msgid ":link: Links"
 msgstr ":link: 链接"
 
-#: src\card.ts:255
+#: src\card.ts:254
 #, javascript-format
 msgid ""
 "[Official Konami DB](${ official }) | [OCG Rulings](${ rulings }) | "
@@ -19,22 +19,22 @@ msgstr ""
 "[K社官方数据库](${ official }) | [事务局FAQ](${ rulings }) | [Yugipedia](${ "
 "yugipedia }) | [YGOPRODECK](${ ygoprodeck })"
 
-#: src\card.ts:258
+#: src\card.ts:257
 #, javascript-format
 msgid "[Yugipedia](${ yugipedia }) | [YGOPRODECK](${ ygoprodeck })"
 msgstr "[Yugipedia](${ yugipedia }) | [YGOPRODECK](${ ygoprodeck })"
 
-#: src\card.ts:318
+#: src\card.ts:317
 #, javascript-format
 msgid "**Type**: ${ RaceIcon[race] } ${ localizedMonsterTypeLine }"
 msgstr "**种族**: ${ RaceIcon[race] } ${ localizedMonsterTypeLine }"
 
-#: src\card.ts:320
+#: src\card.ts:319
 #, javascript-format
 msgid "**Attribute**: ${ AttributeIcon[card.attribute] } ${ localizedAttribute }"
 msgstr "**属性**: ${ AttributeIcon[card.attribute] } ${ localizedAttribute }"
 
-#: src\card.ts:324
+#: src\card.ts:323
 msgid ""
 "**Rank**: ${ Icon.Rank } ${ card.rank } **ATK**: ${ card.atk } **DEF**: ${ "
 "card.def }"
@@ -42,7 +42,7 @@ msgstr ""
 "**阶级**: ${ Icon.Rank } ${ card.rank } **攻击力**: ${ card.atk } **守备力**: ${ "
 "card.def }"
 
-#: src\card.ts:327
+#: src\card.ts:326
 #, javascript-format
 msgid ""
 "**Link Rating**: ${ card.link_arrows.length } **ATK**: ${ card.atk } **Link "
@@ -51,7 +51,7 @@ msgstr ""
 "**连接数值**: ${ card.link_arrows.length } **攻击力**: ${ card.atk } **连接标记**: ${ "
 "arrows }"
 
-#: src\card.ts:329
+#: src\card.ts:328
 #, javascript-format
 msgid ""
 "**Level**: ${ Icon.Level } ${ card.level } **ATK**: ${ card.atk } **DEF**: "
@@ -60,12 +60,12 @@ msgstr ""
 "**等级**: ${ Icon.Level } ${ card.level } **攻击力**: ${ card.atk } **守备力**: ${ "
 "card.def }"
 
-#: src\card.ts:336
+#: src\card.ts:335
 msgid "**Pendulum Scale**: ${ formattedScale }"
 msgstr "**灵摆刻度**: ${ formattedScale }"
 
-#: src\card.ts:356
-#: src\card.ts:374
+#: src\card.ts:355
+#: src\card.ts:373
 #, javascript-format
 msgid "Password: ${ card.password } | Konami ID #${ card.konami_id }"
 msgstr "卡片密码: ${ card.password } | 官方编号${ card.konami_id }"
@@ -129,7 +129,7 @@ msgid "Found what you were looking for? Consider supporting us!"
 msgstr "找到你要的东西了吗？请考虑捐助我们！"
 
 #: src\commands\art.ts:97
-#: src\commands\price.ts:146
+#: src\commands\price.ts:148
 #: src\commands\search.ts:90
 #, javascript-format
 msgid "Could not find a card matching `${ input }`!"
@@ -292,7 +292,7 @@ msgstr ""
 msgid "Error: Your deck is empty."
 msgstr ""
 
-#: src\commands\ping.ts:35
+#: src\commands\ping.ts:36
 #: src\events\message.ts:28
 #, javascript-format
 msgid "Average WebSocket ping (new instance): ${ ping } ms"
@@ -342,7 +342,7 @@ msgstr ""
 msgid "ydke URL"
 msgstr ""
 
-#: src\card.ts:292
+#: src\card.ts:291
 #. Forbidden/Limited Lists or Limit Regulations in the OCG
 msgid "**Limit**: ${ limitRegulationDisplay }"
 msgstr ""
@@ -360,22 +360,21 @@ msgid "CoolStuffInc"
 msgstr ""
 
 #: src\commands\price.ts:118
-#. note: this is about our database, not the user input. Could clarify.
-#. unsure where, how or if to localise this error. Will it even come up?
+#. TODO: future, determine localisation and relevance status of this error
 msgid "Sorry, I can't find the price for a card with no English name!"
 msgstr ""
 
-#: src\commands\price.ts:158
+#: src\commands\price.ts:159
 msgid "No market price"
 msgstr ""
 
-#: src\commands\price.ts:164
+#: src\commands\price.ts:167
 #, javascript-format
-msgid "Prices for ${ card.name[resultLanguage] }"
+msgid "Prices for ${ card.name[resultLanguage] } - ${ vendorName }"
 msgstr ""
 
-#: src\commands\price.ts:172
-msgid "Could not find prices for `${ _name }`!"
+#: src\commands\price.ts:181
+msgid "Could not find prices for `${ name }`!"
 msgstr ""
 
 #: src\card.ts:37
@@ -653,18 +652,18 @@ msgctxt "attribute"
 msgid "DIVINE"
 msgstr "神"
 
-#: src\card.ts:342
-#: src\card.ts:353
+#: src\card.ts:341
+#: src\card.ts:352
 msgctxt "card-embed"
 msgid "Card Text"
 msgstr "卡片文本"
 
-#: src\card.ts:347
+#: src\card.ts:346
 msgctxt "card-embed"
 msgid "Pendulum Effect"
 msgstr "灵摆效果"
 
-#: src\card.ts:369
+#: src\card.ts:368
 msgctxt "card-embed"
 msgid "Card Effect"
 msgstr "卡片效果"
@@ -702,7 +701,7 @@ msgctxt "command-option"
 msgid "page"
 msgstr ""
 
-#: src\commands\help.ts:51
+#: src\commands\help.ts:52
 msgctxt "command-option"
 msgid "command"
 msgstr ""
@@ -799,7 +798,7 @@ msgctxt "command-option-description"
 msgid "The name of the Yugipedia page you want to search for."
 msgstr "你想要查询的Yugipedia页面的名字"
 
-#: src\commands\help.ts:54
+#: src\commands\help.ts:55
 msgctxt "command-option-description"
 msgid "The name of a specific Slash Command."
 msgstr ""
@@ -934,7 +933,7 @@ msgctxt "command-name"
 msgid "art"
 msgstr "卡图"
 
-#: src\commands\ping.ts:22
+#: src\commands\ping.ts:23
 msgctxt "command-name"
 msgid "ping"
 msgstr ""
@@ -949,7 +948,7 @@ msgctxt "command-name"
 msgid "yugipedia"
 msgstr ""
 
-#: src\commands\help.ts:48
+#: src\commands\help.ts:49
 msgctxt "command-name"
 msgid "help"
 msgstr ""
@@ -984,7 +983,7 @@ msgctxt "command-description"
 msgid "Display the art for a card!"
 msgstr "显示卡片图。"
 
-#: src\commands\ping.ts:23
+#: src\commands\ping.ts:24
 msgctxt "command-description"
 msgid "Test latency to the new bot instance."
 msgstr "测试新bot实例的延迟"
@@ -999,7 +998,7 @@ msgctxt "command-description"
 msgid "Search the Yugipedia wiki for a page and link to it."
 msgstr "搜索Yugipedia页面与链接"
 
-#: src\commands\help.ts:49
+#: src\commands\help.ts:50
 msgctxt "command-description"
 msgid "Get help with a Slash Command."
 msgstr ""

--- a/translations/zh-TW.po
+++ b/translations/zh-TW.po
@@ -6,33 +6,33 @@ msgstr ""
 "MIME-Version: 1.0\n"
 "Content-Transfer-Encoding: 8bit\n"
 
-#: src\card.ts:254
+#: src\card.ts:253
 msgid ":link: Links"
 msgstr "鏈接"
 
-#: src\card.ts:255
+#: src\card.ts:254
 #, javascript-format
 msgid ""
 "[Official Konami DB](${ official }) | [OCG Rulings](${ rulings }) | "
 "[Yugipedia](${ yugipedia }) | [YGOPRODECK](${ ygoprodeck })"
 msgstr ""
 
-#: src\card.ts:258
+#: src\card.ts:257
 #, javascript-format
 msgid "[Yugipedia](${ yugipedia }) | [YGOPRODECK](${ ygoprodeck })"
 msgstr "[Yugipedia](${ yugipedia }) | [YGOPRODECK](${ ygoprodeck })"
 
-#: src\card.ts:318
+#: src\card.ts:317
 #, javascript-format
 msgid "**Type**: ${ RaceIcon[race] } ${ localizedMonsterTypeLine }"
 msgstr "**種族**: ${ RaceIcon[race] } ${ localizedMonsterTypeLine }"
 
-#: src\card.ts:320
+#: src\card.ts:319
 #, javascript-format
 msgid "**Attribute**: ${ AttributeIcon[card.attribute] } ${ localizedAttribute }"
 msgstr "**屬性**: ${ AttributeIcon[card.attribute] } ${ localizedAttribute }"
 
-#: src\card.ts:324
+#: src\card.ts:323
 msgid ""
 "**Rank**: ${ Icon.Rank } ${ card.rank } **ATK**: ${ card.atk } **DEF**: ${ "
 "card.def }"
@@ -40,7 +40,7 @@ msgstr ""
 "**階級**: ${ Icon.Rank } ${ card.rank } **攻擊力**: ${ card.atk } **守備力**: ${ "
 "card.def }"
 
-#: src\card.ts:327
+#: src\card.ts:326
 #, javascript-format
 msgid ""
 "**Link Rating**: ${ card.link_arrows.length } **ATK**: ${ card.atk } **Link "
@@ -49,7 +49,7 @@ msgstr ""
 "**連接數值**: ${ card.link_arrows.length } **攻擊力**: ${ card.atk } **連接標記**: ${ "
 "arrows }"
 
-#: src\card.ts:329
+#: src\card.ts:328
 #, javascript-format
 msgid ""
 "**Level**: ${ Icon.Level } ${ card.level } **ATK**: ${ card.atk } **DEF**: "
@@ -58,12 +58,12 @@ msgstr ""
 "**等級**: ${ Icon.Level } ${ card.level } **攻擊力**: ${ card.atk } **守備力**: ${ "
 "card.def }"
 
-#: src\card.ts:336
+#: src\card.ts:335
 msgid "**Pendulum Scale**: ${ formattedScale }"
 msgstr "**靈擺刻度**: ${ formattedScale }"
 
-#: src\card.ts:356
-#: src\card.ts:374
+#: src\card.ts:355
+#: src\card.ts:373
 #, javascript-format
 msgid "Password: ${ card.password } | Konami ID #${ card.konami_id }"
 msgstr "卡片密碼: ${ card.password } | 官方編號${ card.konami_id }"
@@ -124,7 +124,7 @@ msgid "Found what you were looking for? Consider supporting us!"
 msgstr ""
 
 #: src\commands\art.ts:97
-#: src\commands\price.ts:146
+#: src\commands\price.ts:148
 #: src\commands\search.ts:90
 #, javascript-format
 msgid "Could not find a card matching `${ input }`!"
@@ -287,7 +287,7 @@ msgstr ""
 msgid "Error: Your deck is empty."
 msgstr ""
 
-#: src\commands\ping.ts:35
+#: src\commands\ping.ts:36
 #: src\events\message.ts:28
 #, javascript-format
 msgid "Average WebSocket ping (new instance): ${ ping } ms"
@@ -337,7 +337,7 @@ msgstr ""
 msgid "ydke URL"
 msgstr ""
 
-#: src\card.ts:292
+#: src\card.ts:291
 #. Forbidden/Limited Lists or Limit Regulations in the OCG
 msgid "**Limit**: ${ limitRegulationDisplay }"
 msgstr ""
@@ -355,22 +355,21 @@ msgid "CoolStuffInc"
 msgstr ""
 
 #: src\commands\price.ts:118
-#. note: this is about our database, not the user input. Could clarify.
-#. unsure where, how or if to localise this error. Will it even come up?
+#. TODO: future, determine localisation and relevance status of this error
 msgid "Sorry, I can't find the price for a card with no English name!"
 msgstr ""
 
-#: src\commands\price.ts:158
+#: src\commands\price.ts:159
 msgid "No market price"
 msgstr ""
 
-#: src\commands\price.ts:164
+#: src\commands\price.ts:167
 #, javascript-format
-msgid "Prices for ${ card.name[resultLanguage] }"
+msgid "Prices for ${ card.name[resultLanguage] } - ${ vendorName }"
 msgstr ""
 
-#: src\commands\price.ts:172
-msgid "Could not find prices for `${ _name }`!"
+#: src\commands\price.ts:181
+msgid "Could not find prices for `${ name }`!"
 msgstr ""
 
 #: src\card.ts:37
@@ -648,18 +647,18 @@ msgctxt "attribute"
 msgid "DIVINE"
 msgstr ""
 
-#: src\card.ts:342
-#: src\card.ts:353
+#: src\card.ts:341
+#: src\card.ts:352
 msgctxt "card-embed"
 msgid "Card Text"
 msgstr "卡片文本"
 
-#: src\card.ts:347
+#: src\card.ts:346
 msgctxt "card-embed"
 msgid "Pendulum Effect"
 msgstr "靈擺效果"
 
-#: src\card.ts:369
+#: src\card.ts:368
 msgctxt "card-embed"
 msgid "Card Effect"
 msgstr "卡片效果"
@@ -697,7 +696,7 @@ msgctxt "command-option"
 msgid "page"
 msgstr ""
 
-#: src\commands\help.ts:51
+#: src\commands\help.ts:52
 msgctxt "command-option"
 msgid "command"
 msgstr ""
@@ -794,7 +793,7 @@ msgctxt "command-option-description"
 msgid "The name of the Yugipedia page you want to search for."
 msgstr ""
 
-#: src\commands\help.ts:54
+#: src\commands\help.ts:55
 msgctxt "command-option-description"
 msgid "The name of a specific Slash Command."
 msgstr ""
@@ -929,7 +928,7 @@ msgctxt "command-name"
 msgid "art"
 msgstr "卡圖"
 
-#: src\commands\ping.ts:22
+#: src\commands\ping.ts:23
 msgctxt "command-name"
 msgid "ping"
 msgstr ""
@@ -944,7 +943,7 @@ msgctxt "command-name"
 msgid "yugipedia"
 msgstr ""
 
-#: src\commands\help.ts:48
+#: src\commands\help.ts:49
 msgctxt "command-name"
 msgid "help"
 msgstr ""
@@ -979,7 +978,7 @@ msgctxt "command-description"
 msgid "Display the art for a card!"
 msgstr "顯示卡片圖。"
 
-#: src\commands\ping.ts:23
+#: src\commands\ping.ts:24
 msgctxt "command-description"
 msgid "Test latency to the new bot instance."
 msgstr ""
@@ -994,7 +993,7 @@ msgctxt "command-description"
 msgid "Search the Yugipedia wiki for a page and link to it."
 msgstr ""
 
-#: src\commands\help.ts:49
+#: src\commands\help.ts:50
 msgctxt "command-description"
 msgid "Get help with a Slash Command."
 msgstr ""


### PR DESCRIPTION
Closes #171 

It's not immediately clear if the URL should be left of the Official Konami ones, but I think this way makes sense.