### PR TITLE
Switch password and konami-id subcommands to integer options

### DIFF
--- a/src/card.ts
+++ b/src/card.ts
@@ -125,10 +125,26 @@ export const Icon = {
 // TODO: remove "kid"
 export type CardLookupType = "name" | "password" | "konami-id" | "kid";
 
+export type CardSearchOptions =
+	| {
+			type: "name";
+			input: string;
+			resultLanguage: Locale;
+			inputLanguage: Locale;
+	  }
+	| {
+			type: "password" | "konami-id" | "kid";
+			input: number;
+			resultLanguage: Locale;
+			inputLanguage: Locale;
+	  };
+
 // Determine card search options for commands that use name/password/konami-id subcommands and
 // input-language and result-language options.
-// eslint-disable-next-line @typescript-eslint/explicit-function-return-type
-export async function getCardSearchOptions(interaction: ChatInputCommandInteraction, locales: LocaleProvider) {
+export async function getCardSearchOptions(
+	interaction: ChatInputCommandInteraction,
+	locales: LocaleProvider
+): Promise<CardSearchOptions> {
 	const resultLanguage = await locales.get(interaction);
 	const inputLanguage = (interaction.options.getString("input-language") as Locale) ?? resultLanguage;
 

--- a/src/commands/art.ts
+++ b/src/commands/art.ts
@@ -5,7 +5,7 @@ import { ChatInputCommandInteraction } from "discord.js";
 import { Got } from "got";
 import { inject, injectable } from "tsyringe";
 import { c, t, useLocale } from "ttag";
-import { CardLookupType, getCard } from "../card";
+import { getCard, getCardSearchOptions } from "../card";
 import { Command } from "../Command";
 import { CardSchema } from "../definitions";
 import {
@@ -13,7 +13,6 @@ import {
 	getKonamiIdSubcommand,
 	getNameSubcommand,
 	getPasswordSubcommand,
-	Locale,
 	LocaleProvider
 } from "../locale";
 import { getLogger, Logger } from "../logger";
@@ -61,10 +60,7 @@ export class ArtCommand extends Command {
 	}
 
 	protected override async execute(interaction: ChatInputCommandInteraction): Promise<number> {
-		const type = interaction.options.getSubcommand(true) as CardLookupType;
-		const input = interaction.options.getString("input", true);
-		const resultLanguage = await this.locales.get(interaction);
-		const inputLanguage = (interaction.options.getString("input-language") as Locale) ?? resultLanguage;
+		const { type, input, resultLanguage, inputLanguage } = await getCardSearchOptions(interaction, this.locales);
 		// Send out both requests simultaneously
 		const [, card] = await Promise.all([interaction.deferReply(), getCard(this.got, type, input, inputLanguage)]);
 		let end: number;

--- a/src/commands/art.ts
+++ b/src/commands/art.ts
@@ -1,4 +1,4 @@
-import { SlashCommandBuilder, SlashCommandStringOption, SlashCommandSubcommandBuilder } from "@discordjs/builders";
+import { SlashCommandBuilder } from "@discordjs/builders";
 import { Static } from "@sinclair/typebox";
 import { RESTPostAPIApplicationCommandsJSONBody } from "discord-api-types/v10";
 import { ChatInputCommandInteraction } from "discord.js";
@@ -8,7 +8,14 @@ import { c, t, useLocale } from "ttag";
 import { CardLookupType, getCard } from "../card";
 import { Command } from "../Command";
 import { CardSchema } from "../definitions";
-import { buildLocalisedCommand, getInputLangStringOption, Locale, LocaleProvider } from "../locale";
+import {
+	buildLocalisedCommand,
+	getKonamiIdSubcommand,
+	getNameSubcommand,
+	getPasswordSubcommand,
+	Locale,
+	LocaleProvider
+} from "../locale";
 import { getLogger, Logger } from "../logger";
 import { Metrics } from "../metrics";
 
@@ -30,41 +37,15 @@ export class ArtCommand extends Command {
 			() => c("command-name").t`art`,
 			() => c("command-description").t`Display the art for a card!`
 		);
-		const nameSubcommand = buildLocalisedCommand(
-			new SlashCommandSubcommandBuilder(),
-			() => c("command-option").t`name`,
+		const nameSubcommand = getNameSubcommand(
 			() => c("command-option-description").t`Display the art for the card with this name.`
 		);
-		const nameOption = buildLocalisedCommand(
-			new SlashCommandStringOption().setRequired(true),
-			() => c("command-option").t`input`,
-			() => c("command-option-description").t`Card name, fuzzy matching supported.`
-		);
-		const passwordSubcommand = buildLocalisedCommand(
-			new SlashCommandSubcommandBuilder(),
-			() => c("command-option").t`password`,
+		const passwordSubcommand = getPasswordSubcommand(
 			() => c("command-option-description").t`Display the art for the card with this password.`
 		);
-		const passwordOption = buildLocalisedCommand(
-			new SlashCommandStringOption().setRequired(true),
-			() => c("command-option").t`input`,
-			() =>
-				c("command-option-description")
-					.t`Card password, the eight-digit number printed on the bottom left corner.`
-		);
-		const konamiIdSubcommand = buildLocalisedCommand(
-			new SlashCommandSubcommandBuilder(),
-			() => c("command-option").t`konami-id`,
+		const konamiIdSubcommand = getKonamiIdSubcommand(
 			() => c("command-option-description").t`Display the art for the card with this official database ID.`
 		);
-		const konamiIdOption = buildLocalisedCommand(
-			new SlashCommandStringOption().setRequired(true),
-			() => c("command-option").t`input`,
-			() => c("command-option-description").t`Konami's official card database identifier.`
-		);
-		nameSubcommand.addStringOption(nameOption).addStringOption(getInputLangStringOption());
-		passwordSubcommand.addStringOption(passwordOption);
-		konamiIdSubcommand.addStringOption(konamiIdOption);
 		builder.addSubcommand(nameSubcommand).addSubcommand(passwordSubcommand).addSubcommand(konamiIdSubcommand);
 		return builder.toJSON();
 	}

--- a/src/commands/price.ts
+++ b/src/commands/price.ts
@@ -1,4 +1,4 @@
-import { SlashCommandBuilder, SlashCommandStringOption, SlashCommandSubcommandBuilder } from "@discordjs/builders";
+import { SlashCommandBuilder, SlashCommandStringOption } from "@discordjs/builders";
 import { Static } from "@sinclair/typebox";
 import { RESTPostAPIApplicationCommandsJSONBody } from "discord-api-types/v10";
 import { ChatInputCommandInteraction, EmbedBuilder } from "discord.js";
@@ -11,7 +11,9 @@ import { CardSchema } from "../definitions";
 import {
 	buildLocalisedChoice,
 	buildLocalisedCommand,
-	getInputLangStringOption,
+	getKonamiIdSubcommand,
+	getNameSubcommand,
+	getPasswordSubcommand,
 	Locale,
 	LocaleProvider
 } from "../locale";
@@ -58,49 +60,20 @@ export class PriceCommand extends Command {
 			() => c("command-name").t`price`,
 			() => c("command-description").t`Display the price for a card!`
 		);
-		const nameSubcommand = buildLocalisedCommand(
-			new SlashCommandSubcommandBuilder(),
-			() => c("command-option").t`name`,
-			() => c("command-option-description").t`Display the price for the card with this name.`
-		);
-		const nameOption = buildLocalisedCommand(
-			new SlashCommandStringOption().setRequired(true),
-			() => c("command-option").t`input`,
-			() => c("command-option-description").t`Card name, fuzzy matching supported.`
-		);
-		const passwordSubcommand = buildLocalisedCommand(
-			new SlashCommandSubcommandBuilder(),
-			() => c("command-option").t`password`,
-			() => c("command-option-description").t`Display the price for the card with this password.`
-		);
-		const passwordOption = buildLocalisedCommand(
-			new SlashCommandStringOption().setRequired(true),
-			() => c("command-option").t`input`,
-			() =>
-				c("command-option-description")
-					.t`Card password, the eight-digit number printed on the bottom left corner.`
-		);
-		const konamiIdSubcommand = buildLocalisedCommand(
-			new SlashCommandSubcommandBuilder(),
-			() => c("command-option").t`konami-id`,
-			() => c("command-option-description").t`Display the price for the card with this official database ID.`
-		);
-		const konamiIdOption = buildLocalisedCommand(
-			new SlashCommandStringOption().setRequired(true),
-			() => c("command-option").t`input`,
-			() => c("command-option-description").t`Konami's official card database identifier.`
-		);
 		const vendorOption = buildLocalisedCommand(
 			new SlashCommandStringOption().setRequired(true),
 			() => c("command-option").t`vendor`,
 			() => c("command-option-description").t`The vendor to fetch the price data from.`
 		).addChoices(...Object.entries(CHOICES_GLOBAL).map(([value, name]) => buildLocalisedChoice(value, name)));
-		nameSubcommand
-			.addStringOption(nameOption)
-			.addStringOption(vendorOption)
-			.addStringOption(getInputLangStringOption());
-		passwordSubcommand.addStringOption(passwordOption).addStringOption(vendorOption);
-		konamiIdSubcommand.addStringOption(konamiIdOption).addStringOption(vendorOption);
+		const nameSubcommand = getNameSubcommand(
+			() => c("command-option-description").t`Display the price for the card with this name.`
+		).addStringOption(vendorOption);
+		const passwordSubcommand = getPasswordSubcommand(
+			() => c("command-option-description").t`Display the price for the card with this password.`
+		).addStringOption(vendorOption);
+		const konamiIdSubcommand = getKonamiIdSubcommand(
+			() => c("command-option-description").t`Display the price for the card with this official database ID.`
+		).addStringOption(vendorOption);
 		builder.addSubcommand(nameSubcommand).addSubcommand(passwordSubcommand).addSubcommand(konamiIdSubcommand);
 		return builder.toJSON();
 	}

--- a/src/commands/price.ts
+++ b/src/commands/price.ts
@@ -66,8 +66,9 @@ export class PriceCommand extends Command {
 			() => c("command-option-description").t`The vendor to fetch the price data from.`
 		).addChoices(...Object.entries(CHOICES_GLOBAL).map(([value, name]) => buildLocalisedChoice(value, name)));
 		const nameSubcommand = getNameSubcommand(
-			() => c("command-option-description").t`Display the price for the card with this name.`
-		).addStringOption(vendorOption);
+			() => c("command-option-description").t`Display the price for the card with this name.`,
+			vendorOption
+		);
 		const passwordSubcommand = getPasswordSubcommand(
 			() => c("command-option-description").t`Display the price for the card with this password.`
 		).addStringOption(vendorOption);

--- a/src/commands/price.ts
+++ b/src/commands/price.ts
@@ -5,7 +5,7 @@ import { ChatInputCommandInteraction, EmbedBuilder } from "discord.js";
 import { Got } from "got";
 import { inject, injectable } from "tsyringe";
 import { c, t, useLocale } from "ttag";
-import { CardLookupType, getCard } from "../card";
+import { getCard, getCardSearchOptions } from "../card";
 import { Command } from "../Command";
 import { CardSchema } from "../definitions";
 import {
@@ -112,10 +112,7 @@ export class PriceCommand extends Command {
 	}
 
 	protected override async execute(interaction: ChatInputCommandInteraction): Promise<number> {
-		const type = interaction.options.getSubcommand(true) as CardLookupType;
-		const input = interaction.options.getString("input", true);
-		const resultLanguage = await this.locales.get(interaction);
-		const inputLanguage = (interaction.options.getString("input-language") as Locale) ?? resultLanguage;
+		const { type, input, resultLanguage, inputLanguage } = await getCardSearchOptions(interaction, this.locales);
 		const vendor = interaction.options.getString("vendor", true) as vendorId;
 		// Send out both requests simultaneously
 		const [, card] = await Promise.all([interaction.deferReply(), getCard(this.got, type, input, inputLanguage)]);

--- a/src/commands/search.ts
+++ b/src/commands/search.ts
@@ -4,7 +4,7 @@ import { ChatInputCommandInteraction } from "discord.js";
 import { Got } from "got";
 import { inject, injectable } from "tsyringe";
 import { c, t, useLocale } from "ttag";
-import { CardLookupType, createCardEmbed, getCard } from "../card";
+import { createCardEmbed, getCard, getCardSearchOptions } from "../card";
 import { Command } from "../Command";
 import {
 	buildLocalisedCommand,
@@ -12,7 +12,6 @@ import {
 	getNameSubcommand,
 	getPasswordSubcommand,
 	getResultLangStringOption,
-	Locale,
 	LocaleProvider
 } from "../locale";
 import { getLogger, Logger } from "../logger";
@@ -54,21 +53,17 @@ export class SearchCommand extends Command {
 	}
 
 	protected override async execute(interaction: ChatInputCommandInteraction): Promise<number> {
-		const type = interaction.options.getSubcommand(true) as CardLookupType;
-		const input = interaction.options.getString("input", true);
-		const resultLanguage = await this.locales.get(interaction);
-		const inputLanguage = (interaction.options.getString("input-language") as Locale) ?? resultLanguage;
-		// Send out both requests simultaneously
-		const [, card] = await Promise.all([interaction.deferReply(), getCard(this.got, type, input, inputLanguage)]);
+		const { type, input, resultLanguage, inputLanguage } = await getCardSearchOptions(interaction, this.locales);
+		const card = await getCard(this.got, type, input, inputLanguage);
 		let end: number;
 		if (!card) {
 			end = Date.now();
 			useLocale(resultLanguage);
-			await interaction.editReply({ content: t`Could not find a card matching \`${input}\`!` });
+			await interaction.reply({ content: t`Could not find a card matching \`${input}\`!` });
 		} else {
 			const embeds = createCardEmbed(card, resultLanguage);
 			end = Date.now();
-			await interaction.editReply({ embeds }); // Actually returns void
+			await interaction.reply({ embeds }); // Actually returns void
 		}
 		// When using deferReply, editedTimestamp is null, as if the reply was never edited, so provide a best estimate
 		const latency = end - interaction.createdTimestamp;

--- a/src/commands/search.ts
+++ b/src/commands/search.ts
@@ -1,4 +1,4 @@
-import { SlashCommandBuilder, SlashCommandStringOption, SlashCommandSubcommandBuilder } from "@discordjs/builders";
+import { SlashCommandBuilder } from "@discordjs/builders";
 import { RESTPostAPIApplicationCommandsJSONBody } from "discord-api-types/v10";
 import { ChatInputCommandInteraction } from "discord.js";
 import { Got } from "got";
@@ -8,7 +8,9 @@ import { CardLookupType, createCardEmbed, getCard } from "../card";
 import { Command } from "../Command";
 import {
 	buildLocalisedCommand,
-	getInputLangStringOption,
+	getKonamiIdSubcommand,
+	getNameSubcommand,
+	getPasswordSubcommand,
 	getResultLangStringOption,
 	Locale,
 	LocaleProvider
@@ -34,44 +36,15 @@ export class SearchCommand extends Command {
 			() => c("command-name").t`search`,
 			() => c("command-description").t`Find all information on a card!`
 		);
-		const nameSubcommand = buildLocalisedCommand(
-			new SlashCommandSubcommandBuilder(),
-			() => c("command-option").t`name`,
+		const nameSubcommand = getNameSubcommand(
 			() => c("command-option-description").t`Find all information for the card with this name.`
-		);
-		const nameOption = buildLocalisedCommand(
-			new SlashCommandStringOption().setRequired(true),
-			() => c("command-option").t`input`,
-			() => c("command-option-description").t`Card name, fuzzy matching supported.`
-		);
-		const passwordSubcommand = buildLocalisedCommand(
-			new SlashCommandSubcommandBuilder(),
-			() => c("command-option").t`password`,
+		).addStringOption(getResultLangStringOption());
+		const passwordSubcommand = getPasswordSubcommand(
 			() => c("command-option-description").t`Find all information for the card with this password.`
-		);
-		const passwordOption = buildLocalisedCommand(
-			new SlashCommandStringOption().setRequired(true),
-			() => c("command-option").t`input`,
-			() =>
-				c("command-option-description")
-					.t`Card password, the eight-digit number printed on the bottom left corner.`
-		);
-		const konamiIdSubcommand = buildLocalisedCommand(
-			new SlashCommandSubcommandBuilder(),
-			() => c("command-option").t`konami-id`,
+		).addStringOption(getResultLangStringOption());
+		const konamiIdSubcommand = getKonamiIdSubcommand(
 			() => c("command-option-description").t`Find all information for the card with this official database ID.`
-		);
-		const konamiIdOption = buildLocalisedCommand(
-			new SlashCommandStringOption().setRequired(true),
-			() => c("command-option").t`input`,
-			() => c("command-option-description").t`Konami's official card database identifier.`
-		);
-		nameSubcommand
-			.addStringOption(nameOption)
-			.addStringOption(getInputLangStringOption())
-			.addStringOption(getResultLangStringOption());
-		passwordSubcommand.addStringOption(passwordOption).addStringOption(getResultLangStringOption());
-		konamiIdSubcommand.addStringOption(konamiIdOption).addStringOption(getResultLangStringOption());
+		).addStringOption(getResultLangStringOption());
 		builder.addSubcommand(nameSubcommand).addSubcommand(passwordSubcommand).addSubcommand(konamiIdSubcommand);
 		return builder.toJSON();
 	}

--- a/src/locale.ts
+++ b/src/locale.ts
@@ -55,26 +55,6 @@ export function getResultLangStringOption(): SlashCommandStringOption {
 	return option;
 }
 
-export function getInputLangStringOption(): SlashCommandStringOption {
-	const option = new SlashCommandStringOption()
-		.setName("input-language")
-		.setDescription("The language to search in, defaulting to the result language.")
-		.setRequired(false)
-		.addChoices(...LOCALE_CHOICES);
-
-	for (const { gettext, discord } of COMMAND_LOCALIZATIONS) {
-		useLocale(gettext);
-		option
-			.setNameLocalization(discord, c("command-option").t`input-language`)
-			.setDescriptionLocalization(
-				discord,
-				c("command-option-description").t`The language to search in, defaulting to the result language.`
-			);
-	}
-
-	return option;
-}
-
 /**
  * Helper for integrating ttag gettext localisations with discord.js builders.
  * @param component SlashCommandBuilder, subcommand builder, option builder, etc.
@@ -120,6 +100,14 @@ export function buildLocalisedChoice<T = string | number>(
 		choice.name_localizations[discord] = getLocalisedName();
 	}
 	return choice;
+}
+
+export function getInputLangStringOption(): SlashCommandStringOption {
+	return buildLocalisedCommand(
+		new SlashCommandStringOption(),
+		() => c("command-option").t`input-language`,
+		() => c("command-option-description").t`The language to search in, defaulting to the result language.`
+	);
 }
 
 /**

--- a/src/locale.ts
+++ b/src/locale.ts
@@ -1,7 +1,13 @@
 import { SharedNameAndDescription, SlashCommandStringOption } from "@discordjs/builders";
 import sqlite, { Database, Statement } from "better-sqlite3";
 import { APIApplicationCommandOptionChoice, Locale as DiscordLocale } from "discord-api-types/v10";
-import { AutocompleteInteraction, ChatInputCommandInteraction, Message, Snowflake } from "discord.js";
+import {
+	AutocompleteInteraction,
+	ChatInputCommandInteraction,
+	Message,
+	SlashCommandSubcommandBuilder,
+	Snowflake
+} from "discord.js";
 import { inject, singleton } from "tsyringe";
 import { c, useLocale } from "ttag";
 
@@ -107,6 +113,52 @@ export function getInputLangStringOption(): SlashCommandStringOption {
 		new SlashCommandStringOption(),
 		() => c("command-option").t`input-language`,
 		() => c("command-option-description").t`The language to search in, defaulting to the result language.`
+	);
+}
+
+export function getNameSubcommand(getLocalisedDescription: () => string): SlashCommandSubcommandBuilder {
+	return buildLocalisedCommand(
+		new SlashCommandSubcommandBuilder(),
+		() => c("command-option").t`name`,
+		getLocalisedDescription
+	)
+		.addStringOption(
+			buildLocalisedCommand(
+				new SlashCommandStringOption().setRequired(true),
+				() => c("command-option").t`input`,
+				() => c("command-option-description").t`Card name, fuzzy matching supported.`
+			)
+		)
+		.addStringOption(getInputLangStringOption());
+}
+
+export function getPasswordSubcommand(getLocalisedDescription: () => string): SlashCommandSubcommandBuilder {
+	return buildLocalisedCommand(
+		new SlashCommandSubcommandBuilder(),
+		() => c("command-option").t`password`,
+		getLocalisedDescription
+	).addStringOption(
+		buildLocalisedCommand(
+			new SlashCommandStringOption().setRequired(true),
+			() => c("command-option").t`input`,
+			() =>
+				c("command-option-description")
+					.t`Card password, the eight-digit number printed on the bottom left corner.`
+		)
+	);
+}
+
+export function getKonamiIdSubcommand(getLocalisedDescription: () => string): SlashCommandSubcommandBuilder {
+	return buildLocalisedCommand(
+		new SlashCommandSubcommandBuilder(),
+		() => c("command-option").t`konami-id`,
+		getLocalisedDescription
+	).addStringOption(
+		buildLocalisedCommand(
+			new SlashCommandStringOption().setRequired(true),
+			() => c("command-option").t`input`,
+			() => c("command-option-description").t`Konami's official card database identifier.`
+		)
 	);
 }
 

--- a/src/locale.ts
+++ b/src/locale.ts
@@ -116,20 +116,25 @@ export function getInputLangStringOption(): SlashCommandStringOption {
 	);
 }
 
-export function getNameSubcommand(getLocalisedDescription: () => string): SlashCommandSubcommandBuilder {
-	return buildLocalisedCommand(
+export function getNameSubcommand(
+	getLocalisedDescription: () => string,
+	requiredStringOption?: SlashCommandStringOption
+): SlashCommandSubcommandBuilder {
+	const builder = buildLocalisedCommand(
 		new SlashCommandSubcommandBuilder(),
 		() => c("command-option").t`name`,
 		getLocalisedDescription
-	)
-		.addStringOption(
-			buildLocalisedCommand(
-				new SlashCommandStringOption().setRequired(true),
-				() => c("command-option").t`input`,
-				() => c("command-option-description").t`Card name, fuzzy matching supported.`
-			)
+	).addStringOption(
+		buildLocalisedCommand(
+			new SlashCommandStringOption().setRequired(true),
+			() => c("command-option").t`input`,
+			() => c("command-option-description").t`Card name, fuzzy matching supported.`
 		)
-		.addStringOption(getInputLangStringOption());
+	);
+	if (requiredStringOption) {
+		builder.addStringOption(requiredStringOption);
+	}
+	return builder.addStringOption(getInputLangStringOption());
 }
 
 export function getPasswordSubcommand(getLocalisedDescription: () => string): SlashCommandSubcommandBuilder {

--- a/src/locale.ts
+++ b/src/locale.ts
@@ -110,10 +110,10 @@ export function buildLocalisedChoice<T = string | number>(
 
 export function getInputLangStringOption(): SlashCommandStringOption {
 	return buildLocalisedCommand(
-		new SlashCommandStringOption(),
+		new SlashCommandStringOption().setRequired(false),
 		() => c("command-option").t`input-language`,
 		() => c("command-option-description").t`The language to search in, defaulting to the result language.`
-	);
+	).addChoices(...LOCALE_CHOICES);
 }
 
 export function getNameSubcommand(

--- a/src/locale.ts
+++ b/src/locale.ts
@@ -1,4 +1,4 @@
-import { SharedNameAndDescription, SlashCommandStringOption } from "@discordjs/builders";
+import { SharedNameAndDescription, SlashCommandIntegerOption, SlashCommandStringOption } from "@discordjs/builders";
 import sqlite, { Database, Statement } from "better-sqlite3";
 import { APIApplicationCommandOptionChoice, Locale as DiscordLocale } from "discord-api-types/v10";
 import {
@@ -137,9 +137,9 @@ export function getPasswordSubcommand(getLocalisedDescription: () => string): Sl
 		new SlashCommandSubcommandBuilder(),
 		() => c("command-option").t`password`,
 		getLocalisedDescription
-	).addStringOption(
+	).addIntegerOption(
 		buildLocalisedCommand(
-			new SlashCommandStringOption().setRequired(true),
+			new SlashCommandIntegerOption().setRequired(true).setMinValue(0).setMaxValue(999999999),
 			() => c("command-option").t`input`,
 			() =>
 				c("command-option-description")
@@ -153,9 +153,9 @@ export function getKonamiIdSubcommand(getLocalisedDescription: () => string): Sl
 		new SlashCommandSubcommandBuilder(),
 		() => c("command-option").t`konami-id`,
 		getLocalisedDescription
-	).addStringOption(
+	).addIntegerOption(
 		buildLocalisedCommand(
-			new SlashCommandStringOption().setRequired(true),
+			new SlashCommandIntegerOption().setRequired(true).setMinValue(4007).setMaxValue(99999),
 			() => c("command-option").t`input`,
 			() => c("command-option-description").t`Konami's official card database identifier.`
 		)


### PR DESCRIPTION
getInputLangStringOption: use buildLocalisedCommand 
Create helpers for name/password/konami-id subcommands
Add getCardSearchOptions for shared logic
Remove simultaneous calls to deferReply and getCard

Closes #270
Closes #271