### PR TITLE
/rush-duel: update artwork to the second Rush Duel video game (G002)

### DIFF
--- a/src/commands/rush-duel.ts
+++ b/src/commands/rush-duel.ts
@@ -41,8 +41,8 @@ const rc = c;
 function videoGameIllustrationURL(card: Static<typeof RushCardSchema>): string {
 	// Filter card name down to alphanumeric characters
 	const probableBasename = (card.name.en ?? "").replaceAll(/\W/g, "");
-	// https://yugipedia.com/wiki/Category:Yu-Gi-Oh!_RUSH_DUEL:_Dawn_of_the_Battle_Royale!!_card_artworks
-	return `https://yugipedia.com/wiki/Special:Redirect/file/${probableBasename}-DBR-JP-VG-artwork.png`;
+	// https://yugipedia.com/wiki/Category:Yu-Gi-Oh!_RUSH_DUEL:_Saikyo_Battle_Royale!!_Let%27s_Go!_Go_Rush!!_card_artworks
+	return `https://yugipedia.com/wiki/Special:Redirect/file/${probableBasename}-G002-JP-VG-artwork.png`;
 }
 
 function createRushCardEmbed(card: Static<typeof RushCardSchema>, lang: Locale): EmbedBuilder {


### PR DESCRIPTION
As of writing, Yugipedia has 1312 images available vs 694 images, at a cost of one-quarter the resolution (512x512 vs 1024x1024). Closes #281