### PR TITLE
Display placeholder IDs in card embed footer

### DIFF
--- a/src/card.ts
+++ b/src/card.ts
@@ -246,7 +246,7 @@ function formatFooter(card: Static<typeof CardSchema>): EmbedFooterOptions {
 	}
 	if (card.fake_password) {
 		text += "\n";
-		text += t`Fake password: ${card.fake_password}`;
+		text += t`Placeholder ID: ${card.fake_password}`;
 	}
 	return { text };
 }

--- a/src/card.ts
+++ b/src/card.ts
@@ -1,5 +1,5 @@
 import { Static } from "@sinclair/typebox";
-import { ChatInputCommandInteraction, EmbedBuilder } from "discord.js";
+import { ChatInputCommandInteraction, EmbedBuilder, EmbedFooterOptions } from "discord.js";
 import { parseDocument } from "htmlparser2";
 import fetch from "node-fetch";
 import { c, t, useLocale } from "ttag";
@@ -233,6 +233,24 @@ function formatCardText(text: Static<typeof CardSchema>["text"], lang: Locale): 
 	return text[lang] || text.en || "\u200b";
 }
 
+function formatFooter(card: Static<typeof CardSchema>): EmbedFooterOptions {
+	let text = "";
+	if (card.password && card.konami_id) {
+		text = t`Password: ${card.password} | Konami ID #${card.konami_id}`;
+	} else if (!card.password && card.konami_id) {
+		text = t`No password | Konami ID #${card.konami_id}`;
+	} else if (card.password && !card.konami_id) {
+		text = t`Password: ${card.password} | Not yet released`;
+	} else {
+		text = t`Not yet released`;
+	}
+	if (card.fake_password) {
+		text += "\n";
+		text += t`Fake password: ${card.fake_password}`;
+	}
+	return { text };
+}
+
 export function createCardEmbed(card: Static<typeof CardSchema>, lang: Locale): EmbedBuilder[] {
 	useLocale(lang);
 
@@ -351,8 +369,7 @@ export function createCardEmbed(card: Static<typeof CardSchema>, lang: Locale): 
 				.setColor(Colour.Spell)
 				.addFields({ name: c("card-embed").t`Card Text`, value: formatCardText(card.text, lang) })
 				.addFields(links)
-				// one or both may be null to due data corruption or prereleases
-				.setFooter({ text: t`Password: ${card.password} | Konami ID #${card.konami_id}` });
+				.setFooter(formatFooter(card));
 
 			// exclusive Pendulum return path
 			return [embed, addon];
@@ -369,8 +386,7 @@ export function createCardEmbed(card: Static<typeof CardSchema>, lang: Locale): 
 	}
 
 	embed.addFields(links);
-	// one or both may be null to due data corruption or prereleases
-	embed.setFooter({ text: t`Password: ${card.password} | Konami ID #${card.konami_id}` });
+	embed.setFooter(formatFooter(card));
 
 	return [embed];
 }

--- a/translations/de.po
+++ b/translations/de.po
@@ -6,33 +6,33 @@ msgstr ""
 "MIME-Version: 1.0\n"
 "Content-Transfer-Encoding: 8bit\n"
 
-#: src\card.ts:253
+#: src\card.ts:271
 msgid ":link: Links"
 msgstr ""
 
-#: src\card.ts:254
+#: src\card.ts:272
 #, javascript-format
 msgid ""
 "[Official Konami DB](${ official }) | [OCG Rulings](${ rulings }) | "
 "[Yugipedia](${ yugipedia }) | [YGOPRODECK](${ ygoprodeck })"
 msgstr ""
 
-#: src\card.ts:257
+#: src\card.ts:275
 #, javascript-format
 msgid "[Yugipedia](${ yugipedia }) | [YGOPRODECK](${ ygoprodeck })"
 msgstr ""
 
-#: src\card.ts:317
+#: src\card.ts:335
 #, javascript-format
 msgid "**Type**: ${ RaceIcon[race] } ${ localizedMonsterTypeLine }"
 msgstr "**Typ**: ${ RaceIcon[race] } ${ localizedMonsterTypeLine }"
 
-#: src\card.ts:319
+#: src\card.ts:337
 #, javascript-format
 msgid "**Attribute**: ${ AttributeIcon[card.attribute] } ${ localizedAttribute }"
 msgstr "**Eigenschaft**: ${ AttributeIcon[card.attribute] } ${ localizedAttribute }"
 
-#: src\card.ts:323
+#: src\card.ts:341
 msgid ""
 "**Rank**: ${ Icon.Rank } ${ card.rank } **ATK**: ${ card.atk } **DEF**: ${ "
 "card.def }"
@@ -40,14 +40,14 @@ msgstr ""
 "**Rang**: ${ Icon.Rank } ${ card.rank } **ATK**: ${ card.atk } **DEF**: ${ "
 "card.def }"
 
-#: src\card.ts:326
+#: src\card.ts:344
 #, javascript-format
 msgid ""
 "**Link Rating**: ${ card.link_arrows.length } **ATK**: ${ card.atk } **Link "
 "Arrows**: ${ arrows }"
 msgstr ""
 
-#: src\card.ts:328
+#: src\card.ts:346
 #, javascript-format
 msgid ""
 "**Level**: ${ Icon.Level } ${ card.level } **ATK**: ${ card.atk } **DEF**: "
@@ -56,14 +56,31 @@ msgstr ""
 "**Stufe**: ${ Icon.Level } ${ card.level } **ATK**: ${ card.atk } **DEF**: "
 "${ card.def }"
 
-#: src\card.ts:335
+#: src\card.ts:353
 msgid "**Pendulum Scale**: ${ formattedScale }"
 msgstr "**Pendelbereich**: ${ formattedScale }"
 
-#: src\card.ts:355
-#: src\card.ts:373
+#: src\card.ts:239
 #, javascript-format
 msgid "Password: ${ card.password } | Konami ID #${ card.konami_id }"
+msgstr ""
+
+#: src\card.ts:241
+msgid "No password | Konami ID #${ card.konami_id }"
+msgstr ""
+
+#: src\card.ts:243
+#, javascript-format
+msgid "Password: ${ card.password } | Not yet released"
+msgstr ""
+
+#: src\card.ts:245
+msgid "Not yet released"
+msgstr ""
+
+#: src\card.ts:249
+#, javascript-format
+msgid "Fake password: ${ card.fake_password }"
 msgstr ""
 
 #: src\utils.ts:33
@@ -125,7 +142,7 @@ msgstr ""
 #: src\commands\art.ts:97
 #: src\commands\price.ts:148
 #: src\commands\search.ts:90
-#: src\events\message-search.ts:238
+#: src\events\message-search.ts:241
 #, javascript-format
 msgid "Could not find a card matching `${ input }`!"
 msgstr ""
@@ -134,64 +151,64 @@ msgstr ""
 msgid "Could not find art for `${ name }`!"
 msgstr ""
 
-#: src\commands\deck.ts:236
+#: src\commands\deck.ts:245
 #, javascript-format
 msgid "${ counts.Monster } Monster"
 msgid_plural "${ counts.Monster } Monsters"
 msgstr[0] ""
 msgstr[1] ""
 
-#: src\commands\deck.ts:239
+#: src\commands\deck.ts:248
 msgid "${ counts.Spell } Spell"
 msgid_plural "${ counts.Spell } Spells"
 msgstr[0] ""
 msgstr[1] ""
 
-#: src\commands\deck.ts:242
+#: src\commands\deck.ts:251
 #, javascript-format
 msgid "${ counts.Trap } Trap"
 msgid_plural "${ counts.Trap } Traps"
 msgstr[0] ""
 msgstr[1] ""
 
-#: src\commands\deck.ts:270
+#: src\commands\deck.ts:279
 msgid "Your Deck"
 msgstr ""
 
-#: src\commands\deck.ts:275
+#: src\commands\deck.ts:284
 #, javascript-format
 msgid "Main Deck (${ deck.main.length } card — ${ countDetail })"
 msgid_plural "Main Deck (${ deck.main.length } cards — ${ countDetail })"
 msgstr[0] ""
 msgstr[1] ""
 
-#: src\commands\deck.ts:282
+#: src\commands\deck.ts:291
 msgid "Main Deck (continued)"
 msgstr ""
 
-#: src\commands\deck.ts:289
+#: src\commands\deck.ts:298
 #, javascript-format
 msgid "Extra Deck (${ deck.extra.length } card — ${ _countDetail })"
 msgid_plural "Extra Deck (${ deck.extra.length } cards — ${ _countDetail })"
 msgstr[0] ""
 msgstr[1] ""
 
-#: src\commands\deck.ts:296
+#: src\commands\deck.ts:305
 msgid "Extra Deck (continued)"
 msgstr ""
 
-#: src\commands\deck.ts:303
+#: src\commands\deck.ts:312
 #, javascript-format
 msgid "Side Deck (${ deck.side.length } card — ${ _countDetail2 })"
 msgid_plural "Side Deck (${ deck.side.length } cards — ${ _countDetail2 })"
 msgstr[0] ""
 msgstr[1] ""
 
-#: src\commands\deck.ts:310
+#: src\commands\deck.ts:319
 msgid "Side Deck (continued)"
 msgstr ""
 
-#: src\commands\deck.ts:400
+#: src\commands\deck.ts:409
 msgid "Error: Your deck is empty."
 msgstr ""
 
@@ -308,19 +325,19 @@ msgstr ""
 msgid "Revision: ${ process.env.BOT_REVISION }."
 msgstr ""
 
-#: src\commands\deck.ts:320
+#: src\commands\deck.ts:329
 msgid ".ydk files must have the .ydk extension!"
 msgstr ""
 
-#: src\commands\deck.ts:323
+#: src\commands\deck.ts:332
 msgid ".ydk files should not be larger than 1 KB!"
 msgstr ""
 
-#: src\commands\deck.ts:313
+#: src\commands\deck.ts:322
 msgid "ydke URL"
 msgstr ""
 
-#: src\card.ts:291
+#: src\card.ts:309
 #. Forbidden/Limited Lists or Limit Regulations in the OCG
 msgid "**Limit**: ${ limitRegulationDisplay }"
 msgstr ""
@@ -355,22 +372,22 @@ msgstr ""
 msgid "Could not find prices for `${ name }`!"
 msgstr ""
 
-#: src\commands\deck.ts:418
+#: src\commands\deck.ts:427
 #. prepare interaction button for FTP upload
 msgid "Upload to YGOPRODECK"
 msgstr ""
 
-#: src\commands\deck.ts:469
+#: src\commands\deck.ts:478
 #. disable original button
 #. prepare row to disable button on original message
 msgid "Upload Complete"
 msgstr ""
 
-#: src\commands\deck.ts:456
+#: src\commands\deck.ts:465
 msgid "Deck upload failed!"
 msgstr ""
 
-#: src\commands\deck.ts:477
+#: src\commands\deck.ts:486
 #. reply in affirmation
 #, javascript-format
 msgid "Deck successfully uploaded to <${ url }>!"
@@ -698,18 +715,18 @@ msgctxt "attribute"
 msgid "DIVINE"
 msgstr "GÖTTLICH"
 
-#: src\card.ts:341
-#: src\card.ts:352
+#: src\card.ts:359
+#: src\card.ts:370
 msgctxt "card-embed"
 msgid "Card Text"
 msgstr "Kartentext"
 
-#: src\card.ts:346
+#: src\card.ts:364
 msgctxt "card-embed"
 msgid "Pendulum Effect"
 msgstr "Pendeleffekt"
 
-#: src\card.ts:368
+#: src\card.ts:385
 msgctxt "card-embed"
 msgid "Card Effect"
 msgstr ""

--- a/translations/de.po
+++ b/translations/de.po
@@ -80,7 +80,7 @@ msgstr ""
 
 #: src\card.ts:249
 #, javascript-format
-msgid "Fake password: ${ card.fake_password }"
+msgid "Placeholder ID: ${ card.fake_password }"
 msgstr ""
 
 #: src\utils.ts:33

--- a/translations/es.po
+++ b/translations/es.po
@@ -80,7 +80,7 @@ msgstr ""
 
 #: src\card.ts:249
 #, javascript-format
-msgid "Fake password: ${ card.fake_password }"
+msgid "Placeholder ID: ${ card.fake_password }"
 msgstr ""
 
 #: src\utils.ts:33

--- a/translations/es.po
+++ b/translations/es.po
@@ -6,33 +6,33 @@ msgstr ""
 "MIME-Version: 1.0\n"
 "Content-Transfer-Encoding: 8bit\n"
 
-#: src\card.ts:253
+#: src\card.ts:271
 msgid ":link: Links"
 msgstr ""
 
-#: src\card.ts:254
+#: src\card.ts:272
 #, javascript-format
 msgid ""
 "[Official Konami DB](${ official }) | [OCG Rulings](${ rulings }) | "
 "[Yugipedia](${ yugipedia }) | [YGOPRODECK](${ ygoprodeck })"
 msgstr ""
 
-#: src\card.ts:257
+#: src\card.ts:275
 #, javascript-format
 msgid "[Yugipedia](${ yugipedia }) | [YGOPRODECK](${ ygoprodeck })"
 msgstr ""
 
-#: src\card.ts:317
+#: src\card.ts:335
 #, javascript-format
 msgid "**Type**: ${ RaceIcon[race] } ${ localizedMonsterTypeLine }"
 msgstr "**Tipo**: ${ RaceIcon[race] } ${ localizedMonsterTypeLine }"
 
-#: src\card.ts:319
+#: src\card.ts:337
 #, javascript-format
 msgid "**Attribute**: ${ AttributeIcon[card.attribute] } ${ localizedAttribute }"
 msgstr "**Atributo**: ${ AttributeIcon[card.attribute] } ${ localizedAttribute }"
 
-#: src\card.ts:323
+#: src\card.ts:341
 msgid ""
 "**Rank**: ${ Icon.Rank } ${ card.rank } **ATK**: ${ card.atk } **DEF**: ${ "
 "card.def }"
@@ -40,14 +40,14 @@ msgstr ""
 "**Rango**: ${ Icon.Rank } ${ card.rank } **ATK**: ${ card.atk } **DEF**: ${ "
 "card.def }"
 
-#: src\card.ts:326
+#: src\card.ts:344
 #, javascript-format
 msgid ""
 "**Link Rating**: ${ card.link_arrows.length } **ATK**: ${ card.atk } **Link "
 "Arrows**: ${ arrows }"
 msgstr ""
 
-#: src\card.ts:328
+#: src\card.ts:346
 #, javascript-format
 msgid ""
 "**Level**: ${ Icon.Level } ${ card.level } **ATK**: ${ card.atk } **DEF**: "
@@ -56,14 +56,31 @@ msgstr ""
 "**Nivel**: ${ Icon.Level } ${ card.level } **ATK**: ${ card.atk } **DEF**: "
 "${ card.def }"
 
-#: src\card.ts:335
+#: src\card.ts:353
 msgid "**Pendulum Scale**: ${ formattedScale }"
 msgstr "**Escala de Péndulo**: ${ formattedScale }"
 
-#: src\card.ts:355
-#: src\card.ts:373
+#: src\card.ts:239
 #, javascript-format
 msgid "Password: ${ card.password } | Konami ID #${ card.konami_id }"
+msgstr ""
+
+#: src\card.ts:241
+msgid "No password | Konami ID #${ card.konami_id }"
+msgstr ""
+
+#: src\card.ts:243
+#, javascript-format
+msgid "Password: ${ card.password } | Not yet released"
+msgstr ""
+
+#: src\card.ts:245
+msgid "Not yet released"
+msgstr ""
+
+#: src\card.ts:249
+#, javascript-format
+msgid "Fake password: ${ card.fake_password }"
 msgstr ""
 
 #: src\utils.ts:33
@@ -125,7 +142,7 @@ msgstr ""
 #: src\commands\art.ts:97
 #: src\commands\price.ts:148
 #: src\commands\search.ts:90
-#: src\events\message-search.ts:238
+#: src\events\message-search.ts:241
 #, javascript-format
 msgid "Could not find a card matching `${ input }`!"
 msgstr ""
@@ -134,64 +151,64 @@ msgstr ""
 msgid "Could not find art for `${ name }`!"
 msgstr ""
 
-#: src\commands\deck.ts:236
+#: src\commands\deck.ts:245
 #, javascript-format
 msgid "${ counts.Monster } Monster"
 msgid_plural "${ counts.Monster } Monsters"
 msgstr[0] ""
 msgstr[1] ""
 
-#: src\commands\deck.ts:239
+#: src\commands\deck.ts:248
 msgid "${ counts.Spell } Spell"
 msgid_plural "${ counts.Spell } Spells"
 msgstr[0] ""
 msgstr[1] ""
 
-#: src\commands\deck.ts:242
+#: src\commands\deck.ts:251
 #, javascript-format
 msgid "${ counts.Trap } Trap"
 msgid_plural "${ counts.Trap } Traps"
 msgstr[0] ""
 msgstr[1] ""
 
-#: src\commands\deck.ts:270
+#: src\commands\deck.ts:279
 msgid "Your Deck"
 msgstr ""
 
-#: src\commands\deck.ts:275
+#: src\commands\deck.ts:284
 #, javascript-format
 msgid "Main Deck (${ deck.main.length } card — ${ countDetail })"
 msgid_plural "Main Deck (${ deck.main.length } cards — ${ countDetail })"
 msgstr[0] ""
 msgstr[1] ""
 
-#: src\commands\deck.ts:282
+#: src\commands\deck.ts:291
 msgid "Main Deck (continued)"
 msgstr ""
 
-#: src\commands\deck.ts:289
+#: src\commands\deck.ts:298
 #, javascript-format
 msgid "Extra Deck (${ deck.extra.length } card — ${ _countDetail })"
 msgid_plural "Extra Deck (${ deck.extra.length } cards — ${ _countDetail })"
 msgstr[0] ""
 msgstr[1] ""
 
-#: src\commands\deck.ts:296
+#: src\commands\deck.ts:305
 msgid "Extra Deck (continued)"
 msgstr ""
 
-#: src\commands\deck.ts:303
+#: src\commands\deck.ts:312
 #, javascript-format
 msgid "Side Deck (${ deck.side.length } card — ${ _countDetail2 })"
 msgid_plural "Side Deck (${ deck.side.length } cards — ${ _countDetail2 })"
 msgstr[0] ""
 msgstr[1] ""
 
-#: src\commands\deck.ts:310
+#: src\commands\deck.ts:319
 msgid "Side Deck (continued)"
 msgstr ""
 
-#: src\commands\deck.ts:400
+#: src\commands\deck.ts:409
 msgid "Error: Your deck is empty."
 msgstr ""
 
@@ -308,19 +325,19 @@ msgstr ""
 msgid "Revision: ${ process.env.BOT_REVISION }."
 msgstr ""
 
-#: src\commands\deck.ts:320
+#: src\commands\deck.ts:329
 msgid ".ydk files must have the .ydk extension!"
 msgstr ""
 
-#: src\commands\deck.ts:323
+#: src\commands\deck.ts:332
 msgid ".ydk files should not be larger than 1 KB!"
 msgstr ""
 
-#: src\commands\deck.ts:313
+#: src\commands\deck.ts:322
 msgid "ydke URL"
 msgstr ""
 
-#: src\card.ts:291
+#: src\card.ts:309
 #. Forbidden/Limited Lists or Limit Regulations in the OCG
 msgid "**Limit**: ${ limitRegulationDisplay }"
 msgstr ""
@@ -355,22 +372,22 @@ msgstr ""
 msgid "Could not find prices for `${ name }`!"
 msgstr ""
 
-#: src\commands\deck.ts:418
+#: src\commands\deck.ts:427
 #. prepare interaction button for FTP upload
 msgid "Upload to YGOPRODECK"
 msgstr ""
 
-#: src\commands\deck.ts:469
+#: src\commands\deck.ts:478
 #. disable original button
 #. prepare row to disable button on original message
 msgid "Upload Complete"
 msgstr ""
 
-#: src\commands\deck.ts:456
+#: src\commands\deck.ts:465
 msgid "Deck upload failed!"
 msgstr ""
 
-#: src\commands\deck.ts:477
+#: src\commands\deck.ts:486
 #. reply in affirmation
 #, javascript-format
 msgid "Deck successfully uploaded to <${ url }>!"
@@ -698,18 +715,18 @@ msgctxt "attribute"
 msgid "DIVINE"
 msgstr "DIVINIDAD"
 
-#: src\card.ts:341
-#: src\card.ts:352
+#: src\card.ts:359
+#: src\card.ts:370
 msgctxt "card-embed"
 msgid "Card Text"
 msgstr "Texto de carta"
 
-#: src\card.ts:346
+#: src\card.ts:364
 msgctxt "card-embed"
 msgid "Pendulum Effect"
 msgstr "Efecto de Péndulo"
 
-#: src\card.ts:368
+#: src\card.ts:385
 msgctxt "card-embed"
 msgid "Card Effect"
 msgstr ""

--- a/translations/fr.po
+++ b/translations/fr.po
@@ -80,7 +80,7 @@ msgstr ""
 
 #: src\card.ts:249
 #, javascript-format
-msgid "Fake password: ${ card.fake_password }"
+msgid "Placeholder ID: ${ card.fake_password }"
 msgstr ""
 
 #: src\utils.ts:33

--- a/translations/fr.po
+++ b/translations/fr.po
@@ -6,33 +6,33 @@ msgstr ""
 "MIME-Version: 1.0\n"
 "Content-Transfer-Encoding: 8bit\n"
 
-#: src\card.ts:253
+#: src\card.ts:271
 msgid ":link: Links"
 msgstr ""
 
-#: src\card.ts:254
+#: src\card.ts:272
 #, javascript-format
 msgid ""
 "[Official Konami DB](${ official }) | [OCG Rulings](${ rulings }) | "
 "[Yugipedia](${ yugipedia }) | [YGOPRODECK](${ ygoprodeck })"
 msgstr ""
 
-#: src\card.ts:257
+#: src\card.ts:275
 #, javascript-format
 msgid "[Yugipedia](${ yugipedia }) | [YGOPRODECK](${ ygoprodeck })"
 msgstr ""
 
-#: src\card.ts:317
+#: src\card.ts:335
 #, javascript-format
 msgid "**Type**: ${ RaceIcon[race] } ${ localizedMonsterTypeLine }"
 msgstr "**Type**: ${ RaceIcon[race] } ${ localizedMonsterTypeLine }"
 
-#: src\card.ts:319
+#: src\card.ts:337
 #, javascript-format
 msgid "**Attribute**: ${ AttributeIcon[card.attribute] } ${ localizedAttribute }"
 msgstr "**Attribut**: ${ AttributeIcon[card.attribute] } ${ localizedAttribute }"
 
-#: src\card.ts:323
+#: src\card.ts:341
 msgid ""
 "**Rank**: ${ Icon.Rank } ${ card.rank } **ATK**: ${ card.atk } **DEF**: ${ "
 "card.def }"
@@ -40,14 +40,14 @@ msgstr ""
 "**Rang**: ${ Icon.Rank } ${ card.rank } **ATK**: ${ card.atk } **DEF**: ${ "
 "card.def }"
 
-#: src\card.ts:326
+#: src\card.ts:344
 #, javascript-format
 msgid ""
 "**Link Rating**: ${ card.link_arrows.length } **ATK**: ${ card.atk } **Link "
 "Arrows**: ${ arrows }"
 msgstr ""
 
-#: src\card.ts:328
+#: src\card.ts:346
 #, javascript-format
 msgid ""
 "**Level**: ${ Icon.Level } ${ card.level } **ATK**: ${ card.atk } **DEF**: "
@@ -56,14 +56,31 @@ msgstr ""
 "**Niveau**: ${ Icon.Level } ${ card.level } **ATK**: ${ card.atk } **DEF**: "
 "${ card.def }"
 
-#: src\card.ts:335
+#: src\card.ts:353
 msgid "**Pendulum Scale**: ${ formattedScale }"
 msgstr "**Échelle Pendule**: ${ formattedScale }"
 
-#: src\card.ts:355
-#: src\card.ts:373
+#: src\card.ts:239
 #, javascript-format
 msgid "Password: ${ card.password } | Konami ID #${ card.konami_id }"
+msgstr ""
+
+#: src\card.ts:241
+msgid "No password | Konami ID #${ card.konami_id }"
+msgstr ""
+
+#: src\card.ts:243
+#, javascript-format
+msgid "Password: ${ card.password } | Not yet released"
+msgstr ""
+
+#: src\card.ts:245
+msgid "Not yet released"
+msgstr ""
+
+#: src\card.ts:249
+#, javascript-format
+msgid "Fake password: ${ card.fake_password }"
 msgstr ""
 
 #: src\utils.ts:33
@@ -125,7 +142,7 @@ msgstr ""
 #: src\commands\art.ts:97
 #: src\commands\price.ts:148
 #: src\commands\search.ts:90
-#: src\events\message-search.ts:238
+#: src\events\message-search.ts:241
 #, javascript-format
 msgid "Could not find a card matching `${ input }`!"
 msgstr ""
@@ -134,64 +151,64 @@ msgstr ""
 msgid "Could not find art for `${ name }`!"
 msgstr ""
 
-#: src\commands\deck.ts:236
+#: src\commands\deck.ts:245
 #, javascript-format
 msgid "${ counts.Monster } Monster"
 msgid_plural "${ counts.Monster } Monsters"
 msgstr[0] ""
 msgstr[1] ""
 
-#: src\commands\deck.ts:239
+#: src\commands\deck.ts:248
 msgid "${ counts.Spell } Spell"
 msgid_plural "${ counts.Spell } Spells"
 msgstr[0] ""
 msgstr[1] ""
 
-#: src\commands\deck.ts:242
+#: src\commands\deck.ts:251
 #, javascript-format
 msgid "${ counts.Trap } Trap"
 msgid_plural "${ counts.Trap } Traps"
 msgstr[0] ""
 msgstr[1] ""
 
-#: src\commands\deck.ts:270
+#: src\commands\deck.ts:279
 msgid "Your Deck"
 msgstr ""
 
-#: src\commands\deck.ts:275
+#: src\commands\deck.ts:284
 #, javascript-format
 msgid "Main Deck (${ deck.main.length } card — ${ countDetail })"
 msgid_plural "Main Deck (${ deck.main.length } cards — ${ countDetail })"
 msgstr[0] ""
 msgstr[1] ""
 
-#: src\commands\deck.ts:282
+#: src\commands\deck.ts:291
 msgid "Main Deck (continued)"
 msgstr ""
 
-#: src\commands\deck.ts:289
+#: src\commands\deck.ts:298
 #, javascript-format
 msgid "Extra Deck (${ deck.extra.length } card — ${ _countDetail })"
 msgid_plural "Extra Deck (${ deck.extra.length } cards — ${ _countDetail })"
 msgstr[0] ""
 msgstr[1] ""
 
-#: src\commands\deck.ts:296
+#: src\commands\deck.ts:305
 msgid "Extra Deck (continued)"
 msgstr ""
 
-#: src\commands\deck.ts:303
+#: src\commands\deck.ts:312
 #, javascript-format
 msgid "Side Deck (${ deck.side.length } card — ${ _countDetail2 })"
 msgid_plural "Side Deck (${ deck.side.length } cards — ${ _countDetail2 })"
 msgstr[0] ""
 msgstr[1] ""
 
-#: src\commands\deck.ts:310
+#: src\commands\deck.ts:319
 msgid "Side Deck (continued)"
 msgstr ""
 
-#: src\commands\deck.ts:400
+#: src\commands\deck.ts:409
 msgid "Error: Your deck is empty."
 msgstr ""
 
@@ -308,19 +325,19 @@ msgstr ""
 msgid "Revision: ${ process.env.BOT_REVISION }."
 msgstr ""
 
-#: src\commands\deck.ts:320
+#: src\commands\deck.ts:329
 msgid ".ydk files must have the .ydk extension!"
 msgstr ""
 
-#: src\commands\deck.ts:323
+#: src\commands\deck.ts:332
 msgid ".ydk files should not be larger than 1 KB!"
 msgstr ""
 
-#: src\commands\deck.ts:313
+#: src\commands\deck.ts:322
 msgid "ydke URL"
 msgstr ""
 
-#: src\card.ts:291
+#: src\card.ts:309
 #. Forbidden/Limited Lists or Limit Regulations in the OCG
 msgid "**Limit**: ${ limitRegulationDisplay }"
 msgstr ""
@@ -355,22 +372,22 @@ msgstr ""
 msgid "Could not find prices for `${ name }`!"
 msgstr ""
 
-#: src\commands\deck.ts:418
+#: src\commands\deck.ts:427
 #. prepare interaction button for FTP upload
 msgid "Upload to YGOPRODECK"
 msgstr ""
 
-#: src\commands\deck.ts:469
+#: src\commands\deck.ts:478
 #. disable original button
 #. prepare row to disable button on original message
 msgid "Upload Complete"
 msgstr ""
 
-#: src\commands\deck.ts:456
+#: src\commands\deck.ts:465
 msgid "Deck upload failed!"
 msgstr ""
 
-#: src\commands\deck.ts:477
+#: src\commands\deck.ts:486
 #. reply in affirmation
 #, javascript-format
 msgid "Deck successfully uploaded to <${ url }>!"
@@ -698,18 +715,18 @@ msgctxt "attribute"
 msgid "DIVINE"
 msgstr "DIVIN"
 
-#: src\card.ts:341
-#: src\card.ts:352
+#: src\card.ts:359
+#: src\card.ts:370
 msgctxt "card-embed"
 msgid "Card Text"
 msgstr "Texte de carte"
 
-#: src\card.ts:346
+#: src\card.ts:364
 msgctxt "card-embed"
 msgid "Pendulum Effect"
 msgstr "Effet Pendule"
 
-#: src\card.ts:368
+#: src\card.ts:385
 msgctxt "card-embed"
 msgid "Card Effect"
 msgstr ""

--- a/translations/it.po
+++ b/translations/it.po
@@ -6,33 +6,33 @@ msgstr ""
 "MIME-Version: 1.0\n"
 "Content-Transfer-Encoding: 8bit\n"
 
-#: src\card.ts:253
+#: src\card.ts:271
 msgid ":link: Links"
 msgstr ""
 
-#: src\card.ts:254
+#: src\card.ts:272
 #, javascript-format
 msgid ""
 "[Official Konami DB](${ official }) | [OCG Rulings](${ rulings }) | "
 "[Yugipedia](${ yugipedia }) | [YGOPRODECK](${ ygoprodeck })"
 msgstr ""
 
-#: src\card.ts:257
+#: src\card.ts:275
 #, javascript-format
 msgid "[Yugipedia](${ yugipedia }) | [YGOPRODECK](${ ygoprodeck })"
 msgstr ""
 
-#: src\card.ts:317
+#: src\card.ts:335
 #, javascript-format
 msgid "**Type**: ${ RaceIcon[race] } ${ localizedMonsterTypeLine }"
 msgstr "**Tipo**: ${ RaceIcon[race] } ${ localizedMonsterTypeLine }"
 
-#: src\card.ts:319
+#: src\card.ts:337
 #, javascript-format
 msgid "**Attribute**: ${ AttributeIcon[card.attribute] } ${ localizedAttribute }"
 msgstr "**Attributo**: ${ AttributeIcon[card.attribute] } ${ localizedAttribute }"
 
-#: src\card.ts:323
+#: src\card.ts:341
 msgid ""
 "**Rank**: ${ Icon.Rank } ${ card.rank } **ATK**: ${ card.atk } **DEF**: ${ "
 "card.def }"
@@ -40,14 +40,14 @@ msgstr ""
 "**Rango**: ${ Icon.Rank } ${ card.rank } **ATK**: ${ card.atk } **DEF**: ${ "
 "card.def }"
 
-#: src\card.ts:326
+#: src\card.ts:344
 #, javascript-format
 msgid ""
 "**Link Rating**: ${ card.link_arrows.length } **ATK**: ${ card.atk } **Link "
 "Arrows**: ${ arrows }"
 msgstr ""
 
-#: src\card.ts:328
+#: src\card.ts:346
 #, javascript-format
 msgid ""
 "**Level**: ${ Icon.Level } ${ card.level } **ATK**: ${ card.atk } **DEF**: "
@@ -56,14 +56,31 @@ msgstr ""
 "Livello**: ${ Icon.Level } ${ card.level } **ATK**: ${ card.atk } **DEF**: "
 "${ card.def }"
 
-#: src\card.ts:335
+#: src\card.ts:353
 msgid "**Pendulum Scale**: ${ formattedScale }"
 msgstr "**Valore Pendulum**: ${ formattedScale }"
 
-#: src\card.ts:355
-#: src\card.ts:373
+#: src\card.ts:239
 #, javascript-format
 msgid "Password: ${ card.password } | Konami ID #${ card.konami_id }"
+msgstr ""
+
+#: src\card.ts:241
+msgid "No password | Konami ID #${ card.konami_id }"
+msgstr ""
+
+#: src\card.ts:243
+#, javascript-format
+msgid "Password: ${ card.password } | Not yet released"
+msgstr ""
+
+#: src\card.ts:245
+msgid "Not yet released"
+msgstr ""
+
+#: src\card.ts:249
+#, javascript-format
+msgid "Fake password: ${ card.fake_password }"
 msgstr ""
 
 #: src\utils.ts:33
@@ -125,7 +142,7 @@ msgstr ""
 #: src\commands\art.ts:97
 #: src\commands\price.ts:148
 #: src\commands\search.ts:90
-#: src\events\message-search.ts:238
+#: src\events\message-search.ts:241
 #, javascript-format
 msgid "Could not find a card matching `${ input }`!"
 msgstr ""
@@ -134,64 +151,64 @@ msgstr ""
 msgid "Could not find art for `${ name }`!"
 msgstr ""
 
-#: src\commands\deck.ts:236
+#: src\commands\deck.ts:245
 #, javascript-format
 msgid "${ counts.Monster } Monster"
 msgid_plural "${ counts.Monster } Monsters"
 msgstr[0] ""
 msgstr[1] ""
 
-#: src\commands\deck.ts:239
+#: src\commands\deck.ts:248
 msgid "${ counts.Spell } Spell"
 msgid_plural "${ counts.Spell } Spells"
 msgstr[0] ""
 msgstr[1] ""
 
-#: src\commands\deck.ts:242
+#: src\commands\deck.ts:251
 #, javascript-format
 msgid "${ counts.Trap } Trap"
 msgid_plural "${ counts.Trap } Traps"
 msgstr[0] ""
 msgstr[1] ""
 
-#: src\commands\deck.ts:270
+#: src\commands\deck.ts:279
 msgid "Your Deck"
 msgstr ""
 
-#: src\commands\deck.ts:275
+#: src\commands\deck.ts:284
 #, javascript-format
 msgid "Main Deck (${ deck.main.length } card — ${ countDetail })"
 msgid_plural "Main Deck (${ deck.main.length } cards — ${ countDetail })"
 msgstr[0] ""
 msgstr[1] ""
 
-#: src\commands\deck.ts:282
+#: src\commands\deck.ts:291
 msgid "Main Deck (continued)"
 msgstr ""
 
-#: src\commands\deck.ts:289
+#: src\commands\deck.ts:298
 #, javascript-format
 msgid "Extra Deck (${ deck.extra.length } card — ${ _countDetail })"
 msgid_plural "Extra Deck (${ deck.extra.length } cards — ${ _countDetail })"
 msgstr[0] ""
 msgstr[1] ""
 
-#: src\commands\deck.ts:296
+#: src\commands\deck.ts:305
 msgid "Extra Deck (continued)"
 msgstr ""
 
-#: src\commands\deck.ts:303
+#: src\commands\deck.ts:312
 #, javascript-format
 msgid "Side Deck (${ deck.side.length } card — ${ _countDetail2 })"
 msgid_plural "Side Deck (${ deck.side.length } cards — ${ _countDetail2 })"
 msgstr[0] ""
 msgstr[1] ""
 
-#: src\commands\deck.ts:310
+#: src\commands\deck.ts:319
 msgid "Side Deck (continued)"
 msgstr ""
 
-#: src\commands\deck.ts:400
+#: src\commands\deck.ts:409
 msgid "Error: Your deck is empty."
 msgstr ""
 
@@ -308,19 +325,19 @@ msgstr ""
 msgid "Revision: ${ process.env.BOT_REVISION }."
 msgstr ""
 
-#: src\commands\deck.ts:320
+#: src\commands\deck.ts:329
 msgid ".ydk files must have the .ydk extension!"
 msgstr ""
 
-#: src\commands\deck.ts:323
+#: src\commands\deck.ts:332
 msgid ".ydk files should not be larger than 1 KB!"
 msgstr ""
 
-#: src\commands\deck.ts:313
+#: src\commands\deck.ts:322
 msgid "ydke URL"
 msgstr ""
 
-#: src\card.ts:291
+#: src\card.ts:309
 #. Forbidden/Limited Lists or Limit Regulations in the OCG
 msgid "**Limit**: ${ limitRegulationDisplay }"
 msgstr ""
@@ -355,22 +372,22 @@ msgstr ""
 msgid "Could not find prices for `${ name }`!"
 msgstr ""
 
-#: src\commands\deck.ts:418
+#: src\commands\deck.ts:427
 #. prepare interaction button for FTP upload
 msgid "Upload to YGOPRODECK"
 msgstr ""
 
-#: src\commands\deck.ts:469
+#: src\commands\deck.ts:478
 #. disable original button
 #. prepare row to disable button on original message
 msgid "Upload Complete"
 msgstr ""
 
-#: src\commands\deck.ts:456
+#: src\commands\deck.ts:465
 msgid "Deck upload failed!"
 msgstr ""
 
-#: src\commands\deck.ts:477
+#: src\commands\deck.ts:486
 #. reply in affirmation
 #, javascript-format
 msgid "Deck successfully uploaded to <${ url }>!"
@@ -698,18 +715,18 @@ msgctxt "attribute"
 msgid "DIVINE"
 msgstr "DIVINO"
 
-#: src\card.ts:341
-#: src\card.ts:352
+#: src\card.ts:359
+#: src\card.ts:370
 msgctxt "card-embed"
 msgid "Card Text"
 msgstr "Testo carta"
 
-#: src\card.ts:346
+#: src\card.ts:364
 msgctxt "card-embed"
 msgid "Pendulum Effect"
 msgstr "Effetto Pendulum"
 
-#: src\card.ts:368
+#: src\card.ts:385
 msgctxt "card-embed"
 msgid "Card Effect"
 msgstr ""

--- a/translations/it.po
+++ b/translations/it.po
@@ -80,7 +80,7 @@ msgstr ""
 
 #: src\card.ts:249
 #, javascript-format
-msgid "Fake password: ${ card.fake_password }"
+msgid "Placeholder ID: ${ card.fake_password }"
 msgstr ""
 
 #: src\utils.ts:33

--- a/translations/ja.po
+++ b/translations/ja.po
@@ -82,7 +82,7 @@ msgstr ""
 
 #: src\card.ts:249
 #, javascript-format
-msgid "Fake password: ${ card.fake_password }"
+msgid "Placeholder ID: ${ card.fake_password }"
 msgstr ""
 
 #: src\utils.ts:33

--- a/translations/ja.po
+++ b/translations/ja.po
@@ -6,33 +6,33 @@ msgstr ""
 "MIME-Version: 1.0\n"
 "Content-Transfer-Encoding: 8bit\n"
 
-#: src\card.ts:253
+#: src\card.ts:271
 msgid ":link: Links"
 msgstr ""
 
-#: src\card.ts:254
+#: src\card.ts:272
 #, javascript-format
 msgid ""
 "[Official Konami DB](${ official }) | [OCG Rulings](${ rulings }) | "
 "[Yugipedia](${ yugipedia }) | [YGOPRODECK](${ ygoprodeck })"
 msgstr ""
 
-#: src\card.ts:257
+#: src\card.ts:275
 #, javascript-format
 msgid "[Yugipedia](${ yugipedia }) | [YGOPRODECK](${ ygoprodeck })"
 msgstr ""
 
-#: src\card.ts:317
+#: src\card.ts:335
 #, javascript-format
 msgid "**Type**: ${ RaceIcon[race] } ${ localizedMonsterTypeLine }"
 msgstr "**種族**: ${ RaceIcon[race] } ${ localizedMonsterTypeLine }"
 
-#: src\card.ts:319
+#: src\card.ts:337
 #, javascript-format
 msgid "**Attribute**: ${ AttributeIcon[card.attribute] } ${ localizedAttribute }"
 msgstr "**属性**: ${ AttributeIcon[card.attribute] } ${ localizedAttribute }"
 
-#: src\card.ts:323
+#: src\card.ts:341
 msgid ""
 "**Rank**: ${ Icon.Rank } ${ card.rank } **ATK**: ${ card.atk } **DEF**: ${ "
 "card.def }"
@@ -40,7 +40,7 @@ msgstr ""
 "**ランク**: ${ Icon.Rank } ${ card.rank } **攻撃力**: ${ card.atk } **守備力**: ${ "
 "card.def }"
 
-#: src\card.ts:326
+#: src\card.ts:344
 #, javascript-format
 msgid ""
 "**Link Rating**: ${ card.link_arrows.length } **ATK**: ${ card.atk } **Link "
@@ -49,7 +49,7 @@ msgstr ""
 "**リンクの数字分**: ${ card.link_arrows.length } **攻撃力**: ${ card.atk } "
 "**リンクマーカー**: ${ arrows }"
 
-#: src\card.ts:328
+#: src\card.ts:346
 #, javascript-format
 msgid ""
 "**Level**: ${ Icon.Level } ${ card.level } **ATK**: ${ card.atk } **DEF**: "
@@ -58,14 +58,31 @@ msgstr ""
 "**レベル**: ${ Icon.Level } ${ card.level } **攻撃力**: ${ card.atk } **守備力**: ${ "
 "card.def }"
 
-#: src\card.ts:335
+#: src\card.ts:353
 msgid "**Pendulum Scale**: ${ formattedScale }"
 msgstr "**ペンデュラムスケール**: ${ formattedScale }"
 
-#: src\card.ts:355
-#: src\card.ts:373
+#: src\card.ts:239
 #, javascript-format
 msgid "Password: ${ card.password } | Konami ID #${ card.konami_id }"
+msgstr ""
+
+#: src\card.ts:241
+msgid "No password | Konami ID #${ card.konami_id }"
+msgstr ""
+
+#: src\card.ts:243
+#, javascript-format
+msgid "Password: ${ card.password } | Not yet released"
+msgstr ""
+
+#: src\card.ts:245
+msgid "Not yet released"
+msgstr ""
+
+#: src\card.ts:249
+#, javascript-format
+msgid "Fake password: ${ card.fake_password }"
 msgstr ""
 
 #: src\utils.ts:33
@@ -127,7 +144,7 @@ msgstr ""
 #: src\commands\art.ts:97
 #: src\commands\price.ts:148
 #: src\commands\search.ts:90
-#: src\events\message-search.ts:238
+#: src\events\message-search.ts:241
 #, javascript-format
 msgid "Could not find a card matching `${ input }`!"
 msgstr ""
@@ -136,58 +153,58 @@ msgstr ""
 msgid "Could not find art for `${ name }`!"
 msgstr ""
 
-#: src\commands\deck.ts:236
+#: src\commands\deck.ts:245
 #, javascript-format
 msgid "${ counts.Monster } Monster"
 msgid_plural "${ counts.Monster } Monsters"
 msgstr[0] ""
 
-#: src\commands\deck.ts:239
+#: src\commands\deck.ts:248
 msgid "${ counts.Spell } Spell"
 msgid_plural "${ counts.Spell } Spells"
 msgstr[0] ""
 
-#: src\commands\deck.ts:242
+#: src\commands\deck.ts:251
 #, javascript-format
 msgid "${ counts.Trap } Trap"
 msgid_plural "${ counts.Trap } Traps"
 msgstr[0] ""
 
-#: src\commands\deck.ts:270
+#: src\commands\deck.ts:279
 msgid "Your Deck"
 msgstr ""
 
-#: src\commands\deck.ts:275
+#: src\commands\deck.ts:284
 #, javascript-format
 msgid "Main Deck (${ deck.main.length } card — ${ countDetail })"
 msgid_plural "Main Deck (${ deck.main.length } cards — ${ countDetail })"
 msgstr[0] ""
 
-#: src\commands\deck.ts:282
+#: src\commands\deck.ts:291
 msgid "Main Deck (continued)"
 msgstr ""
 
-#: src\commands\deck.ts:289
+#: src\commands\deck.ts:298
 #, javascript-format
 msgid "Extra Deck (${ deck.extra.length } card — ${ _countDetail })"
 msgid_plural "Extra Deck (${ deck.extra.length } cards — ${ _countDetail })"
 msgstr[0] ""
 
-#: src\commands\deck.ts:296
+#: src\commands\deck.ts:305
 msgid "Extra Deck (continued)"
 msgstr ""
 
-#: src\commands\deck.ts:303
+#: src\commands\deck.ts:312
 #, javascript-format
 msgid "Side Deck (${ deck.side.length } card — ${ _countDetail2 })"
 msgid_plural "Side Deck (${ deck.side.length } cards — ${ _countDetail2 })"
 msgstr[0] ""
 
-#: src\commands\deck.ts:310
+#: src\commands\deck.ts:319
 msgid "Side Deck (continued)"
 msgstr ""
 
-#: src\commands\deck.ts:400
+#: src\commands\deck.ts:409
 msgid "Error: Your deck is empty."
 msgstr ""
 
@@ -304,19 +321,19 @@ msgstr ""
 msgid "Revision: ${ process.env.BOT_REVISION }."
 msgstr ""
 
-#: src\commands\deck.ts:320
+#: src\commands\deck.ts:329
 msgid ".ydk files must have the .ydk extension!"
 msgstr ""
 
-#: src\commands\deck.ts:323
+#: src\commands\deck.ts:332
 msgid ".ydk files should not be larger than 1 KB!"
 msgstr ""
 
-#: src\commands\deck.ts:313
+#: src\commands\deck.ts:322
 msgid "ydke URL"
 msgstr ""
 
-#: src\card.ts:291
+#: src\card.ts:309
 #. Forbidden/Limited Lists or Limit Regulations in the OCG
 msgid "**Limit**: ${ limitRegulationDisplay }"
 msgstr ""
@@ -351,22 +368,22 @@ msgstr ""
 msgid "Could not find prices for `${ name }`!"
 msgstr ""
 
-#: src\commands\deck.ts:418
+#: src\commands\deck.ts:427
 #. prepare interaction button for FTP upload
 msgid "Upload to YGOPRODECK"
 msgstr ""
 
-#: src\commands\deck.ts:469
+#: src\commands\deck.ts:478
 #. disable original button
 #. prepare row to disable button on original message
 msgid "Upload Complete"
 msgstr ""
 
-#: src\commands\deck.ts:456
+#: src\commands\deck.ts:465
 msgid "Deck upload failed!"
 msgstr ""
 
-#: src\commands\deck.ts:477
+#: src\commands\deck.ts:486
 #. reply in affirmation
 #, javascript-format
 msgid "Deck successfully uploaded to <${ url }>!"
@@ -694,18 +711,18 @@ msgctxt "attribute"
 msgid "DIVINE"
 msgstr "神"
 
-#: src\card.ts:341
-#: src\card.ts:352
+#: src\card.ts:359
+#: src\card.ts:370
 msgctxt "card-embed"
 msgid "Card Text"
 msgstr "カードテキスト"
 
-#: src\card.ts:346
+#: src\card.ts:364
 msgctxt "card-embed"
 msgid "Pendulum Effect"
 msgstr "ペンデュラム効果"
 
-#: src\card.ts:368
+#: src\card.ts:385
 msgctxt "card-embed"
 msgid "Card Effect"
 msgstr ""

--- a/translations/ko.po
+++ b/translations/ko.po
@@ -76,7 +76,7 @@ msgstr ""
 #: src\card.ts:243
 #, javascript-format
 msgid "Password: ${ card.password } | Not yet released"
-msgstr ""
+msgstr "패스워드: ${ card.password } | Not yet released"
 
 #: src\card.ts:245
 msgid "Not yet released"

--- a/translations/ko.po
+++ b/translations/ko.po
@@ -6,11 +6,11 @@ msgstr ""
 "MIME-Version: 1.0\n"
 "Content-Transfer-Encoding: 8bit\n"
 
-#: src\card.ts:253
+#: src\card.ts:271
 msgid ":link: Links"
 msgstr ":link: 링크"
 
-#: src\card.ts:254
+#: src\card.ts:272
 #, javascript-format
 msgid ""
 "[Official Konami DB](${ official }) | [OCG Rulings](${ rulings }) | "
@@ -19,22 +19,22 @@ msgstr ""
 "[공식 코나미 DB](${ official }) | [OCG 규칙](${ rulings }) | [Yugipedia](${ "
 "yugipedia }) | [YGOPRODECK](${ ygoprodeck })"
 
-#: src\card.ts:257
+#: src\card.ts:275
 #, javascript-format
 msgid "[Yugipedia](${ yugipedia }) | [YGOPRODECK](${ ygoprodeck })"
 msgstr "[Yugipedia](${ yugipedia }) | [YGOPRODECK](${ ygoprodeck })"
 
-#: src\card.ts:317
+#: src\card.ts:335
 #, javascript-format
 msgid "**Type**: ${ RaceIcon[race] } ${ localizedMonsterTypeLine }"
 msgstr "**종족**: ${ RaceIcon[race] } ${ localizedMonsterTypeLine }"
 
-#: src\card.ts:319
+#: src\card.ts:337
 #, javascript-format
 msgid "**Attribute**: ${ AttributeIcon[card.attribute] } ${ localizedAttribute }"
 msgstr "**속성**: ${ AttributeIcon[card.attribute] } ${ localizedAttribute }"
 
-#: src\card.ts:323
+#: src\card.ts:341
 msgid ""
 "**Rank**: ${ Icon.Rank } ${ card.rank } **ATK**: ${ card.atk } **DEF**: ${ "
 "card.def }"
@@ -42,7 +42,7 @@ msgstr ""
 "**랭크**: ${ Icon.Rank } ${ card.rank } **공격력**: ${ card.atk } **수비력**: ${ "
 "card.def }"
 
-#: src\card.ts:326
+#: src\card.ts:344
 #, javascript-format
 msgid ""
 "**Link Rating**: ${ card.link_arrows.length } **ATK**: ${ card.atk } **Link "
@@ -51,7 +51,7 @@ msgstr ""
 "**LINK**: ${ card.link_arrows.length } **공격력**: ${ card.atk } **링크 마커**: ${ "
 "arrows }"
 
-#: src\card.ts:328
+#: src\card.ts:346
 #, javascript-format
 msgid ""
 "**Level**: ${ Icon.Level } ${ card.level } **ATK**: ${ card.atk } **DEF**: "
@@ -60,15 +60,32 @@ msgstr ""
 "**레벨**: ${ Icon.Level } ${ card.level } **공격력**: ${ card.atk } **수비력**: ${ "
 "card.def }"
 
-#: src\card.ts:335
+#: src\card.ts:353
 msgid "**Pendulum Scale**: ${ formattedScale }"
 msgstr "**펜듈럼 스케일**: ${ formattedScale }"
 
-#: src\card.ts:355
-#: src\card.ts:373
+#: src\card.ts:239
 #, javascript-format
 msgid "Password: ${ card.password } | Konami ID #${ card.konami_id }"
 msgstr "패스워드: ${ card.password } | 코나미 ID #${ card.konami_id }"
+
+#: src\card.ts:241
+msgid "No password | Konami ID #${ card.konami_id }"
+msgstr ""
+
+#: src\card.ts:243
+#, javascript-format
+msgid "Password: ${ card.password } | Not yet released"
+msgstr ""
+
+#: src\card.ts:245
+msgid "Not yet released"
+msgstr ""
+
+#: src\card.ts:249
+#, javascript-format
+msgid "Fake password: ${ card.fake_password }"
+msgstr ""
 
 #: src\utils.ts:33
 msgid ":tools: This command is in development."
@@ -131,7 +148,7 @@ msgstr "찾으시려던 것을 찾으셨나요? 저희를 지원해 주시는 �
 #: src\commands\art.ts:97
 #: src\commands\price.ts:148
 #: src\commands\search.ts:90
-#: src\events\message-search.ts:238
+#: src\events\message-search.ts:241
 #, javascript-format
 msgid "Could not find a card matching `${ input }`!"
 msgstr "일치하는 카드를 찾을 수 없습니다. : `${ input }`!"
@@ -252,58 +269,58 @@ msgstr "Yugipedia에서 `${ page }`을(를) 검색하는 중…"
 msgid "Could not find a Yugipedia page named `${ page }`."
 msgstr "일치하는 이름을 Yugipedia 페이지에서 찾을 수 없습니다. : `${ page }`."
 
-#: src\commands\deck.ts:236
+#: src\commands\deck.ts:245
 #, javascript-format
 msgid "${ counts.Monster } Monster"
 msgid_plural "${ counts.Monster } Monsters"
 msgstr[0] ""
 
-#: src\commands\deck.ts:239
+#: src\commands\deck.ts:248
 msgid "${ counts.Spell } Spell"
 msgid_plural "${ counts.Spell } Spells"
 msgstr[0] ""
 
-#: src\commands\deck.ts:242
+#: src\commands\deck.ts:251
 #, javascript-format
 msgid "${ counts.Trap } Trap"
 msgid_plural "${ counts.Trap } Traps"
 msgstr[0] ""
 
-#: src\commands\deck.ts:270
+#: src\commands\deck.ts:279
 msgid "Your Deck"
 msgstr "덱"
 
-#: src\commands\deck.ts:275
+#: src\commands\deck.ts:284
 #, javascript-format
 msgid "Main Deck (${ deck.main.length } card — ${ countDetail })"
 msgid_plural "Main Deck (${ deck.main.length } cards — ${ countDetail })"
 msgstr[0] ""
 
-#: src\commands\deck.ts:282
+#: src\commands\deck.ts:291
 msgid "Main Deck (continued)"
 msgstr "메인 덱 (계속)"
 
-#: src\commands\deck.ts:289
+#: src\commands\deck.ts:298
 #, javascript-format
 msgid "Extra Deck (${ deck.extra.length } card — ${ _countDetail })"
 msgid_plural "Extra Deck (${ deck.extra.length } cards — ${ _countDetail })"
 msgstr[0] ""
 
-#: src\commands\deck.ts:296
+#: src\commands\deck.ts:305
 msgid "Extra Deck (continued)"
 msgstr "엑스트라 덱 (계속)"
 
-#: src\commands\deck.ts:303
+#: src\commands\deck.ts:312
 #, javascript-format
 msgid "Side Deck (${ deck.side.length } card — ${ _countDetail2 })"
 msgid_plural "Side Deck (${ deck.side.length } cards — ${ _countDetail2 })"
 msgstr[0] ""
 
-#: src\commands\deck.ts:310
+#: src\commands\deck.ts:319
 msgid "Side Deck (continued)"
 msgstr "사이드 덱 (계속)"
 
-#: src\commands\deck.ts:400
+#: src\commands\deck.ts:409
 msgid "Error: Your deck is empty."
 msgstr "오류: 덱이 비어 있습니다."
 
@@ -316,19 +333,19 @@ msgstr ""
 msgid "Revision: ${ process.env.BOT_REVISION }."
 msgstr ""
 
-#: src\commands\deck.ts:320
+#: src\commands\deck.ts:329
 msgid ".ydk files must have the .ydk extension!"
 msgstr ".ydk 파일의 확장자는 .ydk여야 합니다!"
 
-#: src\commands\deck.ts:323
+#: src\commands\deck.ts:332
 msgid ".ydk files should not be larger than 1 KB!"
 msgstr ".ydk 파일은 1 KB보다 크면 안 됩니다!"
 
-#: src\commands\deck.ts:313
+#: src\commands\deck.ts:322
 msgid "ydke URL"
 msgstr ""
 
-#: src\card.ts:291
+#: src\card.ts:309
 #. Forbidden/Limited Lists or Limit Regulations in the OCG
 msgid "**Limit**: ${ limitRegulationDisplay }"
 msgstr "**제한**: ${ limitRegulationDisplay }"
@@ -363,22 +380,22 @@ msgstr "${ card.name[resultLanguage] } - ${ vendorName } 가격"
 msgid "Could not find prices for `${ name }`!"
 msgstr "`${ name }`의 가격을 찾을 수 없습니다!"
 
-#: src\commands\deck.ts:418
+#: src\commands\deck.ts:427
 #. prepare interaction button for FTP upload
 msgid "Upload to YGOPRODECK"
 msgstr "YGOPRODECK에 업로드"
 
-#: src\commands\deck.ts:469
+#: src\commands\deck.ts:478
 #. disable original button
 #. prepare row to disable button on original message
 msgid "Upload Complete"
 msgstr "업로드 완료"
 
-#: src\commands\deck.ts:456
+#: src\commands\deck.ts:465
 msgid "Deck upload failed!"
 msgstr "덱 업로드 실패!"
 
-#: src\commands\deck.ts:477
+#: src\commands\deck.ts:486
 #. reply in affirmation
 #, javascript-format
 msgid "Deck successfully uploaded to <${ url }>!"
@@ -706,18 +723,18 @@ msgctxt "attribute"
 msgid "DIVINE"
 msgstr "신"
 
-#: src\card.ts:341
-#: src\card.ts:352
+#: src\card.ts:359
+#: src\card.ts:370
 msgctxt "card-embed"
 msgid "Card Text"
 msgstr "카드 텍스트"
 
-#: src\card.ts:346
+#: src\card.ts:364
 msgctxt "card-embed"
 msgid "Pendulum Effect"
 msgstr "펜듈럼 효과"
 
-#: src\card.ts:368
+#: src\card.ts:385
 msgctxt "card-embed"
 msgid "Card Effect"
 msgstr "카드 효과"

--- a/translations/ko.po
+++ b/translations/ko.po
@@ -84,7 +84,7 @@ msgstr ""
 
 #: src\card.ts:249
 #, javascript-format
-msgid "Fake password: ${ card.fake_password }"
+msgid "Placeholder ID: ${ card.fake_password }"
 msgstr ""
 
 #: src\utils.ts:33

--- a/translations/pt.po
+++ b/translations/pt.po
@@ -76,7 +76,7 @@ msgstr ""
 #: src\card.ts:243
 #, javascript-format
 msgid "Password: ${ card.password } | Not yet released"
-msgstr ""
+msgstr "Senha: ${ card.password } | Not yet released"
 
 #: src\card.ts:245
 msgid "Not yet released"

--- a/translations/pt.po
+++ b/translations/pt.po
@@ -6,11 +6,11 @@ msgstr ""
 "MIME-Version: 1.0\n"
 "Content-Transfer-Encoding: 8bit\n"
 
-#: src\card.ts:253
+#: src\card.ts:271
 msgid ":link: Links"
 msgstr ""
 
-#: src\card.ts:254
+#: src\card.ts:272
 #, javascript-format
 msgid ""
 "[Official Konami DB](${ official }) | [OCG Rulings](${ rulings }) | "
@@ -19,22 +19,22 @@ msgstr ""
 "[Database oficial da Konami](${ official }) | [Regras no OCG](${ rulings }) "
 "| [Yugipedia](${ yugipedia }) | [YGOPRODECK](${ ygoprodeck })"
 
-#: src\card.ts:257
+#: src\card.ts:275
 #, javascript-format
 msgid "[Yugipedia](${ yugipedia }) | [YGOPRODECK](${ ygoprodeck })"
 msgstr ""
 
-#: src\card.ts:317
+#: src\card.ts:335
 #, javascript-format
 msgid "**Type**: ${ RaceIcon[race] } ${ localizedMonsterTypeLine }"
 msgstr "**Tipo**: ${ RaceIcon[race] } ${ localizedMonsterTypeLine }"
 
-#: src\card.ts:319
+#: src\card.ts:337
 #, javascript-format
 msgid "**Attribute**: ${ AttributeIcon[card.attribute] } ${ localizedAttribute }"
 msgstr "**Atributo**: ${ AttributeIcon[card.attribute] } ${ localizedAttribute }"
 
-#: src\card.ts:323
+#: src\card.ts:341
 msgid ""
 "**Rank**: ${ Icon.Rank } ${ card.rank } **ATK**: ${ card.atk } **DEF**: ${ "
 "card.def }"
@@ -42,7 +42,7 @@ msgstr ""
 "**Classe**: ${ Icon.Rank } ${ card.rank } **ATK**: ${ card.atk } **DEF**: "
 "${ card.def }"
 
-#: src\card.ts:326
+#: src\card.ts:344
 #, javascript-format
 msgid ""
 "**Link Rating**: ${ card.link_arrows.length } **ATK**: ${ card.atk } **Link "
@@ -51,7 +51,7 @@ msgstr ""
 "**Valor Link**: ${ card.link_arrows.length } **ATK**: ${ card.atk } **Link "
 "Flechas Link**: ${ arrows }"
 
-#: src\card.ts:328
+#: src\card.ts:346
 #, javascript-format
 msgid ""
 "**Level**: ${ Icon.Level } ${ card.level } **ATK**: ${ card.atk } **DEF**: "
@@ -60,15 +60,32 @@ msgstr ""
 "**Nível**: ${ Icon.Level } ${ card.level } **ATK**: ${ card.atk } **DEF**: "
 "${ card.def }"
 
-#: src\card.ts:335
+#: src\card.ts:353
 msgid "**Pendulum Scale**: ${ formattedScale }"
 msgstr "**Escala Pêndulo**: ${ formattedScale }"
 
-#: src\card.ts:355
-#: src\card.ts:373
+#: src\card.ts:239
 #, javascript-format
 msgid "Password: ${ card.password } | Konami ID #${ card.konami_id }"
 msgstr "Senha: ${ card.password } | Konami ID #${ card.konami_id }"
+
+#: src\card.ts:241
+msgid "No password | Konami ID #${ card.konami_id }"
+msgstr ""
+
+#: src\card.ts:243
+#, javascript-format
+msgid "Password: ${ card.password } | Not yet released"
+msgstr ""
+
+#: src\card.ts:245
+msgid "Not yet released"
+msgstr ""
+
+#: src\card.ts:249
+#, javascript-format
+msgid "Fake password: ${ card.fake_password }"
+msgstr ""
 
 #: src\utils.ts:33
 msgid ":tools: This command is in development."
@@ -132,7 +149,7 @@ msgstr "Você encontrou o que procurava? Considere nos apoiar!"
 #: src\commands\art.ts:97
 #: src\commands\price.ts:148
 #: src\commands\search.ts:90
-#: src\events\message-search.ts:238
+#: src\events\message-search.ts:241
 #, javascript-format
 msgid "Could not find a card matching `${ input }`!"
 msgstr "Não foi possível encontrar uma carta compatível com `${ input }`!"
@@ -141,64 +158,64 @@ msgstr "Não foi possível encontrar uma carta compatível com `${ input }`!"
 msgid "Could not find art for `${ name }`!"
 msgstr "Não foi possível encontrar uma arte para `${ name }`!"
 
-#: src\commands\deck.ts:236
+#: src\commands\deck.ts:245
 #, javascript-format
 msgid "${ counts.Monster } Monster"
 msgid_plural "${ counts.Monster } Monsters"
 msgstr[0] "${ counts.Monster } Monstro"
 msgstr[1] "${ counts.Monster } Monstros"
 
-#: src\commands\deck.ts:239
+#: src\commands\deck.ts:248
 msgid "${ counts.Spell } Spell"
 msgid_plural "${ counts.Spell } Spells"
 msgstr[0] "${ counts.Spell } Magia"
 msgstr[1] "${ counts.Spell } Magias"
 
-#: src\commands\deck.ts:242
+#: src\commands\deck.ts:251
 #, javascript-format
 msgid "${ counts.Trap } Trap"
 msgid_plural "${ counts.Trap } Traps"
 msgstr[0] "${ counts.Trap } Armadilha"
 msgstr[1] "${ counts.Trap } Armadilhas"
 
-#: src\commands\deck.ts:270
+#: src\commands\deck.ts:279
 msgid "Your Deck"
 msgstr "Seu Deck"
 
-#: src\commands\deck.ts:275
+#: src\commands\deck.ts:284
 #, javascript-format
 msgid "Main Deck (${ deck.main.length } card — ${ countDetail })"
 msgid_plural "Main Deck (${ deck.main.length } cards — ${ countDetail })"
 msgstr[0] "Deck Principal (${ deck.main.length } carta — ${ countDetail })"
 msgstr[1] "Deck Principal (${ deck.main.length } cartas — ${ countDetail })"
 
-#: src\commands\deck.ts:282
+#: src\commands\deck.ts:291
 msgid "Main Deck (continued)"
 msgstr "Deck Principal (continuação)"
 
-#: src\commands\deck.ts:289
+#: src\commands\deck.ts:298
 #, javascript-format
 msgid "Extra Deck (${ deck.extra.length } card — ${ _countDetail })"
 msgid_plural "Extra Deck (${ deck.extra.length } cards — ${ _countDetail })"
 msgstr[0] "Deck Adicional (${ deck.extra.length } carta — ${ _countDetail })"
 msgstr[1] "Deck Adicional (${ deck.extra.length } cartas — ${ _countDetail })"
 
-#: src\commands\deck.ts:296
+#: src\commands\deck.ts:305
 msgid "Extra Deck (continued)"
 msgstr "Deck Adicional (continuação)"
 
-#: src\commands\deck.ts:303
+#: src\commands\deck.ts:312
 #, javascript-format
 msgid "Side Deck (${ deck.side.length } card — ${ _countDetail2 })"
 msgid_plural "Side Deck (${ deck.side.length } cards — ${ _countDetail2 })"
 msgstr[0] "Deck Auxiliar (${ deck.side.length } carta — ${ _countDetail2 })"
 msgstr[1] "Deck Auxiliar (${ deck.side.length } cartas — ${ _countDetail2 })"
 
-#: src\commands\deck.ts:310
+#: src\commands\deck.ts:319
 msgid "Side Deck (continued)"
 msgstr "Deck Auxiliar (continuação)"
 
-#: src\commands\deck.ts:400
+#: src\commands\deck.ts:409
 msgid "Error: Your deck is empty."
 msgstr "Erro: Seu deck está vazio"
 
@@ -315,19 +332,19 @@ msgstr "Um bot de _Yu-Gi-Oh!_ gratuito e de código aberto"
 msgid "Revision: ${ process.env.BOT_REVISION }."
 msgstr "Revisão: ${ process.env.BOT_REVISION }."
 
-#: src\commands\deck.ts:320
+#: src\commands\deck.ts:329
 msgid ".ydk files must have the .ydk extension!"
 msgstr ""
 
-#: src\commands\deck.ts:323
+#: src\commands\deck.ts:332
 msgid ".ydk files should not be larger than 1 KB!"
 msgstr ""
 
-#: src\commands\deck.ts:313
+#: src\commands\deck.ts:322
 msgid "ydke URL"
 msgstr ""
 
-#: src\card.ts:291
+#: src\card.ts:309
 #. Forbidden/Limited Lists or Limit Regulations in the OCG
 msgid "**Limit**: ${ limitRegulationDisplay }"
 msgstr ""
@@ -362,22 +379,22 @@ msgstr ""
 msgid "Could not find prices for `${ name }`!"
 msgstr ""
 
-#: src\commands\deck.ts:418
+#: src\commands\deck.ts:427
 #. prepare interaction button for FTP upload
 msgid "Upload to YGOPRODECK"
 msgstr ""
 
-#: src\commands\deck.ts:469
+#: src\commands\deck.ts:478
 #. disable original button
 #. prepare row to disable button on original message
 msgid "Upload Complete"
 msgstr ""
 
-#: src\commands\deck.ts:456
+#: src\commands\deck.ts:465
 msgid "Deck upload failed!"
 msgstr ""
 
-#: src\commands\deck.ts:477
+#: src\commands\deck.ts:486
 #. reply in affirmation
 #, javascript-format
 msgid "Deck successfully uploaded to <${ url }>!"
@@ -705,18 +722,18 @@ msgctxt "attribute"
 msgid "DIVINE"
 msgstr "DIVINO"
 
-#: src\card.ts:341
-#: src\card.ts:352
+#: src\card.ts:359
+#: src\card.ts:370
 msgctxt "card-embed"
 msgid "Card Text"
 msgstr "Texto da carta"
 
-#: src\card.ts:346
+#: src\card.ts:364
 msgctxt "card-embed"
 msgid "Pendulum Effect"
 msgstr "Efeito Pêndulo"
 
-#: src\card.ts:368
+#: src\card.ts:385
 msgctxt "card-embed"
 msgid "Card Effect"
 msgstr "Efeito da Carta"

--- a/translations/pt.po
+++ b/translations/pt.po
@@ -84,7 +84,7 @@ msgstr ""
 
 #: src\card.ts:249
 #, javascript-format
-msgid "Fake password: ${ card.fake_password }"
+msgid "Placeholder ID: ${ card.fake_password }"
 msgstr ""
 
 #: src\utils.ts:33

--- a/translations/zh-CN.po
+++ b/translations/zh-CN.po
@@ -6,11 +6,11 @@ msgstr ""
 "MIME-Version: 1.0\n"
 "Content-Transfer-Encoding: 8bit\n"
 
-#: src\card.ts:253
+#: src\card.ts:271
 msgid ":link: Links"
 msgstr ":link: 链接"
 
-#: src\card.ts:254
+#: src\card.ts:272
 #, javascript-format
 msgid ""
 "[Official Konami DB](${ official }) | [OCG Rulings](${ rulings }) | "
@@ -19,22 +19,22 @@ msgstr ""
 "[K社官方数据库](${ official }) | [事务局FAQ](${ rulings }) | [Yugipedia](${ "
 "yugipedia }) | [YGOPRODECK](${ ygoprodeck })"
 
-#: src\card.ts:257
+#: src\card.ts:275
 #, javascript-format
 msgid "[Yugipedia](${ yugipedia }) | [YGOPRODECK](${ ygoprodeck })"
 msgstr "[Yugipedia](${ yugipedia }) | [YGOPRODECK](${ ygoprodeck })"
 
-#: src\card.ts:317
+#: src\card.ts:335
 #, javascript-format
 msgid "**Type**: ${ RaceIcon[race] } ${ localizedMonsterTypeLine }"
 msgstr "**种族**: ${ RaceIcon[race] } ${ localizedMonsterTypeLine }"
 
-#: src\card.ts:319
+#: src\card.ts:337
 #, javascript-format
 msgid "**Attribute**: ${ AttributeIcon[card.attribute] } ${ localizedAttribute }"
 msgstr "**属性**: ${ AttributeIcon[card.attribute] } ${ localizedAttribute }"
 
-#: src\card.ts:323
+#: src\card.ts:341
 msgid ""
 "**Rank**: ${ Icon.Rank } ${ card.rank } **ATK**: ${ card.atk } **DEF**: ${ "
 "card.def }"
@@ -42,7 +42,7 @@ msgstr ""
 "**阶级**: ${ Icon.Rank } ${ card.rank } **攻击力**: ${ card.atk } **守备力**: ${ "
 "card.def }"
 
-#: src\card.ts:326
+#: src\card.ts:344
 #, javascript-format
 msgid ""
 "**Link Rating**: ${ card.link_arrows.length } **ATK**: ${ card.atk } **Link "
@@ -51,7 +51,7 @@ msgstr ""
 "**连接数值**: ${ card.link_arrows.length } **攻击力**: ${ card.atk } **连接标记**: ${ "
 "arrows }"
 
-#: src\card.ts:328
+#: src\card.ts:346
 #, javascript-format
 msgid ""
 "**Level**: ${ Icon.Level } ${ card.level } **ATK**: ${ card.atk } **DEF**: "
@@ -60,15 +60,32 @@ msgstr ""
 "**等级**: ${ Icon.Level } ${ card.level } **攻击力**: ${ card.atk } **守备力**: ${ "
 "card.def }"
 
-#: src\card.ts:335
+#: src\card.ts:353
 msgid "**Pendulum Scale**: ${ formattedScale }"
 msgstr "**灵摆刻度**: ${ formattedScale }"
 
-#: src\card.ts:355
-#: src\card.ts:373
+#: src\card.ts:239
 #, javascript-format
 msgid "Password: ${ card.password } | Konami ID #${ card.konami_id }"
 msgstr "卡片密码: ${ card.password } | 官方编号${ card.konami_id }"
+
+#: src\card.ts:241
+msgid "No password | Konami ID #${ card.konami_id }"
+msgstr ""
+
+#: src\card.ts:243
+#, javascript-format
+msgid "Password: ${ card.password } | Not yet released"
+msgstr ""
+
+#: src\card.ts:245
+msgid "Not yet released"
+msgstr ""
+
+#: src\card.ts:249
+#, javascript-format
+msgid "Fake password: ${ card.fake_password }"
+msgstr ""
 
 #: src\utils.ts:33
 msgid ":tools: This command is in development."
@@ -132,7 +149,7 @@ msgstr "找到你要的东西了吗？请考虑捐助我们！"
 #: src\commands\art.ts:97
 #: src\commands\price.ts:148
 #: src\commands\search.ts:90
-#: src\events\message-search.ts:238
+#: src\events\message-search.ts:241
 #, javascript-format
 msgid "Could not find a card matching `${ input }`!"
 msgstr "查无此卡：`${ input }`"
@@ -239,58 +256,58 @@ msgstr "正在Yugipedia上搜索`${ page }`…"
 msgid "Could not find a Yugipedia page named `${ page }`."
 msgstr "Yugipedia上找不到`${ page }`"
 
-#: src\commands\deck.ts:236
+#: src\commands\deck.ts:245
 #, javascript-format
 msgid "${ counts.Monster } Monster"
 msgid_plural "${ counts.Monster } Monsters"
 msgstr[0] ""
 
-#: src\commands\deck.ts:239
+#: src\commands\deck.ts:248
 msgid "${ counts.Spell } Spell"
 msgid_plural "${ counts.Spell } Spells"
 msgstr[0] ""
 
-#: src\commands\deck.ts:242
+#: src\commands\deck.ts:251
 #, javascript-format
 msgid "${ counts.Trap } Trap"
 msgid_plural "${ counts.Trap } Traps"
 msgstr[0] ""
 
-#: src\commands\deck.ts:270
+#: src\commands\deck.ts:279
 msgid "Your Deck"
 msgstr ""
 
-#: src\commands\deck.ts:275
+#: src\commands\deck.ts:284
 #, javascript-format
 msgid "Main Deck (${ deck.main.length } card — ${ countDetail })"
 msgid_plural "Main Deck (${ deck.main.length } cards — ${ countDetail })"
 msgstr[0] ""
 
-#: src\commands\deck.ts:282
+#: src\commands\deck.ts:291
 msgid "Main Deck (continued)"
 msgstr ""
 
-#: src\commands\deck.ts:289
+#: src\commands\deck.ts:298
 #, javascript-format
 msgid "Extra Deck (${ deck.extra.length } card — ${ _countDetail })"
 msgid_plural "Extra Deck (${ deck.extra.length } cards — ${ _countDetail })"
 msgstr[0] ""
 
-#: src\commands\deck.ts:296
+#: src\commands\deck.ts:305
 msgid "Extra Deck (continued)"
 msgstr ""
 
-#: src\commands\deck.ts:303
+#: src\commands\deck.ts:312
 #, javascript-format
 msgid "Side Deck (${ deck.side.length } card — ${ _countDetail2 })"
 msgid_plural "Side Deck (${ deck.side.length } cards — ${ _countDetail2 })"
 msgstr[0] ""
 
-#: src\commands\deck.ts:310
+#: src\commands\deck.ts:319
 msgid "Side Deck (continued)"
 msgstr ""
 
-#: src\commands\deck.ts:400
+#: src\commands\deck.ts:409
 msgid "Error: Your deck is empty."
 msgstr ""
 
@@ -309,19 +326,19 @@ msgstr ""
 msgid "Revision: ${ process.env.BOT_REVISION }."
 msgstr ""
 
-#: src\commands\deck.ts:320
+#: src\commands\deck.ts:329
 msgid ".ydk files must have the .ydk extension!"
 msgstr ""
 
-#: src\commands\deck.ts:323
+#: src\commands\deck.ts:332
 msgid ".ydk files should not be larger than 1 KB!"
 msgstr ""
 
-#: src\commands\deck.ts:313
+#: src\commands\deck.ts:322
 msgid "ydke URL"
 msgstr ""
 
-#: src\card.ts:291
+#: src\card.ts:309
 #. Forbidden/Limited Lists or Limit Regulations in the OCG
 msgid "**Limit**: ${ limitRegulationDisplay }"
 msgstr ""
@@ -356,22 +373,22 @@ msgstr ""
 msgid "Could not find prices for `${ name }`!"
 msgstr ""
 
-#: src\commands\deck.ts:418
+#: src\commands\deck.ts:427
 #. prepare interaction button for FTP upload
 msgid "Upload to YGOPRODECK"
 msgstr ""
 
-#: src\commands\deck.ts:469
+#: src\commands\deck.ts:478
 #. disable original button
 #. prepare row to disable button on original message
 msgid "Upload Complete"
 msgstr ""
 
-#: src\commands\deck.ts:456
+#: src\commands\deck.ts:465
 msgid "Deck upload failed!"
 msgstr ""
 
-#: src\commands\deck.ts:477
+#: src\commands\deck.ts:486
 #. reply in affirmation
 #, javascript-format
 msgid "Deck successfully uploaded to <${ url }>!"
@@ -699,18 +716,18 @@ msgctxt "attribute"
 msgid "DIVINE"
 msgstr "神"
 
-#: src\card.ts:341
-#: src\card.ts:352
+#: src\card.ts:359
+#: src\card.ts:370
 msgctxt "card-embed"
 msgid "Card Text"
 msgstr "卡片文本"
 
-#: src\card.ts:346
+#: src\card.ts:364
 msgctxt "card-embed"
 msgid "Pendulum Effect"
 msgstr "灵摆效果"
 
-#: src\card.ts:368
+#: src\card.ts:385
 msgctxt "card-embed"
 msgid "Card Effect"
 msgstr "卡片效果"

--- a/translations/zh-CN.po
+++ b/translations/zh-CN.po
@@ -71,21 +71,21 @@ msgstr "卡片密码: ${ card.password } | 官方编号${ card.konami_id }"
 
 #: src\card.ts:241
 msgid "No password | Konami ID #${ card.konami_id }"
-msgstr ""
+msgstr "无卡密 | 官方编号${ card.konami_id }"
 
 #: src\card.ts:243
 #, javascript-format
 msgid "Password: ${ card.password } | Not yet released"
-msgstr ""
+msgstr "卡片密码: ${ card.password } | 未发行"
 
 #: src\card.ts:245
 msgid "Not yet released"
-msgstr ""
+msgstr "未发行"
 
 #: src\card.ts:249
 #, javascript-format
 msgid "Fake password: ${ card.fake_password }"
-msgstr ""
+msgstr "假卡密: ${ card.fake_password }"
 
 #: src\utils.ts:33
 msgid ":tools: This command is in development."

--- a/translations/zh-CN.po
+++ b/translations/zh-CN.po
@@ -84,7 +84,7 @@ msgstr "未发行"
 
 #: src\card.ts:249
 #, javascript-format
-msgid "Fake password: ${ card.fake_password }"
+msgid "Placeholder ID: ${ card.fake_password }"
 msgstr "假卡密: ${ card.fake_password }"
 
 #: src\utils.ts:33

--- a/translations/zh-TW.po
+++ b/translations/zh-TW.po
@@ -69,25 +69,25 @@ msgstr "卡片密碼: ${ card.password } | 官方編號${ card.konami_id }"
 
 #: src\card.ts:241
 msgid "No password | Konami ID #${ card.konami_id }"
-msgstr ""
+msgstr "無卡密 | 官方編號${ card.konami_id }"
 
 #: src\card.ts:243
 #, javascript-format
 msgid "Password: ${ card.password } | Not yet released"
-msgstr ""
+msgstr "卡片密碼: ${ card.password } | 未發行"
 
 #: src\card.ts:245
 msgid "Not yet released"
-msgstr ""
+msgstr "未發行"
 
 #: src\card.ts:249
 #, javascript-format
 msgid "Fake password: ${ card.fake_password }"
-msgstr ""
+msgstr "假卡密: ${ card.fake_password }"
 
 #: src\utils.ts:33
 msgid ":tools: This command is in development."
-msgstr ""
+msgstr ":tools: 這個指令正在開發中"
 
 #: src\events\message-search.ts:172
 #: src\utils.ts:34

--- a/translations/zh-TW.po
+++ b/translations/zh-TW.po
@@ -6,33 +6,33 @@ msgstr ""
 "MIME-Version: 1.0\n"
 "Content-Transfer-Encoding: 8bit\n"
 
-#: src\card.ts:253
+#: src\card.ts:271
 msgid ":link: Links"
 msgstr "鏈接"
 
-#: src\card.ts:254
+#: src\card.ts:272
 #, javascript-format
 msgid ""
 "[Official Konami DB](${ official }) | [OCG Rulings](${ rulings }) | "
 "[Yugipedia](${ yugipedia }) | [YGOPRODECK](${ ygoprodeck })"
 msgstr ""
 
-#: src\card.ts:257
+#: src\card.ts:275
 #, javascript-format
 msgid "[Yugipedia](${ yugipedia }) | [YGOPRODECK](${ ygoprodeck })"
 msgstr "[Yugipedia](${ yugipedia }) | [YGOPRODECK](${ ygoprodeck })"
 
-#: src\card.ts:317
+#: src\card.ts:335
 #, javascript-format
 msgid "**Type**: ${ RaceIcon[race] } ${ localizedMonsterTypeLine }"
 msgstr "**種族**: ${ RaceIcon[race] } ${ localizedMonsterTypeLine }"
 
-#: src\card.ts:319
+#: src\card.ts:337
 #, javascript-format
 msgid "**Attribute**: ${ AttributeIcon[card.attribute] } ${ localizedAttribute }"
 msgstr "**屬性**: ${ AttributeIcon[card.attribute] } ${ localizedAttribute }"
 
-#: src\card.ts:323
+#: src\card.ts:341
 msgid ""
 "**Rank**: ${ Icon.Rank } ${ card.rank } **ATK**: ${ card.atk } **DEF**: ${ "
 "card.def }"
@@ -40,7 +40,7 @@ msgstr ""
 "**階級**: ${ Icon.Rank } ${ card.rank } **攻擊力**: ${ card.atk } **守備力**: ${ "
 "card.def }"
 
-#: src\card.ts:326
+#: src\card.ts:344
 #, javascript-format
 msgid ""
 "**Link Rating**: ${ card.link_arrows.length } **ATK**: ${ card.atk } **Link "
@@ -49,7 +49,7 @@ msgstr ""
 "**連接數值**: ${ card.link_arrows.length } **攻擊力**: ${ card.atk } **連接標記**: ${ "
 "arrows }"
 
-#: src\card.ts:328
+#: src\card.ts:346
 #, javascript-format
 msgid ""
 "**Level**: ${ Icon.Level } ${ card.level } **ATK**: ${ card.atk } **DEF**: "
@@ -58,15 +58,32 @@ msgstr ""
 "**等級**: ${ Icon.Level } ${ card.level } **攻擊力**: ${ card.atk } **守備力**: ${ "
 "card.def }"
 
-#: src\card.ts:335
+#: src\card.ts:353
 msgid "**Pendulum Scale**: ${ formattedScale }"
 msgstr "**靈擺刻度**: ${ formattedScale }"
 
-#: src\card.ts:355
-#: src\card.ts:373
+#: src\card.ts:239
 #, javascript-format
 msgid "Password: ${ card.password } | Konami ID #${ card.konami_id }"
 msgstr "卡片密碼: ${ card.password } | 官方編號${ card.konami_id }"
+
+#: src\card.ts:241
+msgid "No password | Konami ID #${ card.konami_id }"
+msgstr ""
+
+#: src\card.ts:243
+#, javascript-format
+msgid "Password: ${ card.password } | Not yet released"
+msgstr ""
+
+#: src\card.ts:245
+msgid "Not yet released"
+msgstr ""
+
+#: src\card.ts:249
+#, javascript-format
+msgid "Fake password: ${ card.fake_password }"
+msgstr ""
 
 #: src\utils.ts:33
 msgid ":tools: This command is in development."
@@ -127,7 +144,7 @@ msgstr ""
 #: src\commands\art.ts:97
 #: src\commands\price.ts:148
 #: src\commands\search.ts:90
-#: src\events\message-search.ts:238
+#: src\events\message-search.ts:241
 #, javascript-format
 msgid "Could not find a card matching `${ input }`!"
 msgstr "查無此卡：`${ input }`"
@@ -234,58 +251,58 @@ msgstr ""
 msgid "Could not find a Yugipedia page named `${ page }`."
 msgstr ""
 
-#: src\commands\deck.ts:236
+#: src\commands\deck.ts:245
 #, javascript-format
 msgid "${ counts.Monster } Monster"
 msgid_plural "${ counts.Monster } Monsters"
 msgstr[0] ""
 
-#: src\commands\deck.ts:239
+#: src\commands\deck.ts:248
 msgid "${ counts.Spell } Spell"
 msgid_plural "${ counts.Spell } Spells"
 msgstr[0] ""
 
-#: src\commands\deck.ts:242
+#: src\commands\deck.ts:251
 #, javascript-format
 msgid "${ counts.Trap } Trap"
 msgid_plural "${ counts.Trap } Traps"
 msgstr[0] ""
 
-#: src\commands\deck.ts:270
+#: src\commands\deck.ts:279
 msgid "Your Deck"
 msgstr ""
 
-#: src\commands\deck.ts:275
+#: src\commands\deck.ts:284
 #, javascript-format
 msgid "Main Deck (${ deck.main.length } card — ${ countDetail })"
 msgid_plural "Main Deck (${ deck.main.length } cards — ${ countDetail })"
 msgstr[0] ""
 
-#: src\commands\deck.ts:282
+#: src\commands\deck.ts:291
 msgid "Main Deck (continued)"
 msgstr ""
 
-#: src\commands\deck.ts:289
+#: src\commands\deck.ts:298
 #, javascript-format
 msgid "Extra Deck (${ deck.extra.length } card — ${ _countDetail })"
 msgid_plural "Extra Deck (${ deck.extra.length } cards — ${ _countDetail })"
 msgstr[0] ""
 
-#: src\commands\deck.ts:296
+#: src\commands\deck.ts:305
 msgid "Extra Deck (continued)"
 msgstr ""
 
-#: src\commands\deck.ts:303
+#: src\commands\deck.ts:312
 #, javascript-format
 msgid "Side Deck (${ deck.side.length } card — ${ _countDetail2 })"
 msgid_plural "Side Deck (${ deck.side.length } cards — ${ _countDetail2 })"
 msgstr[0] ""
 
-#: src\commands\deck.ts:310
+#: src\commands\deck.ts:319
 msgid "Side Deck (continued)"
 msgstr ""
 
-#: src\commands\deck.ts:400
+#: src\commands\deck.ts:409
 msgid "Error: Your deck is empty."
 msgstr ""
 
@@ -304,19 +321,19 @@ msgstr ""
 msgid "Revision: ${ process.env.BOT_REVISION }."
 msgstr ""
 
-#: src\commands\deck.ts:320
+#: src\commands\deck.ts:329
 msgid ".ydk files must have the .ydk extension!"
 msgstr ""
 
-#: src\commands\deck.ts:323
+#: src\commands\deck.ts:332
 msgid ".ydk files should not be larger than 1 KB!"
 msgstr ""
 
-#: src\commands\deck.ts:313
+#: src\commands\deck.ts:322
 msgid "ydke URL"
 msgstr ""
 
-#: src\card.ts:291
+#: src\card.ts:309
 #. Forbidden/Limited Lists or Limit Regulations in the OCG
 msgid "**Limit**: ${ limitRegulationDisplay }"
 msgstr ""
@@ -351,22 +368,22 @@ msgstr ""
 msgid "Could not find prices for `${ name }`!"
 msgstr ""
 
-#: src\commands\deck.ts:418
+#: src\commands\deck.ts:427
 #. prepare interaction button for FTP upload
 msgid "Upload to YGOPRODECK"
 msgstr ""
 
-#: src\commands\deck.ts:469
+#: src\commands\deck.ts:478
 #. disable original button
 #. prepare row to disable button on original message
 msgid "Upload Complete"
 msgstr ""
 
-#: src\commands\deck.ts:456
+#: src\commands\deck.ts:465
 msgid "Deck upload failed!"
 msgstr ""
 
-#: src\commands\deck.ts:477
+#: src\commands\deck.ts:486
 #. reply in affirmation
 #, javascript-format
 msgid "Deck successfully uploaded to <${ url }>!"
@@ -694,18 +711,18 @@ msgctxt "attribute"
 msgid "DIVINE"
 msgstr ""
 
-#: src\card.ts:341
-#: src\card.ts:352
+#: src\card.ts:359
+#: src\card.ts:370
 msgctxt "card-embed"
 msgid "Card Text"
 msgstr "卡片文本"
 
-#: src\card.ts:346
+#: src\card.ts:364
 msgctxt "card-embed"
 msgid "Pendulum Effect"
 msgstr "靈擺效果"
 
-#: src\card.ts:368
+#: src\card.ts:385
 msgctxt "card-embed"
 msgid "Card Effect"
 msgstr "卡片效果"

--- a/translations/zh-TW.po
+++ b/translations/zh-TW.po
@@ -82,7 +82,7 @@ msgstr "未發行"
 
 #: src\card.ts:249
 #, javascript-format
-msgid "Fake password: ${ card.fake_password }"
+msgid "Placeholder ID: ${ card.fake_password }"
 msgstr "假卡密: ${ card.fake_password }"
 
 #: src\utils.ts:33


### PR DESCRIPTION
Open to feedback on what the footer should look like. This also fixes the instances of `Password: null` or `Konami ID #null` as that has unclear meaning to the layperson. However, "fake password" also isn't necessarily clear to the layperson either.