### PR TITLE
Improve logging behaviour for reactions

### DIFF
--- a/src/events/message-search.ts
+++ b/src/events/message-search.ts
@@ -300,7 +300,9 @@ export class SearchMessageListener implements Listener<"messageCreate"> {
 		try {
 			return await message.reactions.cache.get(reaction)?.users.remove(message.client.user);
 		} catch (error) {
-			if (!(error instanceof DiscordAPIError && error.code === RESTJSONErrorCodes.UnknownMessage)) {
+			if (error instanceof DiscordAPIError && error.code === RESTJSONErrorCodes.UnknownMessage) {
+				this.log("info", message, "Message deleted before removing reaction");
+			} else {
 				this.log("warn", message, error);
 			}
 		}

--- a/src/events/message-search.ts
+++ b/src/events/message-search.ts
@@ -277,7 +277,7 @@ export class SearchMessageListener implements Listener<"messageCreate"> {
 	async addReaction(message: Message, reaction: EmojiIdentifierResolvable): Promise<MessageReaction | undefined> {
 		if (message.inGuild() && message.guild.members.me) {
 			if (!message.guild.members.me.permissionsIn(message.channel).has(PermissionsBitField.Flags.AddReactions)) {
-				this.log("info", message, "No permission to add reactions");
+				this.log("info", message, "Missing permissions to add reactions");
 				return;
 			}
 		}

--- a/src/events/message-search.ts
+++ b/src/events/message-search.ts
@@ -277,6 +277,7 @@ export class SearchMessageListener implements Listener<"messageCreate"> {
 	async addReaction(message: Message, reaction: EmojiIdentifierResolvable): Promise<MessageReaction | undefined> {
 		if (message.inGuild() && message.guild.members.me) {
 			if (!message.guild.members.me.permissionsIn(message.channel).has(PermissionsBitField.Flags.AddReactions)) {
+				this.log("info", message, "No permission to add reactions");
 				return;
 			}
 		}


### PR DESCRIPTION
Do a cache permission check first to avoid the overhead of attempting to react (HTTP REST call).
Additionally send a typing indicator to indicate 🤔 ⏲️ 
Only log at warning level if the error on reacting was not missing permissions or being blocked by the requester.
Only log at warning level if the error on removal was not the message being deleted.

Closes #191 