### PR TITLE
Implement <> card search

### DIFF
--- a/package.json
+++ b/package.json
@@ -24,6 +24,7 @@
 		"@sinclair/typebox": "^0.24.28",
 		"better-sqlite3": "^7.6.2",
 		"debug": "^4.3.4",
+		"discord-markdown": "2.5.1",
 		"discord.js": "^14.4.0",
 		"dotenv": "^16.0.1",
 		"gettext-parser": "^6.0.0",

--- a/src/bot.ts
+++ b/src/bot.ts
@@ -23,6 +23,7 @@ export class BotFactory {
 			intents: [
 				GatewayIntentBits.Guilds,
 				GatewayIntentBits.GuildMessages,
+				GatewayIntentBits.MessageContent,
 				// Intents.FLAGS.GUILD_MESSAGE_REACTIONS,
 				GatewayIntentBits.DirectMessages
 				// Intents.FLAGS.DIRECT_MESSAGE_REACTIONS

--- a/src/events/index.ts
+++ b/src/events/index.ts
@@ -1,9 +1,10 @@
 import { ClientEvents } from "discord.js";
 
 export interface Listener<K extends keyof ClientEvents> {
-    readonly type: K;
-    run(...args: ClientEvents[K]): Promise<void>;
+	readonly type: K;
+	run(...args: ClientEvents[K]): Promise<void>;
 }
 
 export { InteractionListener } from "./interaction";
-export { MessageListener } from "./message";
+export { PingMessageListener } from "./message-ping";
+export { SearchMessageListener } from "./message-search";

--- a/src/events/message-ping.ts
+++ b/src/events/message-ping.ts
@@ -6,10 +6,10 @@ import { LocaleProvider } from "../locale";
 import { getLogger } from "../logger";
 
 @injectable()
-export class MessageListener implements Listener<"messageCreate"> {
+export class PingMessageListener implements Listener<"messageCreate"> {
 	readonly type = "messageCreate";
 
-	#logger = getLogger("events:message");
+	#logger = getLogger("events:message:ping");
 
 	constructor(@inject("LocaleProvider") private locales: LocaleProvider) {}
 

--- a/src/events/message-search.ts
+++ b/src/events/message-search.ts
@@ -81,15 +81,15 @@ export class SearchMessageListener implements Listener<"messageCreate"> {
 		if (message.author.bot) {
 			return;
 		}
-		const inputs = preprocess(message.content);
+		let inputs = preprocess(message.content);
 		if (inputs.length === 0) {
 			return;
 		}
-		// upper limit of 3
 		this.#logger.info(inputs);
-		const language = await this.locales.getM(message);
+		inputs = inputs.slice(0, 3);
+		message.react("🕙").catch(this.#logger.warn);
 		// metrics
-		// add reaction
+		const language = await this.locales.getM(message);
 		const promises = inputs
 			.map(input => {
 				const password = Number(input);
@@ -124,6 +124,6 @@ export class SearchMessageListener implements Listener<"messageCreate"> {
 				this.#logger.info(-1);
 			}
 		}
-		// remove reaction
+		message.reactions.cache.get("🕙")?.users.remove(message.client.user).catch(this.#logger.warn);
 	}
 }

--- a/src/events/message-search.ts
+++ b/src/events/message-search.ts
@@ -82,8 +82,10 @@ export function preprocess(message: string): string[] {
  * 00010000,ja
  */
 const NUMERIC_REGEX = new RegExp(
-	// eslint-disable-next-line prefer-template
-	/^(?<kid>%)?\s*(?<number>\d+)\s*/.toString().slice(1, -1) + "(?:,(?<lang>" + LOCALES.join("|") + "))?$"
+	/^(?<kid>%)?\s*(?<number>\d+)\s*(?:,(?<lang>LOCALES))?$/
+		.toString()
+		.slice(1, -1)
+		.replace("LOCALES", LOCALES.join("|"))
 );
 
 /**
@@ -97,14 +99,10 @@ const NUMERIC_REGEX = new RegExp(
  * blue-eyes,en,ja
  */
 const TEXT_REGEX = new RegExp(
-	// eslint-disable-next-line prefer-template
-	/^(?<text>.*?)/.toString().slice(1, -1) +
-		"(?:(?<inputLang>," +
-		LOCALES.join("|") +
-		"))?" +
-		"(?:(?<resultLang>," +
-		LOCALES.join("|") +
-		"))?$"
+	/^(?<text>.*?)(?:,(?<inputLang>LOCALES))?(?:,(?<resultLang>))?$/
+		.toString()
+		.slice(1, -1)
+		.replaceAll("LOCALES", LOCALES.join("|"))
 );
 
 @injectable()

--- a/src/events/message-search.ts
+++ b/src/events/message-search.ts
@@ -99,7 +99,7 @@ const NUMERIC_REGEX = new RegExp(
  * blue-eyes,en,ja
  */
 const TEXT_REGEX = new RegExp(
-	/^(?<text>.*?)(?:,(?<inputLang>LOCALES))?(?:,(?<resultLang>))?$/
+	/^(?<text>.*?)(?:,(?<inputLang>LOCALES))?(?:,(?<resultLang>LOCALES))?$/
 		.toString()
 		.slice(1, -1)
 		.replaceAll("LOCALES", LOCALES.join("|"))

--- a/src/events/message-search.ts
+++ b/src/events/message-search.ts
@@ -50,6 +50,23 @@ const DELIMITERS = {
 	HAVEN: { match: /%([^<\n]+?)\^/g, prune: null } // % ^
 } as const;
 
+// eslint-disable-next-line @typescript-eslint/explicit-function-return-type
+function getDelimiter(message: Message) {
+	switch (message.guildId) {
+		case "170669983079071745":
+			return DELIMITERS.CC;
+		case "597478047163219988":
+		case "845400480452050954":
+			return DELIMITERS.SQUARE;
+		case "871582695967301703":
+			return DELIMITERS.HAVEN;
+		case "780952232103116800":
+			return DELIMITERS.TRANS;
+		default:
+			return DELIMITERS.ANGLE;
+	}
+}
+
 export function parseSummons(cleanMessage: string, regex: RegExp): string[] {
 	return [...cleanMessage.matchAll(regex)]
 		.map(match => match[1].trim())
@@ -63,10 +80,15 @@ export function parseSummons(cleanMessage: string, regex: RegExp): string[] {
 		});
 }
 
-export function preprocess(message: string): string[] {
+export function preprocess(
+	message: string,
+	delimiter: typeof DELIMITERS[keyof typeof DELIMITERS] = DELIMITERS.ANGLE
+): string[] {
 	message = cleanMessageMarkup(message);
-	message = message.replaceAll(DELIMITERS.ANGLE.prune, "");
-	return parseSummons(message, DELIMITERS.ANGLE.match);
+	if (delimiter.prune) {
+		message = message.replaceAll(delimiter.prune, "");
+	}
+	return parseSummons(message, delimiter.match);
 }
 
 /**
@@ -117,7 +139,8 @@ export class SearchMessageListener implements Listener<"messageCreate"> {
 		if (message.author.bot) {
 			return;
 		}
-		let inputs = preprocess(message.content);
+		const delimiter = getDelimiter(message);
+		let inputs = preprocess(message.content, delimiter);
 		if (inputs.length === 0) {
 			return;
 		}

--- a/src/events/message-search.ts
+++ b/src/events/message-search.ts
@@ -1,0 +1,81 @@
+import { Message } from "discord.js";
+import { inject, injectable } from "tsyringe";
+import { t, useLocale } from "ttag";
+import { Listener } from ".";
+import { createCardEmbed, getCard } from "../card";
+import { LocaleProvider } from "../locale";
+import { getLogger } from "../logger";
+import { addFunding, addNotice } from "../utils";
+
+@injectable()
+export class SearchMessageListener implements Listener<"messageCreate"> {
+	readonly type = "messageCreate";
+
+	#logger = getLogger("events:message:search");
+
+	constructor(@inject("LocaleProvider") private locales: LocaleProvider) {}
+
+	async run(message: Message): Promise<void> {
+		if (message.author.bot) {
+			return;
+		}
+		// parse markdown, remove code blocks ```, `, spoiler tags ||
+		// ignore doubled-up brackets?
+		const inputs: string[] = [];
+		let remaining = message.content;
+		while (remaining.includes("<")) {
+			const intermediate = remaining.slice(1 + remaining.indexOf("<"));
+			const endPosition = intermediate.indexOf(">");
+			const input = intermediate.slice(0, endPosition);
+			// Skip if this is a Discord markdown element
+			// https://discord.com/developers/docs/reference#message-formatting
+			// also strip and skip if blank
+			// skip if contains "(" or ignore-case "anime" as a heuristic
+			inputs.push(input);
+			remaining = intermediate.slice(1 + endPosition);
+		}
+		if (inputs.length === 0) {
+			return;
+		}
+		// upper limit of 3
+		this.#logger.info(inputs);
+		const language = await this.locales.getM(message);
+		// metrics
+		// add reaction
+		const promises = inputs
+			.map(input => {
+				const password = Number(input);
+				const kid = Number(input.slice(1));
+				let promise;
+				if (input.startsWith("%") && Number.isSafeInteger(kid)) {
+					promise = getCard("konami-id", `${kid}`);
+				} else if (Number.isSafeInteger(password)) {
+					promise = getCard("password", `${password}`);
+				} else {
+					promise = getCard("name", input, language);
+				}
+				return [input, promise] as const;
+			})
+			.map(([input, promise]) =>
+				promise.then(card => {
+					useLocale(language);
+					if (!card) {
+						return message.reply({ content: t`Could not find a card matching \`${input}\`!` });
+					} else {
+						let embeds = createCardEmbed(card, language);
+						embeds = addFunding(addNotice(embeds));
+						return message.reply({ embeds });
+					}
+				})
+			);
+		const replies = await Promise.allSettled(promises);
+		for (const reply of replies) {
+			if (reply.status === "fulfilled") {
+				this.#logger.info(reply.value.createdTimestamp - message.createdTimestamp);
+			} else {
+				this.#logger.info(-1);
+			}
+		}
+		// remove reaction
+	}
+}

--- a/src/events/message-search.ts
+++ b/src/events/message-search.ts
@@ -21,17 +21,21 @@ const parser = parserFor({
 } as ParserRules);
 // Can improve in future to do the entire processing with this parser to just grab the search tokens we want
 
+// https://discord.com/developers/docs/reference#message-formatting-formats
+const mentionPatterns = (
+	["UserWithOptionalNickname", "Channel", "Role", "SlashCommand", "Emoji", "Timestamp"] as const
+).map(key => new RegExp(FormattingPatterns[key], "g"));
+
 function cleanMessageMarkup(message: string): string {
 	// Remove the above markup elements
 	const nodes = parser(message);
 	message = nodes
 		.filter(node => node.type === "text")
 		.map(node => node.content)
-		.join();
-	// https://discord.com/developers/docs/reference#message-formatting-formats
-	const patternKeys = ["UserWithOptionalNickname", "Channel", "Role", "SlashCommand", "Emoji", "Timestamp"] as const;
-	for (const key of patternKeys) {
-		message = message.replaceAll(FormattingPatterns[key], "");
+		.join("");
+
+	for (const regex of mentionPatterns) {
+		message = message.replaceAll(regex, "");
 	}
 	return message;
 }

--- a/src/index.ts
+++ b/src/index.ts
@@ -7,7 +7,7 @@ import { addLocale } from "ttag";
 import { BotFactory } from "./bot";
 import { Command } from "./Command";
 import { classes, registerSlashCommands } from "./commands";
-import { InteractionListener, MessageListener } from "./events";
+import { InteractionListener, PingMessageListener, SearchMessageListener } from "./events";
 import { LocaleProvider, SQLiteLocaleProvider } from "./locale";
 import { getLogger } from "./logger";
 import { Metrics } from "./metrics";
@@ -48,7 +48,8 @@ if (process.argv.length > 2 && process.argv[2] === "--deploy-slash") {
 	container.registerSingleton<LocaleProvider>("LocaleProvider", SQLiteLocaleProvider);
 	classes.forEach(Class => container.register<Command>("Command", { useClass: Class }));
 	container.register<InteractionListener>("Listener", { useClass: InteractionListener });
-	container.register<MessageListener>("Listener", { useClass: MessageListener });
+	container.register<PingMessageListener>("Listener", { useClass: PingMessageListener });
+	container.register<SearchMessageListener>("Listener", { useClass: SearchMessageListener });
 	//container.register<BotFactory>(BotFactory, { useClass: BotFactory });
 
 	const bot = container.resolve(BotFactory).createInstance();

--- a/test/events/message-search.spec.ts
+++ b/test/events/message-search.spec.ts
@@ -1,0 +1,109 @@
+import { cleanMessageMarkup, preprocess } from "../../src/events/message-search";
+
+describe("clean markup", () => {
+	test("cleans > blockQuote", () => {
+		const message = cleanMessageMarkup("foo\n> bar");
+		expect(message.trim()).toBe("foo");
+	});
+	test("cleans >>> blockQuote", () => {
+		const message = cleanMessageMarkup("foo\n>>> bar");
+		expect(message.trim()).toBe("foo");
+	});
+	test("cleans ```", () => {
+		const message = cleanMessageMarkup("```\nfoo\n```\nbar");
+		expect(message.trim()).toBe("bar");
+	});
+	test("cleans `", () => {
+		const message = cleanMessageMarkup("`foo`bar");
+		expect(message.trim()).toBe("bar");
+	});
+	test("does not clean escaped `", () => {
+		const message = cleanMessageMarkup("\\`foo\\`bar");
+		expect(message.trim()).toBe("`foo`bar");
+	});
+	test("cleans ||", () => {
+		const message = cleanMessageMarkup("foo || bar ||");
+		expect(message.trim()).toBe("foo");
+	});
+	test("does not clean escaped ||", () => {
+		const message = cleanMessageMarkup("foo \\|| bar ||");
+		expect(message.trim()).toBe("foo || bar ||");
+	});
+	test("prunes user mention", () => {
+		const message = cleanMessageMarkup("<@80351110224678912>");
+		expect(message.trim()).toBe("");
+	});
+	test("prunes nicknamed user mention", () => {
+		const message = cleanMessageMarkup("<@!80351110224678912>");
+		expect(message.trim()).toBe("");
+	});
+	test("prunes channel mention", () => {
+		const message = cleanMessageMarkup("<#103735883630395392>");
+		expect(message.trim()).toBe("");
+	});
+	test("prunes role mention", () => {
+		const message = cleanMessageMarkup("<@&165511591545143296>");
+		expect(message.trim()).toBe("");
+	});
+	test("prunes slash command mention", () => {
+		const message = cleanMessageMarkup("</airhorn:816437322781949972>");
+		expect(message.trim()).toBe("");
+	});
+	test("prunes emoji", () => {
+		const message = cleanMessageMarkup("<:mmLol:216154654256398347>");
+		expect(message.trim()).toBe("");
+	});
+	test("prunes animated emoji", () => {
+		const message = cleanMessageMarkup("<a:b1nzy:392938283556143104>");
+		expect(message.trim()).toBe("");
+	});
+	test("prunes timestamp", () => {
+		const message = cleanMessageMarkup("<t:1618953630>");
+		expect(message.trim()).toBe("");
+	});
+	test("prunes formatted timestamp", () => {
+		const message = cleanMessageMarkup("<t:1618953630:d>");
+		expect(message.trim()).toBe("");
+	});
+});
+
+describe("preprocess message to get inputs", () => {
+	test("skips doubled delimiters", () => {
+		const inputs = preprocess("<<test>>");
+		expect(inputs.length).toBe(0);
+	});
+	test("gets one", () => {
+		const inputs = preprocess("<test>");
+		expect(inputs).toEqual(["test"]);
+	});
+	test("clears whitespace", () => {
+		const inputs = preprocess("< test >");
+		expect(inputs).toEqual(["test"]);
+	});
+	test("gets multiple", () => {
+		const inputs = preprocess("<foo> <bar>");
+		expect(inputs).toEqual(["foo", "bar"]);
+	});
+	test("ignores hyperlinks", () => {
+		const inputs = preprocess("<https://www.example.net>");
+		expect(inputs.length).toBe(0);
+	});
+	test("ignores parentheses", () => {
+		const inputs = preprocess("<Burning Soul (manga)>");
+		expect(inputs.length).toBe(0);
+	});
+	test("ignores anime", () => {
+		const inputs = preprocess("<winged dragon of ra anime>");
+		expect(inputs.length).toBe(0);
+	});
+	test("ignores anime in other casings", () => {
+		const inputs = preprocess("<C/C/C Critical Eye ANIME>");
+		expect(inputs.length).toBe(0);
+	});
+	test("the kitchen sink", () => {
+		const inputs = preprocess(
+			"<#12345678901234567> <@!12345678901234567> <big test> <<missed>> < nibiru> <@&12345678901234567> :thonk: <t:1664136104811>\n`<miss>`\n\\`<eternity>`\n<tearlaments\n        lulucaros>\n|| <dark magician> ||\n<dark dragoon >>\n```\n<code talker>\n```\n> <majesty's fiend>"
+		);
+		expect(inputs).toEqual(["big test", "nibiru", "eternity", "dark dragoon"]);
+	});
+});

--- a/test/events/message-search.spec.ts
+++ b/test/events/message-search.spec.ts
@@ -1,4 +1,4 @@
-import { cleanMessageMarkup, preprocess } from "../../src/events/message-search";
+import { cleanMessageMarkup, inputToGetCardArguments, preprocess } from "../../src/events/message-search";
 
 describe("clean markup", () => {
 	test("cleans > blockQuote", () => {
@@ -105,5 +105,71 @@ describe("preprocess message to get inputs", () => {
 			"<#12345678901234567> <@!12345678901234567> <big test> <<missed>> < nibiru> <@&12345678901234567> :thonk: <t:1664136104811>\n`<miss>`\n\\`<eternity>`\n<tearlaments\n        lulucaros>\n|| <dark magician> ||\n<dark dragoon >>\n```\n<code talker>\n```\n> <majesty's fiend>"
 		);
 		expect(inputs).toEqual(["big test", "nibiru", "eternity", "dark dragoon"]);
+	});
+});
+
+describe("transform input to arguments", () => {
+	test("Konami ID", () => {
+		const [resultLanguage, type, searchTerm, inputLanguage] = inputToGetCardArguments("%4007", "ja");
+		expect(resultLanguage).toBe("ja");
+		expect(type).toBe("konami-id");
+		expect(searchTerm).toBe("4007");
+		expect(inputLanguage).toBeUndefined();
+	});
+	test("Konami ID with override language", () => {
+		const [resultLanguage, type, searchTerm, inputLanguage] = inputToGetCardArguments("%4007,en", "ja");
+		expect(resultLanguage).toBe("en");
+		expect(type).toBe("konami-id");
+		expect(searchTerm).toBe("4007");
+		expect(inputLanguage).toBeUndefined();
+	});
+	test("Konami ID with whitespace and override language", () => {
+		const [resultLanguage, type, searchTerm, inputLanguage] = inputToGetCardArguments("% 4007  ,en", "ja");
+		expect(resultLanguage).toBe("en");
+		expect(type).toBe("konami-id");
+		expect(searchTerm).toBe("4007");
+		expect(inputLanguage).toBeUndefined();
+	});
+	test("Password", () => {
+		const [resultLanguage, type, searchTerm, inputLanguage] = inputToGetCardArguments("00010000", "ja");
+		expect(resultLanguage).toBe("ja");
+		expect(type).toBe("password");
+		expect(searchTerm).toBe("00010000");
+		expect(inputLanguage).toBeUndefined();
+	});
+	test("Password with override language", () => {
+		const [resultLanguage, type, searchTerm, inputLanguage] = inputToGetCardArguments("00010000,zh-CN", "ja");
+		expect(resultLanguage).toBe("zh-CN");
+		expect(type).toBe("password");
+		expect(searchTerm).toBe("00010000");
+		expect(inputLanguage).toBeUndefined();
+	});
+	test("Card name", () => {
+		const [resultLanguage, type, searchTerm, inputLanguage] = inputToGetCardArguments("blue-eyes", "en");
+		expect(resultLanguage).toBe("en");
+		expect(type).toBe("name");
+		expect(searchTerm).toBe("blue-eyes");
+		expect(inputLanguage).toBe("en");
+	});
+	test("Card name starting with a number", () => {
+		const [resultLanguage, type, searchTerm, inputLanguage] = inputToGetCardArguments("7 colored fish", "en");
+		expect(resultLanguage).toBe("en");
+		expect(type).toBe("name");
+		expect(searchTerm).toBe("7 colored fish");
+		expect(inputLanguage).toBe("en");
+	});
+	test("Card name with input language", () => {
+		const [resultLanguage, type, searchTerm, inputLanguage] = inputToGetCardArguments("baguette,fr", "en");
+		expect(resultLanguage).toBe("en");
+		expect(type).toBe("name");
+		expect(searchTerm).toBe("baguette");
+		expect(inputLanguage).toBe("fr");
+	});
+	test("Card name with input and result language", () => {
+		const [resultLanguage, type, searchTerm, inputLanguage] = inputToGetCardArguments("blue-eyes,en,ja", "fr");
+		expect(resultLanguage).toBe("ja");
+		expect(type).toBe("name");
+		expect(searchTerm).toBe("blue-eyes");
+		expect(inputLanguage).toBe("en");
 	});
 });

--- a/test/events/message.spec.ts
+++ b/test/events/message.spec.ts
@@ -1,5 +1,5 @@
 import { Message } from "discord.js";
-import { MessageListener } from "../../src/events";
+import { PingMessageListener } from "../../src/events";
 import { Locale, LocaleProvider } from "../../src/locale";
 
 const { Message: MockMessage, MessageMentions } = jest.createMockFromModule("discord.js");
@@ -24,7 +24,7 @@ class MockLocaleProvider extends LocaleProvider {
 }
 
 describe("Message event listener", () => {
-	const listener = new MessageListener(new MockLocaleProvider());
+	const listener = new PingMessageListener(new MockLocaleProvider());
 
 	let message: Message;
 	const user = {};

--- a/yarn.lock
+++ b/yarn.lock
@@ -1627,6 +1627,25 @@
   resolved "https://registry.yarnpkg.com/@types/prettier/-/prettier-2.6.4.tgz#ad899dad022bab6b5a9f0a0fe67c2f7a4a8950ed"
   integrity sha512-fOwvpvQYStpb/zHMx0Cauwywu9yLDmzWiiQBC7gJyq5tYLUXFZvDG7VK1B7WBxxjBJNKFOZ0zLoOQn8vmATbhw==
 
+"@types/prop-types@*":
+  version "15.7.5"
+  resolved "https://registry.yarnpkg.com/@types/prop-types/-/prop-types-15.7.5.tgz#5f19d2b85a98e9558036f6a3cacc8819420f05cf"
+  integrity sha512-JCB8C6SnDoQf0cNycqd/35A7MjcnK+ZTqE7judS6o7utxUCg6imJg3QK2qzHKszlTjcj2cn+NwMB2i96ubpj7w==
+
+"@types/react@>=16.0.0":
+  version "18.0.21"
+  resolved "https://registry.yarnpkg.com/@types/react/-/react-18.0.21.tgz#b8209e9626bb00a34c76f55482697edd2b43cc67"
+  integrity sha512-7QUCOxvFgnD5Jk8ZKlUAhVcRj7GuJRjnjjiY/IUBWKgOlnvDvTMLD4RTF7NPyVmbRhNrbomZiOepg7M/2Kj1mA==
+  dependencies:
+    "@types/prop-types" "*"
+    "@types/scheduler" "*"
+    csstype "^3.0.2"
+
+"@types/scheduler@*":
+  version "0.16.2"
+  resolved "https://registry.yarnpkg.com/@types/scheduler/-/scheduler-0.16.2.tgz#1a62f89525723dde24ba1b01b092bf5df8ad4d39"
+  integrity sha512-hppQEBDmlwhFAXKJX2KnWLYu5yMfi91yazPb2l+lbJiwW+wdo1gNeRA+3RgNSO39WYX2euey41KEwnqesU2Jew==
+
 "@types/stack-utils@^2.0.0":
   version "2.0.1"
   resolved "https://registry.yarnpkg.com/@types/stack-utils/-/stack-utils-2.0.1.tgz#20f18294f797f2209b5f65c8e3b5c8e8261d127c"
@@ -2354,6 +2373,11 @@ cross-spawn@^7.0.2, cross-spawn@^7.0.3:
     shebang-command "^2.0.0"
     which "^2.0.1"
 
+csstype@^3.0.2:
+  version "3.1.1"
+  resolved "https://registry.yarnpkg.com/csstype/-/csstype-3.1.1.tgz#841b532c45c758ee546a11d5bd7b7b473c8c30b9"
+  integrity sha512-DJR/VvkAvSZW9bTouZue2sSxDwdTN92uHjqeKVm+0dAqdfNykRzQ95tay8aXMBAAPpUiq4Qcug2L7neoRh2Egw==
+
 debug@^4.1.0, debug@^4.1.1, debug@^4.3.2, debug@^4.3.4:
   version "4.3.4"
   resolved "https://registry.yarnpkg.com/debug/-/debug-4.3.4.tgz#1319f6579357f2338d3337d2cdd4914bb5dcc865"
@@ -2472,6 +2496,14 @@ discord-api-types@^0.37.3:
   version "0.37.4"
   resolved "https://registry.yarnpkg.com/discord-api-types/-/discord-api-types-0.37.4.tgz#fe36f37114c944e7178ee7f878f2638326f3d266"
   integrity sha512-QgqYlUokWM++hdwvAtgVNLjmFumPBzFy+uWnnfVDiwBXKm+5jXHJPk2lx2eilkv/706UpAJPLSk/uVCY9NocjA==
+
+discord-markdown@2.5.1:
+  version "2.5.1"
+  resolved "https://registry.yarnpkg.com/discord-markdown/-/discord-markdown-2.5.1.tgz#d18773c6e3cff8df90f305654ecbbc5e38c507eb"
+  integrity sha512-SGNlL1Y8NYjY2MA5Vj1SI5+Ue5GUW2HkkDAq5jPQ6fI5j/rwOB814lFNhfs2AJMT72Jij8usTEqWZfdU8C3uag==
+  dependencies:
+    highlight.js "^11.2.0"
+    simple-markdown "^0.7.3"
 
 discord.js@^14.4.0:
   version "14.4.0"
@@ -3079,6 +3111,11 @@ has@^1.0.3:
   integrity sha512-f2dvO0VU6Oej7RkWJGrehjbzMAjFp5/VKPp5tTpWIV4JHHZK1/BxbFRtf/siA2SWTe09caDmVtYYzWEIbBS4zw==
   dependencies:
     function-bind "^1.1.1"
+
+highlight.js@^11.2.0:
+  version "11.6.0"
+  resolved "https://registry.yarnpkg.com/highlight.js/-/highlight.js-11.6.0.tgz#a50e9da05763f1bb0c1322c8f4f755242cff3f5a"
+  integrity sha512-ig1eqDzJaB0pqEvlPVIpSSyMaO92bH1N2rJpLMN/nX396wTpDA4Eq0uK+7I/2XG17pFaaKE0kjV/XPeGt7Evjw==
 
 html-escaper@^2.0.0:
   version "2.0.2"
@@ -4618,6 +4655,13 @@ simple-get@^4.0.0:
     decompress-response "^6.0.0"
     once "^1.3.1"
     simple-concat "^1.0.0"
+
+simple-markdown@^0.7.3:
+  version "0.7.3"
+  resolved "https://registry.yarnpkg.com/simple-markdown/-/simple-markdown-0.7.3.tgz#e32150b2ec6f8287197d09869fd928747a9c5640"
+  integrity sha512-uGXIc13NGpqfPeFJIt/7SHHxd6HekEJYtsdoCM06mEBPL9fQH/pSD7LRM6PZ7CKchpSvxKL4tvwMamqAaNDAyg==
+  dependencies:
+    "@types/react" ">=16.0.0"
 
 sisteransi@^1.0.5:
   version "1.0.5"


### PR DESCRIPTION
- Ignores more markup (correctly) than old Bastion
- Will not trigger on Slash Command or timestamp mentions
- Delimiter overrides hardcoded for five servers
- Doubled delimiters for `<`, `[`, and `=` are still ignored
- Hyperlinks, "(", and "anime" are skipped
- Only the first three matches are searched, and the above don't count. This is a departure from too many attempted searches entirely rejecting
- Language overrides by trailing `,lang` and `,lang,lang` work, but a single language in card name mode does not change the result language from the current setting, only the input language
- Konami ID search supported by prefixing numeric query with `%`
- Reactions still added and removed if possible

#152 

https://github.com/AlphaKretin/bastion-bot/blob/master/modules/cardSearch.ts