### PR TITLE
Treat numeric searches under 4 digits as names

### DIFF
--- a/src/events/message-search.ts
+++ b/src/events/message-search.ts
@@ -118,7 +118,7 @@ export function preprocess(
  * 00010000,ja
  */
 const NUMERIC_REGEX = new RegExp(
-	/^(?<kid>%)?\s*(?<number>\d+)\s*(?:,(?<lang>LOCALES))?$/
+	/^(?<kid>%)?\s*(?<number>\d{4,})\s*(?:,(?<lang>LOCALES))?$/
 		.toString()
 		.slice(1, -1)
 		.replace("LOCALES", LOCALES.join("|"))


### PR DESCRIPTION
Allows searching of cards like "7", passwords and Konami IDs are at least four digits long
Closes #188 