### PR TITLE
Add early warning canary if no messageCreate events are received for one minute

### DIFF
--- a/src/bot.ts
+++ b/src/bot.ts
@@ -55,6 +55,26 @@ export class BotFactory {
 			bot.user?.setActivity(process.env.BOT_PRESENCE || "<card name> to search!");
 		});
 
+		bot.once("ready", () => {
+			let lastEventTimestamp = Date.now();
+			let incidentNotified = false;
+			bot.on("messageCreate", () => void (lastEventTimestamp = Date.now()));
+			setInterval(() => {
+				if (Date.now() - lastEventTimestamp > 60000) {
+					if (!incidentNotified) {
+						logger.warn("⚠️ No messageCreate gateway events received for one minute ⚠️");
+						incidentNotified = true;
+					}
+				} else {
+					if (incidentNotified) {
+						logger.notify("Started receiving messageCreate gateway events again");
+					}
+					incidentNotified = false;
+				}
+			}, 1000);
+			logger.info("Registered messageCreate gateway event frequency early warning canary");
+		});
+
 		for (const listener of this.listeners) {
 			bot.on(listener.type, (...args) => listener.run(...args));
 		}


### PR DESCRIPTION
Given #199 and #204, this is an interim warning system before we can get a full healthcheck bot going with incident notifications to GitHub