### PR TITLE
Handle Speed Duel limit regulations

### DIFF
--- a/src/card.ts
+++ b/src/card.ts
@@ -3,7 +3,7 @@ import { ChatInputCommandInteraction, EmbedBuilder, EmbedFooterOptions } from "d
 import { Got } from "got";
 import { parseDocument } from "htmlparser2";
 import { c, t, useLocale } from "ttag";
-import { CardSchema, LimitRegulation } from "./definitions";
+import { CardSchema, OCGLimitRegulation, SpeedLimitRegulation } from "./definitions";
 import { RushCardSchema } from "./definitions/rush";
 import { Locale, LocaleProvider } from "./locale";
 
@@ -58,6 +58,12 @@ c("spell-trap-property").t`Ritual Spell`;
 c("spell-trap-property").t`Normal Trap`;
 c("spell-trap-property").t`Continuous Trap`;
 c("spell-trap-property").t`Counter Trap`;
+// SpeedLimitRegulation is not converted to a number for display
+c("limit-regulation").t`Forbidden`;
+c("limit-regulation").t`Limited 1`;
+c("limit-regulation").t`Limited 2`;
+c("limit-regulation").t`Limited 3`;
+c("limit-regulation").t`Unlimited`;
 
 // Guarantee default locale at import time since the resulting strings matter.
 useLocale("en");
@@ -195,7 +201,7 @@ export async function getCard(
 	throw new got.HTTPError(response);
 }
 
-function formatLimitRegulation(value: LimitRegulation | null | undefined): number | null {
+function formatOCGLimitRegulation(value: OCGLimitRegulation | null | undefined): number | null {
 	switch (value) {
 		case "Forbidden":
 			return 0;
@@ -208,6 +214,19 @@ function formatLimitRegulation(value: LimitRegulation | null | undefined): numbe
 		default:
 			return null;
 	}
+}
+
+function formatSpeedLimitRegulation(value: SpeedLimitRegulation | null | undefined): string | null {
+	if (
+		value === "Forbidden" ||
+		value === "Limited 1" ||
+		value === "Limited 2" ||
+		value === "Limited 3" ||
+		value === "Unlimited"
+	) {
+		return rc("limit-regulation").gettext(value);
+	}
+	return null;
 }
 
 export function parseAndExpandRuby(html: string): [string, string] {
@@ -336,9 +355,9 @@ export function createCardEmbed(card: Static<typeof CardSchema>, lang: Locale): 
 	}
 
 	const limitRegulations = [
-		{ label: "TCG: ", value: formatLimitRegulation(card.limit_regulation.tcg) },
-		{ label: "OCG: ", value: formatLimitRegulation(card.limit_regulation.ocg) },
-		{ label: "Speed: ", value: formatLimitRegulation(card.limit_regulation.speed) }
+		{ label: "TCG: ", value: formatOCGLimitRegulation(card.limit_regulation.tcg) },
+		{ label: "OCG: ", value: formatOCGLimitRegulation(card.limit_regulation.ocg) },
+		{ label: "Speed: ", value: formatSpeedLimitRegulation(card.limit_regulation.speed) }
 	];
 	let limitRegulationDisplay: string;
 	if (["ja", "ko", "zh-CN", "zh-TW"].includes(lang)) {

--- a/translations/de.po
+++ b/translations/de.po
@@ -6,186 +6,186 @@ msgstr ""
 "MIME-Version: 1.0\n"
 "Content-Transfer-Encoding: 8bit\n"
 
-#: src\card.ts:279
+#: src\card.ts:339
 #: src\commands\rush-duel.ts:60
 msgid "🔗 Links"
 msgstr ""
 
-#: src\card.ts:280
+#: src\card.ts:340
 #, javascript-format
 msgid "[Official Konami DB](${ official }) | [OCG Rulings](${ rulings }) | [Yugipedia](${ yugipedia }) | [YGOPRODECK](${ ygoprodeck })"
 msgstr ""
 
-#: src\card.ts:283
+#: src\card.ts:343
 #, javascript-format
 msgid "[Yugipedia](${ yugipedia }) | [YGOPRODECK](${ ygoprodeck })"
 msgstr ""
 
-#: src\card.ts:343
+#: src\card.ts:403
 #: src\commands\rush-duel.ts:107
 #, javascript-format
 msgid "**Type**: ${ RaceIcon[race] } ${ localizedMonsterTypeLine }"
 msgstr "**Typ**: ${ RaceIcon[race] } ${ localizedMonsterTypeLine }"
 
-#: src\card.ts:345
+#: src\card.ts:405
 #: src\commands\rush-duel.ts:109
 #, javascript-format
 msgid "**Attribute**: ${ AttributeIcon[card.attribute] } ${ localizedAttribute }"
 msgstr "**Eigenschaft**: ${ AttributeIcon[card.attribute] } ${ localizedAttribute }"
 
-#: src\card.ts:349
+#: src\card.ts:409
 msgid "**Rank**: ${ Icon.Rank } ${ card.rank } **ATK**: ${ card.atk } **DEF**: ${ card.def }"
 msgstr "**Rang**: ${ Icon.Rank } ${ card.rank } **ATK**: ${ card.atk } **DEF**: ${ card.def }"
 
-#: src\card.ts:352
+#: src\card.ts:412
 #, javascript-format
 msgid "**Link Rating**: ${ card.link_arrows.length } **ATK**: ${ card.atk } **Link Arrows**: ${ arrows }"
 msgstr ""
 
-#: src\card.ts:354
+#: src\card.ts:414
 #: src\commands\rush-duel.ts:111
 #, javascript-format
 msgid "**Level**: ${ Icon.Level } ${ card.level } **ATK**: ${ card.atk } **DEF**: ${ card.def }"
 msgstr "**Stufe**: ${ Icon.Level } ${ card.level } **ATK**: ${ card.atk } **DEF**: ${ card.def }"
 
-#: src\card.ts:361
+#: src\card.ts:421
 msgid "**Pendulum Scale**: ${ formattedScale }"
 msgstr "**Pendelbereich**: ${ formattedScale }"
 
-#: src\card.ts:240
+#: src\card.ts:300
 #, javascript-format
 msgid "Password: ${ card.password } | Konami ID #${ card.konami_id }"
 msgstr ""
 
-#: src\card.ts:242
+#: src\card.ts:302
 msgid "No password | Konami ID #${ card.konami_id }"
 msgstr ""
 
-#: src\card.ts:244
+#: src\card.ts:304
 #, javascript-format
 msgid "Password: ${ card.password } | Not yet released"
 msgstr ""
 
-#: src\card.ts:246
+#: src\card.ts:306
 #: src\commands\rush-duel.ts:161
 msgid "Not yet released"
 msgstr ""
 
-#: src\card.ts:250
+#: src\card.ts:310
 #, javascript-format
 msgid "Placeholder ID: ${ card.fake_password }"
 msgstr ""
 
-#: src\utils.ts:45
+#: src\utils.ts:41
 msgid "🛠️ This command is in development."
 msgstr ""
 
-#: src\utils.ts:46
+#: src\utils.ts:42
 msgid "📨 Please send feedback to [our issue tracker](https://github.com/DawnbrandBots/bastion-bot) or the [support server](https://discord.gg/4aFuPyuE96)!"
 msgstr ""
 
-#: src\utils.ts:57
+#: src\utils.ts:53
 msgid "Please consider supporting us!"
 msgstr ""
 
-#: src\utils.ts:58
+#: src\utils.ts:54
 msgid "Help keep Bastion online!"
 msgstr ""
 
-#: src\utils.ts:59
+#: src\utils.ts:55
 msgid "Please help keep Bastion online!"
 msgstr ""
 
-#: src\utils.ts:60
+#: src\utils.ts:56
 msgid "Was Bastion helpful? Consider supporting us!"
 msgstr ""
 
-#: src\utils.ts:61
+#: src\utils.ts:57
 msgid "Was Bastion helpful? We need your support!"
 msgstr ""
 
-#: src\utils.ts:62
+#: src\utils.ts:58
 msgid "Did you find Bastion useful? Consider supporting us!"
 msgstr ""
 
-#: src\utils.ts:63
+#: src\utils.ts:59
 msgid "Did you find Bastion useful? Help keep it online!"
 msgstr ""
 
-#: src\utils.ts:64
+#: src\utils.ts:60
 msgid "Did you find Bastion useful? We need your support!"
 msgstr ""
 
-#: src\utils.ts:65
+#: src\utils.ts:61
 msgid "Enjoy Bastion? Help keep it online!"
 msgstr ""
 
-#: src\utils.ts:66
+#: src\utils.ts:62
 msgid "Enjoy Bastion? Consider supporting us!"
 msgstr ""
 
-#: src\utils.ts:67
+#: src\utils.ts:63
 msgid "Found what you were looking for? Consider supporting us!"
 msgstr ""
 
-#: src\commands\art.ts:97
-#: src\commands\price.ts:148
-#: src\commands\rush-duel.ts:309
-#: src\commands\rush-duel.ts:342
-#: src\commands\search.ts:89
-#: src\events\message-search.ts:270
+#: src\commands\art.ts:69
+#: src\commands\price.ts:121
+#: src\commands\rush-duel.ts:306
+#: src\commands\rush-duel.ts:339
+#: src\commands\search.ts:62
+#: src\events\message-search.ts:295
 #, javascript-format
 msgid "Could not find a card matching `${ input }`!"
 msgstr ""
 
-#: src\commands\art.ts:107
+#: src\commands\art.ts:83
 msgid "Could not find art for `${ name }`!"
 msgstr ""
 
-#: src\commands\deck.ts:245
+#: src\commands\deck.ts:248
 #, javascript-format
 msgid "${ counts.Monster } Monster"
 msgid_plural "${ counts.Monster } Monsters"
 msgstr[0] ""
 msgstr[1] ""
 
-#: src\commands\deck.ts:248
+#: src\commands\deck.ts:251
 msgid "${ counts.Spell } Spell"
 msgid_plural "${ counts.Spell } Spells"
 msgstr[0] ""
 msgstr[1] ""
 
-#: src\commands\deck.ts:251
+#: src\commands\deck.ts:254
 #, javascript-format
 msgid "${ counts.Trap } Trap"
 msgid_plural "${ counts.Trap } Traps"
 msgstr[0] ""
 msgstr[1] ""
 
-#: src\commands\deck.ts:279
+#: src\commands\deck.ts:282
 msgid "Your Deck"
 msgstr ""
 
-#: src\commands\deck.ts:284
+#: src\commands\deck.ts:287
 #, javascript-format
 msgid "Main Deck (${ deck.main.length } card — ${ countDetail })"
 msgid_plural "Main Deck (${ deck.main.length } cards — ${ countDetail })"
 msgstr[0] ""
 msgstr[1] ""
 
-#: src\commands\deck.ts:291
+#: src\commands\deck.ts:294
 msgid "Main Deck (continued)"
 msgstr ""
 
-#: src\commands\deck.ts:305
+#: src\commands\deck.ts:308
 msgid "Extra Deck (continued)"
 msgstr ""
 
-#: src\commands\deck.ts:319
+#: src\commands\deck.ts:322
 msgid "Side Deck (continued)"
 msgstr ""
 
-#: src\commands\deck.ts:409
+#: src\commands\deck.ts:411
 msgid "Error: Your deck is empty."
 msgstr ""
 
@@ -279,79 +279,79 @@ msgstr ""
 msgid "Revision: ${ process.env.BOT_REVISION }."
 msgstr ""
 
-#: src\commands\deck.ts:329
+#: src\commands\deck.ts:332
 msgid ".ydk files must have the .ydk extension!"
 msgstr ""
 
-#: src\commands\deck.ts:332
+#: src\commands\deck.ts:335
 msgid ".ydk files should not be larger than 1 KB!"
 msgstr ""
 
-#: src\commands\deck.ts:322
+#: src\commands\deck.ts:325
 msgid "ydke URL"
 msgstr ""
 
-#: src\card.ts:317
+#: src\card.ts:377
 #. Forbidden/Limited Lists or Limit Regulations in the OCG
 msgid "**Limit**: ${ limitRegulationDisplay }"
 msgstr ""
 
-#: src\commands\price.ts:38
+#: src\commands\price.ts:40
 msgid "TCGPlayer"
 msgstr ""
 
-#: src\commands\price.ts:39
+#: src\commands\price.ts:41
 msgid "Cardmarket"
 msgstr ""
 
-#: src\commands\price.ts:40
+#: src\commands\price.ts:42
 msgid "CoolStuffInc"
 msgstr ""
 
-#: src\commands\price.ts:118
+#: src\commands\price.ts:96
 #. TODO: future, determine localisation and relevance status of this error
 msgid "Sorry, I can't find the price for a card with no English name!"
 msgstr ""
 
-#: src\commands\price.ts:162
+#: src\commands\price.ts:140
 msgid "No market price"
 msgstr ""
 
-#: src\commands\price.ts:170
+#: src\commands\price.ts:148
 #, javascript-format
 msgid "Prices for ${ card.name[resultLanguage] } - ${ vendorName }"
 msgstr ""
 
-#: src\commands\price.ts:184
+#: src\commands\price.ts:162
 msgid "Could not find prices for `${ name }`!"
 msgstr ""
 
-#: src\commands\deck.ts:427
+#: src\commands\deck.ts:429
 #. prepare interaction button for FTP upload
 msgid "Upload to YGOPRODECK"
 msgstr ""
 
-#: src\commands\deck.ts:485
+#: src\commands\deck.ts:487
 #. disable original button
 #. prepare row to disable button on original message
 msgid "Upload Complete"
 msgstr ""
 
-#: src\commands\deck.ts:472
+#: src\commands\deck.ts:474
 msgid "Deck upload failed!"
 msgstr ""
 
-#: src\commands\deck.ts:493
+#: src\commands\deck.ts:495
 #. reply in affirmation
 #, javascript-format
 msgid "Deck successfully uploaded to <${ url }>!"
 msgstr ""
 
-#: src\events\message-search.ts:275
+#: src\events\message-search.ts:300
 msgid "💬 Translations missing?"
 msgstr ""
 
-#: src\events\message-search.ts:276
+#: src\events\message-search.ts:301
 msgid "Help translate Bastion at the links above."
 msgstr ""
 
@@ -371,11 +371,11 @@ msgid ""
 "💬 Translations missing? Help translate Bastion on [GitHub](https://github.com/DawnbrandBots/bastion-bot)."
 msgstr ""
 
-#: src\events\message-search.ts:268
+#: src\events\message-search.ts:293
 msgid "Search type: ${ localisedType }"
 msgstr ""
 
-#: src\events\message-search.ts:265
+#: src\events\message-search.ts:290
 #, javascript-format
 msgid "Search language: **${ localisedInputLanguage }** (${ inputLanguage }). Check defaults with </locale get:${ id }> and configure with </locale set:${ id }>"
 msgstr ""
@@ -385,22 +385,22 @@ msgid "⚠️ You pinged me, but I am missing permissions in the channel!"
 msgstr ""
 
 #: src\events\message-ping.ts:94
-#: src\events\message-search.ts:182
+#: src\events\message-search.ts:192
 msgid "Please have a server administrator [fix this](https://github.com/DawnbrandBots/bastion-bot#discord-permissions)."
 msgstr ""
 
-#: src\events\message-search.ts:179
+#: src\events\message-search.ts:189
 msgid "⚠️ I am missing permissions in the channel!"
 msgstr ""
 
-#: src\commands\deck.ts:298
+#: src\commands\deck.ts:301
 #, javascript-format
 msgid "Extra Deck (${ deck.extra.length } card — ${ countDetail })"
 msgid_plural "Extra Deck (${ deck.extra.length } cards — ${ countDetail })"
 msgstr[0] ""
 msgstr[1] ""
 
-#: src\commands\deck.ts:312
+#: src\commands\deck.ts:315
 #, javascript-format
 msgid "Side Deck (${ deck.side.length } card — ${ countDetail })"
 msgid_plural "Side Deck (${ deck.side.length } cards — ${ countDetail })"
@@ -444,12 +444,12 @@ msgstr ""
 msgid "Konami ID #${ card.konami_id }"
 msgstr ""
 
-#: src\commands\deck.ts:453
-#: src\commands\rush-duel.ts:489
+#: src\commands\deck.ts:455
+#: src\commands\rush-duel.ts:486
 msgid "Buttons can only be used by the user who called Bastion."
 msgstr ""
 
-#: src\commands\rush-duel.ts:401
+#: src\commands\rush-duel.ts:398
 #, javascript-format
 msgid "Could not find art for `${ input }`!"
 msgstr ""
@@ -524,127 +524,127 @@ msgctxt "monster-type-race"
 msgid "Gemini"
 msgstr "Zwilling"
 
-#: src\card.ts:66
+#: src\card.ts:72
 msgctxt "monster-type-race"
 msgid "Warrior"
 msgstr "Krieger"
 
-#: src\card.ts:67
+#: src\card.ts:73
 msgctxt "monster-type-race"
 msgid "Spellcaster"
 msgstr "Hexer"
 
-#: src\card.ts:68
+#: src\card.ts:74
 msgctxt "monster-type-race"
 msgid "Fairy"
 msgstr "Fee"
 
-#: src\card.ts:69
+#: src\card.ts:75
 msgctxt "monster-type-race"
 msgid "Fiend"
 msgstr "Unterweltler"
 
-#: src\card.ts:70
+#: src\card.ts:76
 msgctxt "monster-type-race"
 msgid "Zombie"
 msgstr "Zombie"
 
-#: src\card.ts:71
+#: src\card.ts:77
 msgctxt "monster-type-race"
 msgid "Machine"
 msgstr "Maschine"
 
-#: src\card.ts:72
+#: src\card.ts:78
 msgctxt "monster-type-race"
 msgid "Aqua"
 msgstr "Aqua"
 
-#: src\card.ts:73
+#: src\card.ts:79
 msgctxt "monster-type-race"
 msgid "Pyro"
 msgstr "Pyro"
 
-#: src\card.ts:74
+#: src\card.ts:80
 msgctxt "monster-type-race"
 msgid "Rock"
 msgstr "Fels"
 
-#: src\card.ts:75
+#: src\card.ts:81
 msgctxt "monster-type-race"
 msgid "Winged Beast"
 msgstr "Geflügeltes Ungeheuer"
 
-#: src\card.ts:76
+#: src\card.ts:82
 msgctxt "monster-type-race"
 msgid "Plant"
 msgstr "Pflanze"
 
-#: src\card.ts:77
+#: src\card.ts:83
 msgctxt "monster-type-race"
 msgid "Insect"
 msgstr "Insekt"
 
-#: src\card.ts:78
+#: src\card.ts:84
 msgctxt "monster-type-race"
 msgid "Thunder"
 msgstr "Donner"
 
-#: src\card.ts:79
+#: src\card.ts:85
 msgctxt "monster-type-race"
 msgid "Dragon"
 msgstr "Drache"
 
-#: src\card.ts:80
+#: src\card.ts:86
 msgctxt "monster-type-race"
 msgid "Beast"
 msgstr "Ungeheuer"
 
-#: src\card.ts:81
+#: src\card.ts:87
 msgctxt "monster-type-race"
 msgid "Beast-Warrior"
 msgstr "Ungeheuer-Krieger"
 
-#: src\card.ts:82
+#: src\card.ts:88
 msgctxt "monster-type-race"
 msgid "Dinosaur"
 msgstr "Dinosaurier"
 
-#: src\card.ts:83
+#: src\card.ts:89
 msgctxt "monster-type-race"
 msgid "Fish"
 msgstr "Fisch"
 
-#: src\card.ts:84
+#: src\card.ts:90
 msgctxt "monster-type-race"
 msgid "Sea Serpent"
 msgstr "Seeschlange"
 
-#: src\card.ts:85
+#: src\card.ts:91
 msgctxt "monster-type-race"
 msgid "Reptile"
 msgstr "Reptil"
 
-#: src\card.ts:86
+#: src\card.ts:92
 msgctxt "monster-type-race"
 msgid "Psychic"
 msgstr "Psi"
 
-#: src\card.ts:87
+#: src\card.ts:93
 msgctxt "monster-type-race"
 msgid "Divine-Beast"
 msgstr "Göttliches Ungeheuer"
 
-#: src\card.ts:88
+#: src\card.ts:94
 msgctxt "monster-type-race"
 msgid "Creator God"
 msgstr ""
 
-#: src\card.ts:89
+#: src\card.ts:95
 msgctxt "monster-type-race"
 msgid "Wyrm"
 msgstr "Wyrm"
 
-#: src\card.ts:90
+#: src\card.ts:96
 msgctxt "monster-type-race"
 msgid "Cyberse"
 msgstr "Cyberse"
@@ -694,54 +694,80 @@ msgctxt "spell-trap-property"
 msgid "Counter Trap"
 msgstr "Konterfalle"
 
-#: src\card.ts:96
+#: src\card.ts:62
+#. SpeedLimitRegulation is not converted to a number for display
+msgctxt "limit-regulation"
+msgid "Forbidden"
+msgstr "Verbotene"
+
+#: src\card.ts:63
+msgctxt "limit-regulation"
+msgid "Limited 1"
+msgstr ""
+
+#: src\card.ts:64
+msgctxt "limit-regulation"
+msgid "Limited 2"
+msgstr ""
+
+#: src\card.ts:65
+msgctxt "limit-regulation"
+msgid "Limited 3"
+msgstr ""
+
+#: src\card.ts:66
+msgctxt "limit-regulation"
+msgid "Unlimited"
+msgstr ""
+
+#: src\card.ts:102
 msgctxt "attribute"
 msgid "EARTH"
 msgstr "ERDE"
 
-#: src\card.ts:97
+#: src\card.ts:103
 msgctxt "attribute"
 msgid "WATER"
 msgstr "WASSER"
 
-#: src\card.ts:98
+#: src\card.ts:104
 msgctxt "attribute"
 msgid "FIRE"
 msgstr "FEUER"
 
-#: src\card.ts:99
+#: src\card.ts:105
 msgctxt "attribute"
 msgid "WIND"
 msgstr "WIND"
 
-#: src\card.ts:100
+#: src\card.ts:106
 msgctxt "attribute"
 msgid "LIGHT"
 msgstr "LICHT"
 
-#: src\card.ts:101
+#: src\card.ts:107
 msgctxt "attribute"
 msgid "DARK"
 msgstr "FINSTERNIS"
 
-#: src\card.ts:102
+#: src\card.ts:108
 msgctxt "attribute"
 msgid "DIVINE"
 msgstr "GÖTTLICH"
 
-#: src\card.ts:367
-#: src\card.ts:378
+#: src\card.ts:427
+#: src\card.ts:438
 #: src\commands\rush-duel.ts:142
 msgctxt "card-embed"
 msgid "Card Text"
 msgstr "Kartentext"
 
-#: src\card.ts:372
+#: src\card.ts:432
 msgctxt "card-embed"
 msgid "Pendulum Effect"
 msgstr "Pendeleffekt"
 
-#: src\card.ts:393
+#: src\card.ts:453
 msgctxt "card-embed"
 msgid "Card Effect"
 msgstr ""
@@ -768,27 +794,21 @@ msgctxt "card-embed"
 msgid "[MULTI-CHOICE EFFECT]"
 msgstr ""
 
-#: src\locale.ts:48
+#: src\locale.ts:71
 msgctxt "command-option"
 msgid "result-language"
 msgstr ""
 
-#: src\locale.ts:68
+#: src\locale.ts:131
 msgctxt "command-option"
 msgid "input-language"
 msgstr ""
 
-#: src\commands\art.ts:36
-#: src\commands\art.ts:46
-#: src\commands\art.ts:58
-#: src\commands\price.ts:64
-#: src\commands\price.ts:74
-#: src\commands\price.ts:86
 #: src\commands\rush-duel.ts:194
 #: src\commands\rush-duel.ts:206
-#: src\commands\search.ts:39
-#: src\commands\search.ts:49
-#: src\commands\search.ts:61
+#: src\locale.ts:147
+#: src\locale.ts:165
+#: src\locale.ts:181
 msgctxt "command-option"
 msgid "input"
 msgstr ""
@@ -808,50 +828,44 @@ msgctxt "command-option"
 msgid "page"
 msgstr ""
 
-#: src\commands\deck.ts:122
+#: src\commands\deck.ts:126
 msgctxt "command-option"
 msgid "url"
 msgstr ""
 
-#: src\commands\deck.ts:128
+#: src\commands\deck.ts:132
 msgctxt "command-option"
 msgid "file"
 msgstr ""
 
-#: src\commands\deck.ts:134
-#: src\commands\deck.ts:140
+#: src\commands\deck.ts:138
+#: src\commands\deck.ts:144
 msgctxt "command-option"
 msgid "deck"
 msgstr ""
 
-#: src\commands\deck.ts:146
+#: src\commands\deck.ts:150
 msgctxt "command-option"
 msgid "public"
 msgstr ""
 
-#: src\commands\deck.ts:153
+#: src\commands\deck.ts:157
 msgctxt "command-option"
 msgid "stacked"
 msgstr ""
 
-#: src\commands\art.ts:31
-#: src\commands\price.ts:59
-#: src\commands\search.ts:34
+#: src\locale.ts:142
 msgctxt "command-option"
 msgid "name"
 msgstr ""
 
-#: src\commands\art.ts:41
-#: src\commands\price.ts:69
-#: src\commands\search.ts:44
+#: src\locale.ts:160
 msgctxt "command-option"
 msgid "password"
 msgstr ""
 
-#: src\commands\art.ts:53
-#: src\commands\price.ts:81
 #: src\commands\rush-duel.ts:199
-#: src\commands\search.ts:56
+#: src\locale.ts:176
 msgctxt "command-option"
 msgid "konami-id"
 msgstr ""
@@ -876,7 +890,7 @@ msgctxt "command-option"
 msgid "locale"
 msgstr ""
 
-#: src\commands\price.ts:91
+#: src\commands\price.ts:65
 msgctxt "command-option"
 msgid "vendor"
 msgstr ""
@@ -896,12 +910,12 @@ msgctxt "command-option"
 msgid "art"
 msgstr ""
 
-#: src\locale.ts:51
+#: src\locale.ts:74
 msgctxt "command-option-description"
 msgid "The output language for the card embed, overriding other settings."
 msgstr ""
 
-#: src\locale.ts:71
+#: src\locale.ts:132
 msgctxt "command-option-description"
 msgid "The language to search in, defaulting to the result language."
 msgstr ""
@@ -916,85 +930,79 @@ msgctxt "command-option-description"
 msgid "The name of the Yugipedia page you want to search for."
 msgstr ""
 
-#: src\commands\deck.ts:125
+#: src\commands\deck.ts:129
 msgctxt "command-option-description"
 msgid "View a deck by entering a ydke:// URL."
 msgstr ""
 
-#: src\commands\deck.ts:131
+#: src\commands\deck.ts:135
 msgctxt "command-option-description"
 msgid "View a deck by uploading a .ydk file."
 msgstr ""
 
-#: src\commands\deck.ts:137
+#: src\commands\deck.ts:141
 msgctxt "command-option-description"
 msgid "The ydke:// URL of the deck you want to view."
 msgstr ""
 
-#: src\commands\deck.ts:143
+#: src\commands\deck.ts:147
 msgctxt "command-option-description"
 msgid "The .ydk file of the deck you want to view."
 msgstr ""
 
-#: src\commands\deck.ts:149
+#: src\commands\deck.ts:153
 msgctxt "command-option-description"
 msgid "Whether to display the deck details publicly in chat. This is false by default."
 msgstr ""
 
-#: src\commands\deck.ts:156
+#: src\commands\deck.ts:160
 msgctxt "command-option-description"
 msgid "Whether to display the deck sections as one stacked column. This is false (side-by-side) by default."
 msgstr ""
 
-#: src\commands\art.ts:32
+#: src\commands\art.ts:41
 msgctxt "command-option-description"
 msgid "Display the art for the card with this name."
 msgstr ""
 
-#: src\commands\art.ts:37
-#: src\commands\price.ts:65
 #: src\commands\rush-duel.ts:195
-#: src\commands\search.ts:40
+#: src\locale.ts:148
 msgctxt "command-option-description"
 msgid "Card name, fuzzy matching supported."
 msgstr ""
 
-#: src\commands\art.ts:42
+#: src\commands\art.ts:44
 msgctxt "command-option-description"
 msgid "Display the art for the card with this password."
 msgstr ""
 
-#: src\commands\art.ts:48
-#: src\commands\price.ts:76
-#: src\commands\search.ts:51
+#: src\locale.ts:167
 msgctxt "command-option-description"
 msgid "Card password, the eight-digit number printed on the bottom left corner."
 msgstr ""
 
-#: src\commands\art.ts:54
+#: src\commands\art.ts:47
 msgctxt "command-option-description"
 msgid "Display the art for the card with this official database ID."
 msgstr ""
 
-#: src\commands\art.ts:59
-#: src\commands\price.ts:87
 #: src\commands\rush-duel.ts:207
-#: src\commands\search.ts:62
+#: src\locale.ts:182
 msgctxt "command-option-description"
 msgid "Konami's official card database identifier."
 msgstr ""
 
-#: src\commands\search.ts:35
+#: src\commands\search.ts:40
 msgctxt "command-option-description"
 msgid "Find all information for the card with this name."
 msgstr ""
 
-#: src\commands\search.ts:45
+#: src\commands\search.ts:43
 msgctxt "command-option-description"
 msgid "Find all information for the card with this password."
 msgstr ""
 
-#: src\commands\search.ts:57
+#: src\commands\search.ts:46
 msgctxt "command-option-description"
 msgid "Find all information for the card with this official database ID."
 msgstr ""
@@ -1019,22 +1027,22 @@ msgctxt "command-option-description"
 msgid "The new default language to use in this channel or server."
 msgstr ""
 
-#: src\commands\price.ts:60
+#: src\commands\price.ts:69
 msgctxt "command-option-description"
 msgid "Display the price for the card with this name."
 msgstr ""
 
-#: src\commands\price.ts:70
+#: src\commands\price.ts:73
 msgctxt "command-option-description"
 msgid "Display the price for the card with this password."
 msgstr ""
 
-#: src\commands\price.ts:82
+#: src\commands\price.ts:76
 msgctxt "command-option-description"
 msgid "Display the price for the card with this official database ID."
 msgstr ""
 
-#: src\commands\price.ts:92
+#: src\commands\price.ts:66
 msgctxt "command-option-description"
 msgid "The vendor to fetch the price data from."
 msgstr ""
@@ -1064,7 +1072,7 @@ msgctxt "command-option-description"
 msgid "Display just the art for the Rush Duel card with this name."
 msgstr ""
 
-#: src\commands\art.ts:26
+#: src\commands\art.ts:37
 msgctxt "command-name"
 msgid "art"
 msgstr ""
@@ -1089,12 +1097,12 @@ msgctxt "command-name"
 msgid "yugipedia"
 msgstr ""
 
-#: src\commands\deck.ts:115
+#: src\commands\deck.ts:119
 msgctxt "command-name"
 msgid "deck"
 msgstr ""
 
-#: src\commands\search.ts:29
+#: src\commands\search.ts:36
 msgctxt "command-name"
 msgid "search"
 msgstr ""
@@ -1104,12 +1112,12 @@ msgctxt "command-name"
 msgid "locale"
 msgstr ""
 
-#: src\commands\random.ts:24
+#: src\commands\random.ts:30
 msgctxt "command-name"
 msgid "random"
 msgstr ""
 
-#: src\commands\price.ts:54
+#: src\commands\price.ts:60
 msgctxt "command-name"
 msgid "price"
 msgstr ""
@@ -1119,7 +1127,7 @@ msgctxt "command-name"
 msgid "rush-duel"
 msgstr ""
 
-#: src\commands\art.ts:27
+#: src\commands\art.ts:38
 msgctxt "command-description"
 msgid "Display the art for a card!"
 msgstr ""
@@ -1144,12 +1152,12 @@ msgctxt "command-description"
 msgid "Search the Yugipedia wiki for a page and link to it."
 msgstr ""
 
-#: src\commands\deck.ts:118
+#: src\commands\deck.ts:122
 msgctxt "command-description"
 msgid "Display a deck list from ydke:// or .ydk format, exported from a number of deck building programs."
 msgstr ""
 
-#: src\commands\search.ts:30
+#: src\commands\search.ts:37
 msgctxt "command-description"
 msgid "Find all information on a card!"
 msgstr ""
@@ -1159,12 +1167,12 @@ msgctxt "command-description"
 msgid "Check or set Bastion's locale for this channel or server."
 msgstr ""
 
-#: src\commands\random.ts:25
+#: src\commands\random.ts:31
 msgctxt "command-description"
 msgid "Get a random Yu-Gi-Oh! card."
 msgstr ""
 
-#: src\commands\price.ts:55
+#: src\commands\price.ts:61
 msgctxt "command-description"
 msgid "Display the price for a card!"
 msgstr ""

--- a/translations/es.po
+++ b/translations/es.po
@@ -6,186 +6,186 @@ msgstr ""
 "MIME-Version: 1.0\n"
 "Content-Transfer-Encoding: 8bit\n"
 
-#: src\card.ts:279
+#: src\card.ts:339
 #: src\commands\rush-duel.ts:60
 msgid "🔗 Links"
 msgstr ""
 
-#: src\card.ts:280
+#: src\card.ts:340
 #, javascript-format
 msgid "[Official Konami DB](${ official }) | [OCG Rulings](${ rulings }) | [Yugipedia](${ yugipedia }) | [YGOPRODECK](${ ygoprodeck })"
 msgstr ""
 
-#: src\card.ts:283
+#: src\card.ts:343
 #, javascript-format
 msgid "[Yugipedia](${ yugipedia }) | [YGOPRODECK](${ ygoprodeck })"
 msgstr ""
 
-#: src\card.ts:343
+#: src\card.ts:403
 #: src\commands\rush-duel.ts:107
 #, javascript-format
 msgid "**Type**: ${ RaceIcon[race] } ${ localizedMonsterTypeLine }"
 msgstr "**Tipo**: ${ RaceIcon[race] } ${ localizedMonsterTypeLine }"
 
-#: src\card.ts:345
+#: src\card.ts:405
 #: src\commands\rush-duel.ts:109
 #, javascript-format
 msgid "**Attribute**: ${ AttributeIcon[card.attribute] } ${ localizedAttribute }"
 msgstr "**Atributo**: ${ AttributeIcon[card.attribute] } ${ localizedAttribute }"
 
-#: src\card.ts:349
+#: src\card.ts:409
 msgid "**Rank**: ${ Icon.Rank } ${ card.rank } **ATK**: ${ card.atk } **DEF**: ${ card.def }"
 msgstr "**Rango**: ${ Icon.Rank } ${ card.rank } **ATK**: ${ card.atk } **DEF**: ${ card.def }"
 
-#: src\card.ts:352
+#: src\card.ts:412
 #, javascript-format
 msgid "**Link Rating**: ${ card.link_arrows.length } **ATK**: ${ card.atk } **Link Arrows**: ${ arrows }"
 msgstr ""
 
-#: src\card.ts:354
+#: src\card.ts:414
 #: src\commands\rush-duel.ts:111
 #, javascript-format
 msgid "**Level**: ${ Icon.Level } ${ card.level } **ATK**: ${ card.atk } **DEF**: ${ card.def }"
 msgstr "**Nivel**: ${ Icon.Level } ${ card.level } **ATK**: ${ card.atk } **DEF**: ${ card.def }"
 
-#: src\card.ts:361
+#: src\card.ts:421
 msgid "**Pendulum Scale**: ${ formattedScale }"
 msgstr "**Escala de Péndulo**: ${ formattedScale }"
 
-#: src\card.ts:240
+#: src\card.ts:300
 #, javascript-format
 msgid "Password: ${ card.password } | Konami ID #${ card.konami_id }"
 msgstr ""
 
-#: src\card.ts:242
+#: src\card.ts:302
 msgid "No password | Konami ID #${ card.konami_id }"
 msgstr ""
 
-#: src\card.ts:244
+#: src\card.ts:304
 #, javascript-format
 msgid "Password: ${ card.password } | Not yet released"
 msgstr ""
 
-#: src\card.ts:246
+#: src\card.ts:306
 #: src\commands\rush-duel.ts:161
 msgid "Not yet released"
 msgstr ""
 
-#: src\card.ts:250
+#: src\card.ts:310
 #, javascript-format
 msgid "Placeholder ID: ${ card.fake_password }"
 msgstr ""
 
-#: src\utils.ts:45
+#: src\utils.ts:41
 msgid "🛠️ This command is in development."
 msgstr ""
 
-#: src\utils.ts:46
+#: src\utils.ts:42
 msgid "📨 Please send feedback to [our issue tracker](https://github.com/DawnbrandBots/bastion-bot) or the [support server](https://discord.gg/4aFuPyuE96)!"
 msgstr ""
 
-#: src\utils.ts:57
+#: src\utils.ts:53
 msgid "Please consider supporting us!"
 msgstr ""
 
-#: src\utils.ts:58
+#: src\utils.ts:54
 msgid "Help keep Bastion online!"
 msgstr ""
 
-#: src\utils.ts:59
+#: src\utils.ts:55
 msgid "Please help keep Bastion online!"
 msgstr ""
 
-#: src\utils.ts:60
+#: src\utils.ts:56
 msgid "Was Bastion helpful? Consider supporting us!"
 msgstr ""
 
-#: src\utils.ts:61
+#: src\utils.ts:57
 msgid "Was Bastion helpful? We need your support!"
 msgstr ""
 
-#: src\utils.ts:62
+#: src\utils.ts:58
 msgid "Did you find Bastion useful? Consider supporting us!"
 msgstr ""
 
-#: src\utils.ts:63
+#: src\utils.ts:59
 msgid "Did you find Bastion useful? Help keep it online!"
 msgstr ""
 
-#: src\utils.ts:64
+#: src\utils.ts:60
 msgid "Did you find Bastion useful? We need your support!"
 msgstr ""
 
-#: src\utils.ts:65
+#: src\utils.ts:61
 msgid "Enjoy Bastion? Help keep it online!"
 msgstr ""
 
-#: src\utils.ts:66
+#: src\utils.ts:62
 msgid "Enjoy Bastion? Consider supporting us!"
 msgstr ""
 
-#: src\utils.ts:67
+#: src\utils.ts:63
 msgid "Found what you were looking for? Consider supporting us!"
 msgstr ""
 
-#: src\commands\art.ts:97
-#: src\commands\price.ts:148
-#: src\commands\rush-duel.ts:309
-#: src\commands\rush-duel.ts:342
-#: src\commands\search.ts:89
-#: src\events\message-search.ts:270
+#: src\commands\art.ts:69
+#: src\commands\price.ts:121
+#: src\commands\rush-duel.ts:306
+#: src\commands\rush-duel.ts:339
+#: src\commands\search.ts:62
+#: src\events\message-search.ts:295
 #, javascript-format
 msgid "Could not find a card matching `${ input }`!"
 msgstr ""
 
-#: src\commands\art.ts:107
+#: src\commands\art.ts:83
 msgid "Could not find art for `${ name }`!"
 msgstr ""
 
-#: src\commands\deck.ts:245
+#: src\commands\deck.ts:248
 #, javascript-format
 msgid "${ counts.Monster } Monster"
 msgid_plural "${ counts.Monster } Monsters"
 msgstr[0] ""
 msgstr[1] ""
 
-#: src\commands\deck.ts:248
+#: src\commands\deck.ts:251
 msgid "${ counts.Spell } Spell"
 msgid_plural "${ counts.Spell } Spells"
 msgstr[0] ""
 msgstr[1] ""
 
-#: src\commands\deck.ts:251
+#: src\commands\deck.ts:254
 #, javascript-format
 msgid "${ counts.Trap } Trap"
 msgid_plural "${ counts.Trap } Traps"
 msgstr[0] ""
 msgstr[1] ""
 
-#: src\commands\deck.ts:279
+#: src\commands\deck.ts:282
 msgid "Your Deck"
 msgstr ""
 
-#: src\commands\deck.ts:284
+#: src\commands\deck.ts:287
 #, javascript-format
 msgid "Main Deck (${ deck.main.length } card — ${ countDetail })"
 msgid_plural "Main Deck (${ deck.main.length } cards — ${ countDetail })"
 msgstr[0] ""
 msgstr[1] ""
 
-#: src\commands\deck.ts:291
+#: src\commands\deck.ts:294
 msgid "Main Deck (continued)"
 msgstr ""
 
-#: src\commands\deck.ts:305
+#: src\commands\deck.ts:308
 msgid "Extra Deck (continued)"
 msgstr ""
 
-#: src\commands\deck.ts:319
+#: src\commands\deck.ts:322
 msgid "Side Deck (continued)"
 msgstr ""
 
-#: src\commands\deck.ts:409
+#: src\commands\deck.ts:411
 msgid "Error: Your deck is empty."
 msgstr ""
 
@@ -279,79 +279,79 @@ msgstr ""
 msgid "Revision: ${ process.env.BOT_REVISION }."
 msgstr ""
 
-#: src\commands\deck.ts:329
+#: src\commands\deck.ts:332
 msgid ".ydk files must have the .ydk extension!"
 msgstr ""
 
-#: src\commands\deck.ts:332
+#: src\commands\deck.ts:335
 msgid ".ydk files should not be larger than 1 KB!"
 msgstr ""
 
-#: src\commands\deck.ts:322
+#: src\commands\deck.ts:325
 msgid "ydke URL"
 msgstr ""
 
-#: src\card.ts:317
+#: src\card.ts:377
 #. Forbidden/Limited Lists or Limit Regulations in the OCG
 msgid "**Limit**: ${ limitRegulationDisplay }"
 msgstr ""
 
-#: src\commands\price.ts:38
+#: src\commands\price.ts:40
 msgid "TCGPlayer"
 msgstr ""
 
-#: src\commands\price.ts:39
+#: src\commands\price.ts:41
 msgid "Cardmarket"
 msgstr ""
 
-#: src\commands\price.ts:40
+#: src\commands\price.ts:42
 msgid "CoolStuffInc"
 msgstr ""
 
-#: src\commands\price.ts:118
+#: src\commands\price.ts:96
 #. TODO: future, determine localisation and relevance status of this error
 msgid "Sorry, I can't find the price for a card with no English name!"
 msgstr ""
 
-#: src\commands\price.ts:162
+#: src\commands\price.ts:140
 msgid "No market price"
 msgstr ""
 
-#: src\commands\price.ts:170
+#: src\commands\price.ts:148
 #, javascript-format
 msgid "Prices for ${ card.name[resultLanguage] } - ${ vendorName }"
 msgstr ""
 
-#: src\commands\price.ts:184
+#: src\commands\price.ts:162
 msgid "Could not find prices for `${ name }`!"
 msgstr ""
 
-#: src\commands\deck.ts:427
+#: src\commands\deck.ts:429
 #. prepare interaction button for FTP upload
 msgid "Upload to YGOPRODECK"
 msgstr ""
 
-#: src\commands\deck.ts:485
+#: src\commands\deck.ts:487
 #. disable original button
 #. prepare row to disable button on original message
 msgid "Upload Complete"
 msgstr ""
 
-#: src\commands\deck.ts:472
+#: src\commands\deck.ts:474
 msgid "Deck upload failed!"
 msgstr ""
 
-#: src\commands\deck.ts:493
+#: src\commands\deck.ts:495
 #. reply in affirmation
 #, javascript-format
 msgid "Deck successfully uploaded to <${ url }>!"
 msgstr ""
 
-#: src\events\message-search.ts:275
+#: src\events\message-search.ts:300
 msgid "💬 Translations missing?"
 msgstr ""
 
-#: src\events\message-search.ts:276
+#: src\events\message-search.ts:301
 msgid "Help translate Bastion at the links above."
 msgstr ""
 
@@ -371,11 +371,11 @@ msgid ""
 "💬 Translations missing? Help translate Bastion on [GitHub](https://github.com/DawnbrandBots/bastion-bot)."
 msgstr ""
 
-#: src\events\message-search.ts:268
+#: src\events\message-search.ts:293
 msgid "Search type: ${ localisedType }"
 msgstr ""
 
-#: src\events\message-search.ts:265
+#: src\events\message-search.ts:290
 #, javascript-format
 msgid "Search language: **${ localisedInputLanguage }** (${ inputLanguage }). Check defaults with </locale get:${ id }> and configure with </locale set:${ id }>"
 msgstr ""
@@ -385,22 +385,22 @@ msgid "⚠️ You pinged me, but I am missing permissions in the channel!"
 msgstr ""
 
 #: src\events\message-ping.ts:94
-#: src\events\message-search.ts:182
+#: src\events\message-search.ts:192
 msgid "Please have a server administrator [fix this](https://github.com/DawnbrandBots/bastion-bot#discord-permissions)."
 msgstr ""
 
-#: src\events\message-search.ts:179
+#: src\events\message-search.ts:189
 msgid "⚠️ I am missing permissions in the channel!"
 msgstr ""
 
-#: src\commands\deck.ts:298
+#: src\commands\deck.ts:301
 #, javascript-format
 msgid "Extra Deck (${ deck.extra.length } card — ${ countDetail })"
 msgid_plural "Extra Deck (${ deck.extra.length } cards — ${ countDetail })"
 msgstr[0] ""
 msgstr[1] ""
 
-#: src\commands\deck.ts:312
+#: src\commands\deck.ts:315
 #, javascript-format
 msgid "Side Deck (${ deck.side.length } card — ${ countDetail })"
 msgid_plural "Side Deck (${ deck.side.length } cards — ${ countDetail })"
@@ -444,12 +444,12 @@ msgstr ""
 msgid "Konami ID #${ card.konami_id }"
 msgstr ""
 
-#: src\commands\deck.ts:453
-#: src\commands\rush-duel.ts:489
+#: src\commands\deck.ts:455
+#: src\commands\rush-duel.ts:486
 msgid "Buttons can only be used by the user who called Bastion."
 msgstr ""
 
-#: src\commands\rush-duel.ts:401
+#: src\commands\rush-duel.ts:398
 #, javascript-format
 msgid "Could not find art for `${ input }`!"
 msgstr ""
@@ -524,127 +524,127 @@ msgctxt "monster-type-race"
 msgid "Gemini"
 msgstr "Géminis"
 
-#: src\card.ts:66
+#: src\card.ts:72
 msgctxt "monster-type-race"
 msgid "Warrior"
 msgstr "Guerrero"
 
-#: src\card.ts:67
+#: src\card.ts:73
 msgctxt "monster-type-race"
 msgid "Spellcaster"
 msgstr "Lanzador de Conjuros"
 
-#: src\card.ts:68
+#: src\card.ts:74
 msgctxt "monster-type-race"
 msgid "Fairy"
 msgstr "Hada"
 
-#: src\card.ts:69
+#: src\card.ts:75
 msgctxt "monster-type-race"
 msgid "Fiend"
 msgstr "Demonio"
 
-#: src\card.ts:70
+#: src\card.ts:76
 msgctxt "monster-type-race"
 msgid "Zombie"
 msgstr "Zombi"
 
-#: src\card.ts:71
+#: src\card.ts:77
 msgctxt "monster-type-race"
 msgid "Machine"
 msgstr "Máquina"
 
-#: src\card.ts:72
+#: src\card.ts:78
 msgctxt "monster-type-race"
 msgid "Aqua"
 msgstr "Aqua"
 
-#: src\card.ts:73
+#: src\card.ts:79
 msgctxt "monster-type-race"
 msgid "Pyro"
 msgstr "Piro"
 
-#: src\card.ts:74
+#: src\card.ts:80
 msgctxt "monster-type-race"
 msgid "Rock"
 msgstr "Roca"
 
-#: src\card.ts:75
+#: src\card.ts:81
 msgctxt "monster-type-race"
 msgid "Winged Beast"
 msgstr "Bestia Alada"
 
-#: src\card.ts:76
+#: src\card.ts:82
 msgctxt "monster-type-race"
 msgid "Plant"
 msgstr "Pianta"
 
-#: src\card.ts:77
+#: src\card.ts:83
 msgctxt "monster-type-race"
 msgid "Insect"
 msgstr "Insecto"
 
-#: src\card.ts:78
+#: src\card.ts:84
 msgctxt "monster-type-race"
 msgid "Thunder"
 msgstr "Trueno"
 
-#: src\card.ts:79
+#: src\card.ts:85
 msgctxt "monster-type-race"
 msgid "Dragon"
 msgstr "Dragón"
 
-#: src\card.ts:80
+#: src\card.ts:86
 msgctxt "monster-type-race"
 msgid "Beast"
 msgstr "Bestia"
 
-#: src\card.ts:81
+#: src\card.ts:87
 msgctxt "monster-type-race"
 msgid "Beast-Warrior"
 msgstr "Guerrero-Bestia"
 
-#: src\card.ts:82
+#: src\card.ts:88
 msgctxt "monster-type-race"
 msgid "Dinosaur"
 msgstr "Dinosaurio"
 
-#: src\card.ts:83
+#: src\card.ts:89
 msgctxt "monster-type-race"
 msgid "Fish"
 msgstr "Pez"
 
-#: src\card.ts:84
+#: src\card.ts:90
 msgctxt "monster-type-race"
 msgid "Sea Serpent"
 msgstr "Serpiente Marina"
 
-#: src\card.ts:85
+#: src\card.ts:91
 msgctxt "monster-type-race"
 msgid "Reptile"
 msgstr "Reptil"
 
-#: src\card.ts:86
+#: src\card.ts:92
 msgctxt "monster-type-race"
 msgid "Psychic"
 msgstr "Psíquico"
 
-#: src\card.ts:87
+#: src\card.ts:93
 msgctxt "monster-type-race"
 msgid "Divine-Beast"
 msgstr "Bestia Divina"
 
-#: src\card.ts:88
+#: src\card.ts:94
 msgctxt "monster-type-race"
 msgid "Creator God"
 msgstr ""
 
-#: src\card.ts:89
+#: src\card.ts:95
 msgctxt "monster-type-race"
 msgid "Wyrm"
 msgstr "Wyrm"
 
-#: src\card.ts:90
+#: src\card.ts:96
 msgctxt "monster-type-race"
 msgid "Cyberse"
 msgstr "Ciberso"
@@ -694,54 +694,80 @@ msgctxt "spell-trap-property"
 msgid "Counter Trap"
 msgstr "Trampa de Contraefecto"
 
-#: src\card.ts:96
+#: src\card.ts:62
+#. SpeedLimitRegulation is not converted to a number for display
+msgctxt "limit-regulation"
+msgid "Forbidden"
+msgstr "Prohibida"
+
+#: src\card.ts:63
+msgctxt "limit-regulation"
+msgid "Limited 1"
+msgstr ""
+
+#: src\card.ts:64
+msgctxt "limit-regulation"
+msgid "Limited 2"
+msgstr ""
+
+#: src\card.ts:65
+msgctxt "limit-regulation"
+msgid "Limited 3"
+msgstr ""
+
+#: src\card.ts:66
+msgctxt "limit-regulation"
+msgid "Unlimited"
+msgstr ""
+
+#: src\card.ts:102
 msgctxt "attribute"
 msgid "EARTH"
 msgstr "TIERRA"
 
-#: src\card.ts:97
+#: src\card.ts:103
 msgctxt "attribute"
 msgid "WATER"
 msgstr "AGUA"
 
-#: src\card.ts:98
+#: src\card.ts:104
 msgctxt "attribute"
 msgid "FIRE"
 msgstr "FUEGO"
 
-#: src\card.ts:99
+#: src\card.ts:105
 msgctxt "attribute"
 msgid "WIND"
 msgstr "VIENTO"
 
-#: src\card.ts:100
+#: src\card.ts:106
 msgctxt "attribute"
 msgid "LIGHT"
 msgstr "LUZ"
 
-#: src\card.ts:101
+#: src\card.ts:107
 msgctxt "attribute"
 msgid "DARK"
 msgstr "OSCURIDAD"
 
-#: src\card.ts:102
+#: src\card.ts:108
 msgctxt "attribute"
 msgid "DIVINE"
 msgstr "DIVINIDAD"
 
-#: src\card.ts:367
-#: src\card.ts:378
+#: src\card.ts:427
+#: src\card.ts:438
 #: src\commands\rush-duel.ts:142
 msgctxt "card-embed"
 msgid "Card Text"
 msgstr "Texto de carta"
 
-#: src\card.ts:372
+#: src\card.ts:432
 msgctxt "card-embed"
 msgid "Pendulum Effect"
 msgstr "Efecto de Péndulo"
 
-#: src\card.ts:393
+#: src\card.ts:453
 msgctxt "card-embed"
 msgid "Card Effect"
 msgstr ""
@@ -768,27 +794,21 @@ msgctxt "card-embed"
 msgid "[MULTI-CHOICE EFFECT]"
 msgstr ""
 
-#: src\locale.ts:48
+#: src\locale.ts:71
 msgctxt "command-option"
 msgid "result-language"
 msgstr ""
 
-#: src\locale.ts:68
+#: src\locale.ts:131
 msgctxt "command-option"
 msgid "input-language"
 msgstr ""
 
-#: src\commands\art.ts:36
-#: src\commands\art.ts:46
-#: src\commands\art.ts:58
-#: src\commands\price.ts:64
-#: src\commands\price.ts:74
-#: src\commands\price.ts:86
 #: src\commands\rush-duel.ts:194
 #: src\commands\rush-duel.ts:206
-#: src\commands\search.ts:39
-#: src\commands\search.ts:49
-#: src\commands\search.ts:61
+#: src\locale.ts:147
+#: src\locale.ts:165
+#: src\locale.ts:181
 msgctxt "command-option"
 msgid "input"
 msgstr ""
@@ -808,50 +828,44 @@ msgctxt "command-option"
 msgid "page"
 msgstr ""
 
-#: src\commands\deck.ts:122
+#: src\commands\deck.ts:126
 msgctxt "command-option"
 msgid "url"
 msgstr ""
 
-#: src\commands\deck.ts:128
+#: src\commands\deck.ts:132
 msgctxt "command-option"
 msgid "file"
 msgstr ""
 
-#: src\commands\deck.ts:134
-#: src\commands\deck.ts:140
+#: src\commands\deck.ts:138
+#: src\commands\deck.ts:144
 msgctxt "command-option"
 msgid "deck"
 msgstr ""
 
-#: src\commands\deck.ts:146
+#: src\commands\deck.ts:150
 msgctxt "command-option"
 msgid "public"
 msgstr ""
 
-#: src\commands\deck.ts:153
+#: src\commands\deck.ts:157
 msgctxt "command-option"
 msgid "stacked"
 msgstr ""
 
-#: src\commands\art.ts:31
-#: src\commands\price.ts:59
-#: src\commands\search.ts:34
+#: src\locale.ts:142
 msgctxt "command-option"
 msgid "name"
 msgstr ""
 
-#: src\commands\art.ts:41
-#: src\commands\price.ts:69
-#: src\commands\search.ts:44
+#: src\locale.ts:160
 msgctxt "command-option"
 msgid "password"
 msgstr ""
 
-#: src\commands\art.ts:53
-#: src\commands\price.ts:81
 #: src\commands\rush-duel.ts:199
-#: src\commands\search.ts:56
+#: src\locale.ts:176
 msgctxt "command-option"
 msgid "konami-id"
 msgstr ""
@@ -876,7 +890,7 @@ msgctxt "command-option"
 msgid "locale"
 msgstr ""
 
-#: src\commands\price.ts:91
+#: src\commands\price.ts:65
 msgctxt "command-option"
 msgid "vendor"
 msgstr ""
@@ -896,12 +910,12 @@ msgctxt "command-option"
 msgid "art"
 msgstr ""
 
-#: src\locale.ts:51
+#: src\locale.ts:74
 msgctxt "command-option-description"
 msgid "The output language for the card embed, overriding other settings."
 msgstr ""
 
-#: src\locale.ts:71
+#: src\locale.ts:132
 msgctxt "command-option-description"
 msgid "The language to search in, defaulting to the result language."
 msgstr ""
@@ -916,85 +930,79 @@ msgctxt "command-option-description"
 msgid "The name of the Yugipedia page you want to search for."
 msgstr ""
 
-#: src\commands\deck.ts:125
+#: src\commands\deck.ts:129
 msgctxt "command-option-description"
 msgid "View a deck by entering a ydke:// URL."
 msgstr ""
 
-#: src\commands\deck.ts:131
+#: src\commands\deck.ts:135
 msgctxt "command-option-description"
 msgid "View a deck by uploading a .ydk file."
 msgstr ""
 
-#: src\commands\deck.ts:137
+#: src\commands\deck.ts:141
 msgctxt "command-option-description"
 msgid "The ydke:// URL of the deck you want to view."
 msgstr ""
 
-#: src\commands\deck.ts:143
+#: src\commands\deck.ts:147
 msgctxt "command-option-description"
 msgid "The .ydk file of the deck you want to view."
 msgstr ""
 
-#: src\commands\deck.ts:149
+#: src\commands\deck.ts:153
 msgctxt "command-option-description"
 msgid "Whether to display the deck details publicly in chat. This is false by default."
 msgstr ""
 
-#: src\commands\deck.ts:156
+#: src\commands\deck.ts:160
 msgctxt "command-option-description"
 msgid "Whether to display the deck sections as one stacked column. This is false (side-by-side) by default."
 msgstr ""
 
-#: src\commands\art.ts:32
+#: src\commands\art.ts:41
 msgctxt "command-option-description"
 msgid "Display the art for the card with this name."
 msgstr ""
 
-#: src\commands\art.ts:37
-#: src\commands\price.ts:65
 #: src\commands\rush-duel.ts:195
-#: src\commands\search.ts:40
+#: src\locale.ts:148
 msgctxt "command-option-description"
 msgid "Card name, fuzzy matching supported."
 msgstr ""
 
-#: src\commands\art.ts:42
+#: src\commands\art.ts:44
 msgctxt "command-option-description"
 msgid "Display the art for the card with this password."
 msgstr ""
 
-#: src\commands\art.ts:48
-#: src\commands\price.ts:76
-#: src\commands\search.ts:51
+#: src\locale.ts:167
 msgctxt "command-option-description"
 msgid "Card password, the eight-digit number printed on the bottom left corner."
 msgstr ""
 
-#: src\commands\art.ts:54
+#: src\commands\art.ts:47
 msgctxt "command-option-description"
 msgid "Display the art for the card with this official database ID."
 msgstr ""
 
-#: src\commands\art.ts:59
-#: src\commands\price.ts:87
 #: src\commands\rush-duel.ts:207
-#: src\commands\search.ts:62
+#: src\locale.ts:182
 msgctxt "command-option-description"
 msgid "Konami's official card database identifier."
 msgstr ""
 
-#: src\commands\search.ts:35
+#: src\commands\search.ts:40
 msgctxt "command-option-description"
 msgid "Find all information for the card with this name."
 msgstr ""
 
-#: src\commands\search.ts:45
+#: src\commands\search.ts:43
 msgctxt "command-option-description"
 msgid "Find all information for the card with this password."
 msgstr ""
 
-#: src\commands\search.ts:57
+#: src\commands\search.ts:46
 msgctxt "command-option-description"
 msgid "Find all information for the card with this official database ID."
 msgstr ""
@@ -1019,22 +1027,22 @@ msgctxt "command-option-description"
 msgid "The new default language to use in this channel or server."
 msgstr ""
 
-#: src\commands\price.ts:60
+#: src\commands\price.ts:69
 msgctxt "command-option-description"
 msgid "Display the price for the card with this name."
 msgstr ""
 
-#: src\commands\price.ts:70
+#: src\commands\price.ts:73
 msgctxt "command-option-description"
 msgid "Display the price for the card with this password."
 msgstr ""
 
-#: src\commands\price.ts:82
+#: src\commands\price.ts:76
 msgctxt "command-option-description"
 msgid "Display the price for the card with this official database ID."
 msgstr ""
 
-#: src\commands\price.ts:92
+#: src\commands\price.ts:66
 msgctxt "command-option-description"
 msgid "The vendor to fetch the price data from."
 msgstr ""
@@ -1064,7 +1072,7 @@ msgctxt "command-option-description"
 msgid "Display just the art for the Rush Duel card with this name."
 msgstr ""
 
-#: src\commands\art.ts:26
+#: src\commands\art.ts:37
 msgctxt "command-name"
 msgid "art"
 msgstr ""
@@ -1089,12 +1097,12 @@ msgctxt "command-name"
 msgid "yugipedia"
 msgstr ""
 
-#: src\commands\deck.ts:115
+#: src\commands\deck.ts:119
 msgctxt "command-name"
 msgid "deck"
 msgstr ""
 
-#: src\commands\search.ts:29
+#: src\commands\search.ts:36
 msgctxt "command-name"
 msgid "search"
 msgstr ""
@@ -1104,12 +1112,12 @@ msgctxt "command-name"
 msgid "locale"
 msgstr ""
 
-#: src\commands\random.ts:24
+#: src\commands\random.ts:30
 msgctxt "command-name"
 msgid "random"
 msgstr ""
 
-#: src\commands\price.ts:54
+#: src\commands\price.ts:60
 msgctxt "command-name"
 msgid "price"
 msgstr ""
@@ -1119,7 +1127,7 @@ msgctxt "command-name"
 msgid "rush-duel"
 msgstr ""
 
-#: src\commands\art.ts:27
+#: src\commands\art.ts:38
 msgctxt "command-description"
 msgid "Display the art for a card!"
 msgstr ""
@@ -1144,12 +1152,12 @@ msgctxt "command-description"
 msgid "Search the Yugipedia wiki for a page and link to it."
 msgstr ""
 
-#: src\commands\deck.ts:118
+#: src\commands\deck.ts:122
 msgctxt "command-description"
 msgid "Display a deck list from ydke:// or .ydk format, exported from a number of deck building programs."
 msgstr ""
 
-#: src\commands\search.ts:30
+#: src\commands\search.ts:37
 msgctxt "command-description"
 msgid "Find all information on a card!"
 msgstr ""
@@ -1159,12 +1167,12 @@ msgctxt "command-description"
 msgid "Check or set Bastion's locale for this channel or server."
 msgstr ""
 
-#: src\commands\random.ts:25
+#: src\commands\random.ts:31
 msgctxt "command-description"
 msgid "Get a random Yu-Gi-Oh! card."
 msgstr ""
 
-#: src\commands\price.ts:55
+#: src\commands\price.ts:61
 msgctxt "command-description"
 msgid "Display the price for a card!"
 msgstr ""

--- a/translations/fr.po
+++ b/translations/fr.po
@@ -6,186 +6,186 @@ msgstr ""
 "MIME-Version: 1.0\n"
 "Content-Transfer-Encoding: 8bit\n"
 
-#: src\card.ts:279
+#: src\card.ts:339
 #: src\commands\rush-duel.ts:60
 msgid "🔗 Links"
 msgstr ""
 
-#: src\card.ts:280
+#: src\card.ts:340
 #, javascript-format
 msgid "[Official Konami DB](${ official }) | [OCG Rulings](${ rulings }) | [Yugipedia](${ yugipedia }) | [YGOPRODECK](${ ygoprodeck })"
 msgstr ""
 
-#: src\card.ts:283
+#: src\card.ts:343
 #, javascript-format
 msgid "[Yugipedia](${ yugipedia }) | [YGOPRODECK](${ ygoprodeck })"
 msgstr ""
 
-#: src\card.ts:343
+#: src\card.ts:403
 #: src\commands\rush-duel.ts:107
 #, javascript-format
 msgid "**Type**: ${ RaceIcon[race] } ${ localizedMonsterTypeLine }"
 msgstr "**Type**: ${ RaceIcon[race] } ${ localizedMonsterTypeLine }"
 
-#: src\card.ts:345
+#: src\card.ts:405
 #: src\commands\rush-duel.ts:109
 #, javascript-format
 msgid "**Attribute**: ${ AttributeIcon[card.attribute] } ${ localizedAttribute }"
 msgstr "**Attribut**: ${ AttributeIcon[card.attribute] } ${ localizedAttribute }"
 
-#: src\card.ts:349
+#: src\card.ts:409
 msgid "**Rank**: ${ Icon.Rank } ${ card.rank } **ATK**: ${ card.atk } **DEF**: ${ card.def }"
 msgstr "**Rang**: ${ Icon.Rank } ${ card.rank } **ATK**: ${ card.atk } **DEF**: ${ card.def }"
 
-#: src\card.ts:352
+#: src\card.ts:412
 #, javascript-format
 msgid "**Link Rating**: ${ card.link_arrows.length } **ATK**: ${ card.atk } **Link Arrows**: ${ arrows }"
 msgstr ""
 
-#: src\card.ts:354
+#: src\card.ts:414
 #: src\commands\rush-duel.ts:111
 #, javascript-format
 msgid "**Level**: ${ Icon.Level } ${ card.level } **ATK**: ${ card.atk } **DEF**: ${ card.def }"
 msgstr "**Niveau**: ${ Icon.Level } ${ card.level } **ATK**: ${ card.atk } **DEF**: ${ card.def }"
 
-#: src\card.ts:361
+#: src\card.ts:421
 msgid "**Pendulum Scale**: ${ formattedScale }"
 msgstr "**Échelle Pendule**: ${ formattedScale }"
 
-#: src\card.ts:240
+#: src\card.ts:300
 #, javascript-format
 msgid "Password: ${ card.password } | Konami ID #${ card.konami_id }"
 msgstr ""
 
-#: src\card.ts:242
+#: src\card.ts:302
 msgid "No password | Konami ID #${ card.konami_id }"
 msgstr ""
 
-#: src\card.ts:244
+#: src\card.ts:304
 #, javascript-format
 msgid "Password: ${ card.password } | Not yet released"
 msgstr ""
 
-#: src\card.ts:246
+#: src\card.ts:306
 #: src\commands\rush-duel.ts:161
 msgid "Not yet released"
 msgstr ""
 
-#: src\card.ts:250
+#: src\card.ts:310
 #, javascript-format
 msgid "Placeholder ID: ${ card.fake_password }"
 msgstr ""
 
-#: src\utils.ts:45
+#: src\utils.ts:41
 msgid "🛠️ This command is in development."
 msgstr ""
 
-#: src\utils.ts:46
+#: src\utils.ts:42
 msgid "📨 Please send feedback to [our issue tracker](https://github.com/DawnbrandBots/bastion-bot) or the [support server](https://discord.gg/4aFuPyuE96)!"
 msgstr ""
 
-#: src\utils.ts:57
+#: src\utils.ts:53
 msgid "Please consider supporting us!"
 msgstr ""
 
-#: src\utils.ts:58
+#: src\utils.ts:54
 msgid "Help keep Bastion online!"
 msgstr ""
 
-#: src\utils.ts:59
+#: src\utils.ts:55
 msgid "Please help keep Bastion online!"
 msgstr ""
 
-#: src\utils.ts:60
+#: src\utils.ts:56
 msgid "Was Bastion helpful? Consider supporting us!"
 msgstr ""
 
-#: src\utils.ts:61
+#: src\utils.ts:57
 msgid "Was Bastion helpful? We need your support!"
 msgstr ""
 
-#: src\utils.ts:62
+#: src\utils.ts:58
 msgid "Did you find Bastion useful? Consider supporting us!"
 msgstr ""
 
-#: src\utils.ts:63
+#: src\utils.ts:59
 msgid "Did you find Bastion useful? Help keep it online!"
 msgstr ""
 
-#: src\utils.ts:64
+#: src\utils.ts:60
 msgid "Did you find Bastion useful? We need your support!"
 msgstr ""
 
-#: src\utils.ts:65
+#: src\utils.ts:61
 msgid "Enjoy Bastion? Help keep it online!"
 msgstr ""
 
-#: src\utils.ts:66
+#: src\utils.ts:62
 msgid "Enjoy Bastion? Consider supporting us!"
 msgstr ""
 
-#: src\utils.ts:67
+#: src\utils.ts:63
 msgid "Found what you were looking for? Consider supporting us!"
 msgstr ""
 
-#: src\commands\art.ts:97
-#: src\commands\price.ts:148
-#: src\commands\rush-duel.ts:309
-#: src\commands\rush-duel.ts:342
-#: src\commands\search.ts:89
-#: src\events\message-search.ts:270
+#: src\commands\art.ts:69
+#: src\commands\price.ts:121
+#: src\commands\rush-duel.ts:306
+#: src\commands\rush-duel.ts:339
+#: src\commands\search.ts:62
+#: src\events\message-search.ts:295
 #, javascript-format
 msgid "Could not find a card matching `${ input }`!"
 msgstr ""
 
-#: src\commands\art.ts:107
+#: src\commands\art.ts:83
 msgid "Could not find art for `${ name }`!"
 msgstr ""
 
-#: src\commands\deck.ts:245
+#: src\commands\deck.ts:248
 #, javascript-format
 msgid "${ counts.Monster } Monster"
 msgid_plural "${ counts.Monster } Monsters"
 msgstr[0] ""
 msgstr[1] ""
 
-#: src\commands\deck.ts:248
+#: src\commands\deck.ts:251
 msgid "${ counts.Spell } Spell"
 msgid_plural "${ counts.Spell } Spells"
 msgstr[0] ""
 msgstr[1] ""
 
-#: src\commands\deck.ts:251
+#: src\commands\deck.ts:254
 #, javascript-format
 msgid "${ counts.Trap } Trap"
 msgid_plural "${ counts.Trap } Traps"
 msgstr[0] ""
 msgstr[1] ""
 
-#: src\commands\deck.ts:279
+#: src\commands\deck.ts:282
 msgid "Your Deck"
 msgstr ""
 
-#: src\commands\deck.ts:284
+#: src\commands\deck.ts:287
 #, javascript-format
 msgid "Main Deck (${ deck.main.length } card — ${ countDetail })"
 msgid_plural "Main Deck (${ deck.main.length } cards — ${ countDetail })"
 msgstr[0] ""
 msgstr[1] ""
 
-#: src\commands\deck.ts:291
+#: src\commands\deck.ts:294
 msgid "Main Deck (continued)"
 msgstr ""
 
-#: src\commands\deck.ts:305
+#: src\commands\deck.ts:308
 msgid "Extra Deck (continued)"
 msgstr ""
 
-#: src\commands\deck.ts:319
+#: src\commands\deck.ts:322
 msgid "Side Deck (continued)"
 msgstr ""
 
-#: src\commands\deck.ts:409
+#: src\commands\deck.ts:411
 msgid "Error: Your deck is empty."
 msgstr ""
 
@@ -279,79 +279,79 @@ msgstr ""
 msgid "Revision: ${ process.env.BOT_REVISION }."
 msgstr ""
 
-#: src\commands\deck.ts:329
+#: src\commands\deck.ts:332
 msgid ".ydk files must have the .ydk extension!"
 msgstr ""
 
-#: src\commands\deck.ts:332
+#: src\commands\deck.ts:335
 msgid ".ydk files should not be larger than 1 KB!"
 msgstr ""
 
-#: src\commands\deck.ts:322
+#: src\commands\deck.ts:325
 msgid "ydke URL"
 msgstr ""
 
-#: src\card.ts:317
+#: src\card.ts:377
 #. Forbidden/Limited Lists or Limit Regulations in the OCG
 msgid "**Limit**: ${ limitRegulationDisplay }"
 msgstr ""
 
-#: src\commands\price.ts:38
+#: src\commands\price.ts:40
 msgid "TCGPlayer"
 msgstr ""
 
-#: src\commands\price.ts:39
+#: src\commands\price.ts:41
 msgid "Cardmarket"
 msgstr ""
 
-#: src\commands\price.ts:40
+#: src\commands\price.ts:42
 msgid "CoolStuffInc"
 msgstr ""
 
-#: src\commands\price.ts:118
+#: src\commands\price.ts:96
 #. TODO: future, determine localisation and relevance status of this error
 msgid "Sorry, I can't find the price for a card with no English name!"
 msgstr ""
 
-#: src\commands\price.ts:162
+#: src\commands\price.ts:140
 msgid "No market price"
 msgstr ""
 
-#: src\commands\price.ts:170
+#: src\commands\price.ts:148
 #, javascript-format
 msgid "Prices for ${ card.name[resultLanguage] } - ${ vendorName }"
 msgstr ""
 
-#: src\commands\price.ts:184
+#: src\commands\price.ts:162
 msgid "Could not find prices for `${ name }`!"
 msgstr ""
 
-#: src\commands\deck.ts:427
+#: src\commands\deck.ts:429
 #. prepare interaction button for FTP upload
 msgid "Upload to YGOPRODECK"
 msgstr ""
 
-#: src\commands\deck.ts:485
+#: src\commands\deck.ts:487
 #. disable original button
 #. prepare row to disable button on original message
 msgid "Upload Complete"
 msgstr ""
 
-#: src\commands\deck.ts:472
+#: src\commands\deck.ts:474
 msgid "Deck upload failed!"
 msgstr ""
 
-#: src\commands\deck.ts:493
+#: src\commands\deck.ts:495
 #. reply in affirmation
 #, javascript-format
 msgid "Deck successfully uploaded to <${ url }>!"
 msgstr ""
 
-#: src\events\message-search.ts:275
+#: src\events\message-search.ts:300
 msgid "💬 Translations missing?"
 msgstr ""
 
-#: src\events\message-search.ts:276
+#: src\events\message-search.ts:301
 msgid "Help translate Bastion at the links above."
 msgstr ""
 
@@ -371,11 +371,11 @@ msgid ""
 "💬 Translations missing? Help translate Bastion on [GitHub](https://github.com/DawnbrandBots/bastion-bot)."
 msgstr ""
 
-#: src\events\message-search.ts:268
+#: src\events\message-search.ts:293
 msgid "Search type: ${ localisedType }"
 msgstr ""
 
-#: src\events\message-search.ts:265
+#: src\events\message-search.ts:290
 #, javascript-format
 msgid "Search language: **${ localisedInputLanguage }** (${ inputLanguage }). Check defaults with </locale get:${ id }> and configure with </locale set:${ id }>"
 msgstr ""
@@ -385,22 +385,22 @@ msgid "⚠️ You pinged me, but I am missing permissions in the channel!"
 msgstr ""
 
 #: src\events\message-ping.ts:94
-#: src\events\message-search.ts:182
+#: src\events\message-search.ts:192
 msgid "Please have a server administrator [fix this](https://github.com/DawnbrandBots/bastion-bot#discord-permissions)."
 msgstr ""
 
-#: src\events\message-search.ts:179
+#: src\events\message-search.ts:189
 msgid "⚠️ I am missing permissions in the channel!"
 msgstr ""
 
-#: src\commands\deck.ts:298
+#: src\commands\deck.ts:301
 #, javascript-format
 msgid "Extra Deck (${ deck.extra.length } card — ${ countDetail })"
 msgid_plural "Extra Deck (${ deck.extra.length } cards — ${ countDetail })"
 msgstr[0] ""
 msgstr[1] ""
 
-#: src\commands\deck.ts:312
+#: src\commands\deck.ts:315
 #, javascript-format
 msgid "Side Deck (${ deck.side.length } card — ${ countDetail })"
 msgid_plural "Side Deck (${ deck.side.length } cards — ${ countDetail })"
@@ -444,12 +444,12 @@ msgstr ""
 msgid "Konami ID #${ card.konami_id }"
 msgstr ""
 
-#: src\commands\deck.ts:453
-#: src\commands\rush-duel.ts:489
+#: src\commands\deck.ts:455
+#: src\commands\rush-duel.ts:486
 msgid "Buttons can only be used by the user who called Bastion."
 msgstr ""
 
-#: src\commands\rush-duel.ts:401
+#: src\commands\rush-duel.ts:398
 #, javascript-format
 msgid "Could not find art for `${ input }`!"
 msgstr ""
@@ -524,127 +524,127 @@ msgctxt "monster-type-race"
 msgid "Gemini"
 msgstr "Gémeau"
 
-#: src\card.ts:66
+#: src\card.ts:72
 msgctxt "monster-type-race"
 msgid "Warrior"
 msgstr "Guerrier"
 
-#: src\card.ts:67
+#: src\card.ts:73
 msgctxt "monster-type-race"
 msgid "Spellcaster"
 msgstr "Magicien"
 
-#: src\card.ts:68
+#: src\card.ts:74
 msgctxt "monster-type-race"
 msgid "Fairy"
 msgstr "Elfe"
 
-#: src\card.ts:69
+#: src\card.ts:75
 msgctxt "monster-type-race"
 msgid "Fiend"
 msgstr "Démon"
 
-#: src\card.ts:70
+#: src\card.ts:76
 msgctxt "monster-type-race"
 msgid "Zombie"
 msgstr "Zombie"
 
-#: src\card.ts:71
+#: src\card.ts:77
 msgctxt "monster-type-race"
 msgid "Machine"
 msgstr "Machine"
 
-#: src\card.ts:72
+#: src\card.ts:78
 msgctxt "monster-type-race"
 msgid "Aqua"
 msgstr "Aqua"
 
-#: src\card.ts:73
+#: src\card.ts:79
 msgctxt "monster-type-race"
 msgid "Pyro"
 msgstr "Pyro"
 
-#: src\card.ts:74
+#: src\card.ts:80
 msgctxt "monster-type-race"
 msgid "Rock"
 msgstr "Rocher"
 
-#: src\card.ts:75
+#: src\card.ts:81
 msgctxt "monster-type-race"
 msgid "Winged Beast"
 msgstr "Bête Ailée"
 
-#: src\card.ts:76
+#: src\card.ts:82
 msgctxt "monster-type-race"
 msgid "Plant"
 msgstr "Plante"
 
-#: src\card.ts:77
+#: src\card.ts:83
 msgctxt "monster-type-race"
 msgid "Insect"
 msgstr "Insecte"
 
-#: src\card.ts:78
+#: src\card.ts:84
 msgctxt "monster-type-race"
 msgid "Thunder"
 msgstr "Tonnerre"
 
-#: src\card.ts:79
+#: src\card.ts:85
 msgctxt "monster-type-race"
 msgid "Dragon"
 msgstr "Dragon"
 
-#: src\card.ts:80
+#: src\card.ts:86
 msgctxt "monster-type-race"
 msgid "Beast"
 msgstr "Bête"
 
-#: src\card.ts:81
+#: src\card.ts:87
 msgctxt "monster-type-race"
 msgid "Beast-Warrior"
 msgstr "Bête-Guerrier"
 
-#: src\card.ts:82
+#: src\card.ts:88
 msgctxt "monster-type-race"
 msgid "Dinosaur"
 msgstr "Dinosaure"
 
-#: src\card.ts:83
+#: src\card.ts:89
 msgctxt "monster-type-race"
 msgid "Fish"
 msgstr "Poisson"
 
-#: src\card.ts:84
+#: src\card.ts:90
 msgctxt "monster-type-race"
 msgid "Sea Serpent"
 msgstr "Serpent de Mer"
 
-#: src\card.ts:85
+#: src\card.ts:91
 msgctxt "monster-type-race"
 msgid "Reptile"
 msgstr "Reptile"
 
-#: src\card.ts:86
+#: src\card.ts:92
 msgctxt "monster-type-race"
 msgid "Psychic"
 msgstr "Psychique"
 
-#: src\card.ts:87
+#: src\card.ts:93
 msgctxt "monster-type-race"
 msgid "Divine-Beast"
 msgstr "Bête Divine"
 
-#: src\card.ts:88
+#: src\card.ts:94
 msgctxt "monster-type-race"
 msgid "Creator God"
 msgstr ""
 
-#: src\card.ts:89
+#: src\card.ts:95
 msgctxt "monster-type-race"
 msgid "Wyrm"
 msgstr "Wyrm"
 
-#: src\card.ts:90
+#: src\card.ts:96
 msgctxt "monster-type-race"
 msgid "Cyberse"
 msgstr "Cyberse"
@@ -694,54 +694,80 @@ msgctxt "spell-trap-property"
 msgid "Counter Trap"
 msgstr "Contre-Piège"
 
-#: src\card.ts:96
+#: src\card.ts:62
+#. SpeedLimitRegulation is not converted to a number for display
+msgctxt "limit-regulation"
+msgid "Forbidden"
+msgstr "Interdite"
+
+#: src\card.ts:63
+msgctxt "limit-regulation"
+msgid "Limited 1"
+msgstr ""
+
+#: src\card.ts:64
+msgctxt "limit-regulation"
+msgid "Limited 2"
+msgstr ""
+
+#: src\card.ts:65
+msgctxt "limit-regulation"
+msgid "Limited 3"
+msgstr ""
+
+#: src\card.ts:66
+msgctxt "limit-regulation"
+msgid "Unlimited"
+msgstr ""
+
+#: src\card.ts:102
 msgctxt "attribute"
 msgid "EARTH"
 msgstr "TERRE"
 
-#: src\card.ts:97
+#: src\card.ts:103
 msgctxt "attribute"
 msgid "WATER"
 msgstr "EAU"
 
-#: src\card.ts:98
+#: src\card.ts:104
 msgctxt "attribute"
 msgid "FIRE"
 msgstr "FEU"
 
-#: src\card.ts:99
+#: src\card.ts:105
 msgctxt "attribute"
 msgid "WIND"
 msgstr "VENT"
 
-#: src\card.ts:100
+#: src\card.ts:106
 msgctxt "attribute"
 msgid "LIGHT"
 msgstr "LUMIÈRE"
 
-#: src\card.ts:101
+#: src\card.ts:107
 msgctxt "attribute"
 msgid "DARK"
 msgstr "TÉNÈBRES"
 
-#: src\card.ts:102
+#: src\card.ts:108
 msgctxt "attribute"
 msgid "DIVINE"
 msgstr "DIVIN"
 
-#: src\card.ts:367
-#: src\card.ts:378
+#: src\card.ts:427
+#: src\card.ts:438
 #: src\commands\rush-duel.ts:142
 msgctxt "card-embed"
 msgid "Card Text"
 msgstr "Texte de carte"
 
-#: src\card.ts:372
+#: src\card.ts:432
 msgctxt "card-embed"
 msgid "Pendulum Effect"
 msgstr "Effet Pendule"
 
-#: src\card.ts:393
+#: src\card.ts:453
 msgctxt "card-embed"
 msgid "Card Effect"
 msgstr ""
@@ -768,27 +794,21 @@ msgctxt "card-embed"
 msgid "[MULTI-CHOICE EFFECT]"
 msgstr ""
 
-#: src\locale.ts:48
+#: src\locale.ts:71
 msgctxt "command-option"
 msgid "result-language"
 msgstr ""
 
-#: src\locale.ts:68
+#: src\locale.ts:131
 msgctxt "command-option"
 msgid "input-language"
 msgstr ""
 
-#: src\commands\art.ts:36
-#: src\commands\art.ts:46
-#: src\commands\art.ts:58
-#: src\commands\price.ts:64
-#: src\commands\price.ts:74
-#: src\commands\price.ts:86
 #: src\commands\rush-duel.ts:194
 #: src\commands\rush-duel.ts:206
-#: src\commands\search.ts:39
-#: src\commands\search.ts:49
-#: src\commands\search.ts:61
+#: src\locale.ts:147
+#: src\locale.ts:165
+#: src\locale.ts:181
 msgctxt "command-option"
 msgid "input"
 msgstr ""
@@ -808,50 +828,44 @@ msgctxt "command-option"
 msgid "page"
 msgstr ""
 
-#: src\commands\deck.ts:122
+#: src\commands\deck.ts:126
 msgctxt "command-option"
 msgid "url"
 msgstr ""
 
-#: src\commands\deck.ts:128
+#: src\commands\deck.ts:132
 msgctxt "command-option"
 msgid "file"
 msgstr ""
 
-#: src\commands\deck.ts:134
-#: src\commands\deck.ts:140
+#: src\commands\deck.ts:138
+#: src\commands\deck.ts:144
 msgctxt "command-option"
 msgid "deck"
 msgstr ""
 
-#: src\commands\deck.ts:146
+#: src\commands\deck.ts:150
 msgctxt "command-option"
 msgid "public"
 msgstr ""
 
-#: src\commands\deck.ts:153
+#: src\commands\deck.ts:157
 msgctxt "command-option"
 msgid "stacked"
 msgstr ""
 
-#: src\commands\art.ts:31
-#: src\commands\price.ts:59
-#: src\commands\search.ts:34
+#: src\locale.ts:142
 msgctxt "command-option"
 msgid "name"
 msgstr ""
 
-#: src\commands\art.ts:41
-#: src\commands\price.ts:69
-#: src\commands\search.ts:44
+#: src\locale.ts:160
 msgctxt "command-option"
 msgid "password"
 msgstr ""
 
-#: src\commands\art.ts:53
-#: src\commands\price.ts:81
 #: src\commands\rush-duel.ts:199
-#: src\commands\search.ts:56
+#: src\locale.ts:176
 msgctxt "command-option"
 msgid "konami-id"
 msgstr ""
@@ -876,7 +890,7 @@ msgctxt "command-option"
 msgid "locale"
 msgstr ""
 
-#: src\commands\price.ts:91
+#: src\commands\price.ts:65
 msgctxt "command-option"
 msgid "vendor"
 msgstr ""
@@ -896,12 +910,12 @@ msgctxt "command-option"
 msgid "art"
 msgstr ""
 
-#: src\locale.ts:51
+#: src\locale.ts:74
 msgctxt "command-option-description"
 msgid "The output language for the card embed, overriding other settings."
 msgstr ""
 
-#: src\locale.ts:71
+#: src\locale.ts:132
 msgctxt "command-option-description"
 msgid "The language to search in, defaulting to the result language."
 msgstr ""
@@ -916,85 +930,79 @@ msgctxt "command-option-description"
 msgid "The name of the Yugipedia page you want to search for."
 msgstr ""
 
-#: src\commands\deck.ts:125
+#: src\commands\deck.ts:129
 msgctxt "command-option-description"
 msgid "View a deck by entering a ydke:// URL."
 msgstr ""
 
-#: src\commands\deck.ts:131
+#: src\commands\deck.ts:135
 msgctxt "command-option-description"
 msgid "View a deck by uploading a .ydk file."
 msgstr ""
 
-#: src\commands\deck.ts:137
+#: src\commands\deck.ts:141
 msgctxt "command-option-description"
 msgid "The ydke:// URL of the deck you want to view."
 msgstr ""
 
-#: src\commands\deck.ts:143
+#: src\commands\deck.ts:147
 msgctxt "command-option-description"
 msgid "The .ydk file of the deck you want to view."
 msgstr ""
 
-#: src\commands\deck.ts:149
+#: src\commands\deck.ts:153
 msgctxt "command-option-description"
 msgid "Whether to display the deck details publicly in chat. This is false by default."
 msgstr ""
 
-#: src\commands\deck.ts:156
+#: src\commands\deck.ts:160
 msgctxt "command-option-description"
 msgid "Whether to display the deck sections as one stacked column. This is false (side-by-side) by default."
 msgstr ""
 
-#: src\commands\art.ts:32
+#: src\commands\art.ts:41
 msgctxt "command-option-description"
 msgid "Display the art for the card with this name."
 msgstr ""
 
-#: src\commands\art.ts:37
-#: src\commands\price.ts:65
 #: src\commands\rush-duel.ts:195
-#: src\commands\search.ts:40
+#: src\locale.ts:148
 msgctxt "command-option-description"
 msgid "Card name, fuzzy matching supported."
 msgstr ""
 
-#: src\commands\art.ts:42
+#: src\commands\art.ts:44
 msgctxt "command-option-description"
 msgid "Display the art for the card with this password."
 msgstr ""
 
-#: src\commands\art.ts:48
-#: src\commands\price.ts:76
-#: src\commands\search.ts:51
+#: src\locale.ts:167
 msgctxt "command-option-description"
 msgid "Card password, the eight-digit number printed on the bottom left corner."
 msgstr ""
 
-#: src\commands\art.ts:54
+#: src\commands\art.ts:47
 msgctxt "command-option-description"
 msgid "Display the art for the card with this official database ID."
 msgstr ""
 
-#: src\commands\art.ts:59
-#: src\commands\price.ts:87
 #: src\commands\rush-duel.ts:207
-#: src\commands\search.ts:62
+#: src\locale.ts:182
 msgctxt "command-option-description"
 msgid "Konami's official card database identifier."
 msgstr ""
 
-#: src\commands\search.ts:35
+#: src\commands\search.ts:40
 msgctxt "command-option-description"
 msgid "Find all information for the card with this name."
 msgstr ""
 
-#: src\commands\search.ts:45
+#: src\commands\search.ts:43
 msgctxt "command-option-description"
 msgid "Find all information for the card with this password."
 msgstr ""
 
-#: src\commands\search.ts:57
+#: src\commands\search.ts:46
 msgctxt "command-option-description"
 msgid "Find all information for the card with this official database ID."
 msgstr ""
@@ -1019,22 +1027,22 @@ msgctxt "command-option-description"
 msgid "The new default language to use in this channel or server."
 msgstr ""
 
-#: src\commands\price.ts:60
+#: src\commands\price.ts:69
 msgctxt "command-option-description"
 msgid "Display the price for the card with this name."
 msgstr ""
 
-#: src\commands\price.ts:70
+#: src\commands\price.ts:73
 msgctxt "command-option-description"
 msgid "Display the price for the card with this password."
 msgstr ""
 
-#: src\commands\price.ts:82
+#: src\commands\price.ts:76
 msgctxt "command-option-description"
 msgid "Display the price for the card with this official database ID."
 msgstr ""
 
-#: src\commands\price.ts:92
+#: src\commands\price.ts:66
 msgctxt "command-option-description"
 msgid "The vendor to fetch the price data from."
 msgstr ""
@@ -1064,7 +1072,7 @@ msgctxt "command-option-description"
 msgid "Display just the art for the Rush Duel card with this name."
 msgstr ""
 
-#: src\commands\art.ts:26
+#: src\commands\art.ts:37
 msgctxt "command-name"
 msgid "art"
 msgstr ""
@@ -1089,12 +1097,12 @@ msgctxt "command-name"
 msgid "yugipedia"
 msgstr ""
 
-#: src\commands\deck.ts:115
+#: src\commands\deck.ts:119
 msgctxt "command-name"
 msgid "deck"
 msgstr ""
 
-#: src\commands\search.ts:29
+#: src\commands\search.ts:36
 msgctxt "command-name"
 msgid "search"
 msgstr ""
@@ -1104,12 +1112,12 @@ msgctxt "command-name"
 msgid "locale"
 msgstr ""
 
-#: src\commands\random.ts:24
+#: src\commands\random.ts:30
 msgctxt "command-name"
 msgid "random"
 msgstr ""
 
-#: src\commands\price.ts:54
+#: src\commands\price.ts:60
 msgctxt "command-name"
 msgid "price"
 msgstr ""
@@ -1119,7 +1127,7 @@ msgctxt "command-name"
 msgid "rush-duel"
 msgstr ""
 
-#: src\commands\art.ts:27
+#: src\commands\art.ts:38
 msgctxt "command-description"
 msgid "Display the art for a card!"
 msgstr ""
@@ -1144,12 +1152,12 @@ msgctxt "command-description"
 msgid "Search the Yugipedia wiki for a page and link to it."
 msgstr ""
 
-#: src\commands\deck.ts:118
+#: src\commands\deck.ts:122
 msgctxt "command-description"
 msgid "Display a deck list from ydke:// or .ydk format, exported from a number of deck building programs."
 msgstr ""
 
-#: src\commands\search.ts:30
+#: src\commands\search.ts:37
 msgctxt "command-description"
 msgid "Find all information on a card!"
 msgstr ""
@@ -1159,12 +1167,12 @@ msgctxt "command-description"
 msgid "Check or set Bastion's locale for this channel or server."
 msgstr ""
 
-#: src\commands\random.ts:25
+#: src\commands\random.ts:31
 msgctxt "command-description"
 msgid "Get a random Yu-Gi-Oh! card."
 msgstr ""
 
-#: src\commands\price.ts:55
+#: src\commands\price.ts:61
 msgctxt "command-description"
 msgid "Display the price for a card!"
 msgstr ""

--- a/translations/it.po
+++ b/translations/it.po
@@ -6,186 +6,186 @@ msgstr ""
 "MIME-Version: 1.0\n"
 "Content-Transfer-Encoding: 8bit\n"
 
-#: src\card.ts:279
+#: src\card.ts:339
 #: src\commands\rush-duel.ts:60
 msgid "🔗 Links"
 msgstr ""
 
-#: src\card.ts:280
+#: src\card.ts:340
 #, javascript-format
 msgid "[Official Konami DB](${ official }) | [OCG Rulings](${ rulings }) | [Yugipedia](${ yugipedia }) | [YGOPRODECK](${ ygoprodeck })"
 msgstr ""
 
-#: src\card.ts:283
+#: src\card.ts:343
 #, javascript-format
 msgid "[Yugipedia](${ yugipedia }) | [YGOPRODECK](${ ygoprodeck })"
 msgstr ""
 
-#: src\card.ts:343
+#: src\card.ts:403
 #: src\commands\rush-duel.ts:107
 #, javascript-format
 msgid "**Type**: ${ RaceIcon[race] } ${ localizedMonsterTypeLine }"
 msgstr "**Tipo**: ${ RaceIcon[race] } ${ localizedMonsterTypeLine }"
 
-#: src\card.ts:345
+#: src\card.ts:405
 #: src\commands\rush-duel.ts:109
 #, javascript-format
 msgid "**Attribute**: ${ AttributeIcon[card.attribute] } ${ localizedAttribute }"
 msgstr "**Attributo**: ${ AttributeIcon[card.attribute] } ${ localizedAttribute }"
 
-#: src\card.ts:349
+#: src\card.ts:409
 msgid "**Rank**: ${ Icon.Rank } ${ card.rank } **ATK**: ${ card.atk } **DEF**: ${ card.def }"
 msgstr "**Rango**: ${ Icon.Rank } ${ card.rank } **ATK**: ${ card.atk } **DEF**: ${ card.def }"
 
-#: src\card.ts:352
+#: src\card.ts:412
 #, javascript-format
 msgid "**Link Rating**: ${ card.link_arrows.length } **ATK**: ${ card.atk } **Link Arrows**: ${ arrows }"
 msgstr ""
 
-#: src\card.ts:354
+#: src\card.ts:414
 #: src\commands\rush-duel.ts:111
 #, javascript-format
 msgid "**Level**: ${ Icon.Level } ${ card.level } **ATK**: ${ card.atk } **DEF**: ${ card.def }"
 msgstr "Livello**: ${ Icon.Level } ${ card.level } **ATK**: ${ card.atk } **DEF**: ${ card.def }"
 
-#: src\card.ts:361
+#: src\card.ts:421
 msgid "**Pendulum Scale**: ${ formattedScale }"
 msgstr "**Valore Pendulum**: ${ formattedScale }"
 
-#: src\card.ts:240
+#: src\card.ts:300
 #, javascript-format
 msgid "Password: ${ card.password } | Konami ID #${ card.konami_id }"
 msgstr ""
 
-#: src\card.ts:242
+#: src\card.ts:302
 msgid "No password | Konami ID #${ card.konami_id }"
 msgstr ""
 
-#: src\card.ts:244
+#: src\card.ts:304
 #, javascript-format
 msgid "Password: ${ card.password } | Not yet released"
 msgstr ""
 
-#: src\card.ts:246
+#: src\card.ts:306
 #: src\commands\rush-duel.ts:161
 msgid "Not yet released"
 msgstr ""
 
-#: src\card.ts:250
+#: src\card.ts:310
 #, javascript-format
 msgid "Placeholder ID: ${ card.fake_password }"
 msgstr ""
 
-#: src\utils.ts:45
+#: src\utils.ts:41
 msgid "🛠️ This command is in development."
 msgstr ""
 
-#: src\utils.ts:46
+#: src\utils.ts:42
 msgid "📨 Please send feedback to [our issue tracker](https://github.com/DawnbrandBots/bastion-bot) or the [support server](https://discord.gg/4aFuPyuE96)!"
 msgstr ""
 
-#: src\utils.ts:57
+#: src\utils.ts:53
 msgid "Please consider supporting us!"
 msgstr ""
 
-#: src\utils.ts:58
+#: src\utils.ts:54
 msgid "Help keep Bastion online!"
 msgstr ""
 
-#: src\utils.ts:59
+#: src\utils.ts:55
 msgid "Please help keep Bastion online!"
 msgstr ""
 
-#: src\utils.ts:60
+#: src\utils.ts:56
 msgid "Was Bastion helpful? Consider supporting us!"
 msgstr ""
 
-#: src\utils.ts:61
+#: src\utils.ts:57
 msgid "Was Bastion helpful? We need your support!"
 msgstr ""
 
-#: src\utils.ts:62
+#: src\utils.ts:58
 msgid "Did you find Bastion useful? Consider supporting us!"
 msgstr ""
 
-#: src\utils.ts:63
+#: src\utils.ts:59
 msgid "Did you find Bastion useful? Help keep it online!"
 msgstr ""
 
-#: src\utils.ts:64
+#: src\utils.ts:60
 msgid "Did you find Bastion useful? We need your support!"
 msgstr ""
 
-#: src\utils.ts:65
+#: src\utils.ts:61
 msgid "Enjoy Bastion? Help keep it online!"
 msgstr ""
 
-#: src\utils.ts:66
+#: src\utils.ts:62
 msgid "Enjoy Bastion? Consider supporting us!"
 msgstr ""
 
-#: src\utils.ts:67
+#: src\utils.ts:63
 msgid "Found what you were looking for? Consider supporting us!"
 msgstr ""
 
-#: src\commands\art.ts:97
-#: src\commands\price.ts:148
-#: src\commands\rush-duel.ts:309
-#: src\commands\rush-duel.ts:342
-#: src\commands\search.ts:89
-#: src\events\message-search.ts:270
+#: src\commands\art.ts:69
+#: src\commands\price.ts:121
+#: src\commands\rush-duel.ts:306
+#: src\commands\rush-duel.ts:339
+#: src\commands\search.ts:62
+#: src\events\message-search.ts:295
 #, javascript-format
 msgid "Could not find a card matching `${ input }`!"
 msgstr ""
 
-#: src\commands\art.ts:107
+#: src\commands\art.ts:83
 msgid "Could not find art for `${ name }`!"
 msgstr ""
 
-#: src\commands\deck.ts:245
+#: src\commands\deck.ts:248
 #, javascript-format
 msgid "${ counts.Monster } Monster"
 msgid_plural "${ counts.Monster } Monsters"
 msgstr[0] ""
 msgstr[1] ""
 
-#: src\commands\deck.ts:248
+#: src\commands\deck.ts:251
 msgid "${ counts.Spell } Spell"
 msgid_plural "${ counts.Spell } Spells"
 msgstr[0] ""
 msgstr[1] ""
 
-#: src\commands\deck.ts:251
+#: src\commands\deck.ts:254
 #, javascript-format
 msgid "${ counts.Trap } Trap"
 msgid_plural "${ counts.Trap } Traps"
 msgstr[0] ""
 msgstr[1] ""
 
-#: src\commands\deck.ts:279
+#: src\commands\deck.ts:282
 msgid "Your Deck"
 msgstr ""
 
-#: src\commands\deck.ts:284
+#: src\commands\deck.ts:287
 #, javascript-format
 msgid "Main Deck (${ deck.main.length } card — ${ countDetail })"
 msgid_plural "Main Deck (${ deck.main.length } cards — ${ countDetail })"
 msgstr[0] ""
 msgstr[1] ""
 
-#: src\commands\deck.ts:291
+#: src\commands\deck.ts:294
 msgid "Main Deck (continued)"
 msgstr ""
 
-#: src\commands\deck.ts:305
+#: src\commands\deck.ts:308
 msgid "Extra Deck (continued)"
 msgstr ""
 
-#: src\commands\deck.ts:319
+#: src\commands\deck.ts:322
 msgid "Side Deck (continued)"
 msgstr ""
 
-#: src\commands\deck.ts:409
+#: src\commands\deck.ts:411
 msgid "Error: Your deck is empty."
 msgstr ""
 
@@ -279,79 +279,79 @@ msgstr ""
 msgid "Revision: ${ process.env.BOT_REVISION }."
 msgstr ""
 
-#: src\commands\deck.ts:329
+#: src\commands\deck.ts:332
 msgid ".ydk files must have the .ydk extension!"
 msgstr ""
 
-#: src\commands\deck.ts:332
+#: src\commands\deck.ts:335
 msgid ".ydk files should not be larger than 1 KB!"
 msgstr ""
 
-#: src\commands\deck.ts:322
+#: src\commands\deck.ts:325
 msgid "ydke URL"
 msgstr ""
 
-#: src\card.ts:317
+#: src\card.ts:377
 #. Forbidden/Limited Lists or Limit Regulations in the OCG
 msgid "**Limit**: ${ limitRegulationDisplay }"
 msgstr ""
 
-#: src\commands\price.ts:38
+#: src\commands\price.ts:40
 msgid "TCGPlayer"
 msgstr ""
 
-#: src\commands\price.ts:39
+#: src\commands\price.ts:41
 msgid "Cardmarket"
 msgstr ""
 
-#: src\commands\price.ts:40
+#: src\commands\price.ts:42
 msgid "CoolStuffInc"
 msgstr ""
 
-#: src\commands\price.ts:118
+#: src\commands\price.ts:96
 #. TODO: future, determine localisation and relevance status of this error
 msgid "Sorry, I can't find the price for a card with no English name!"
 msgstr ""
 
-#: src\commands\price.ts:162
+#: src\commands\price.ts:140
 msgid "No market price"
 msgstr ""
 
-#: src\commands\price.ts:170
+#: src\commands\price.ts:148
 #, javascript-format
 msgid "Prices for ${ card.name[resultLanguage] } - ${ vendorName }"
 msgstr ""
 
-#: src\commands\price.ts:184
+#: src\commands\price.ts:162
 msgid "Could not find prices for `${ name }`!"
 msgstr ""
 
-#: src\commands\deck.ts:427
+#: src\commands\deck.ts:429
 #. prepare interaction button for FTP upload
 msgid "Upload to YGOPRODECK"
 msgstr ""
 
-#: src\commands\deck.ts:485
+#: src\commands\deck.ts:487
 #. disable original button
 #. prepare row to disable button on original message
 msgid "Upload Complete"
 msgstr ""
 
-#: src\commands\deck.ts:472
+#: src\commands\deck.ts:474
 msgid "Deck upload failed!"
 msgstr ""
 
-#: src\commands\deck.ts:493
+#: src\commands\deck.ts:495
 #. reply in affirmation
 #, javascript-format
 msgid "Deck successfully uploaded to <${ url }>!"
 msgstr ""
 
-#: src\events\message-search.ts:275
+#: src\events\message-search.ts:300
 msgid "💬 Translations missing?"
 msgstr ""
 
-#: src\events\message-search.ts:276
+#: src\events\message-search.ts:301
 msgid "Help translate Bastion at the links above."
 msgstr ""
 
@@ -371,11 +371,11 @@ msgid ""
 "💬 Translations missing? Help translate Bastion on [GitHub](https://github.com/DawnbrandBots/bastion-bot)."
 msgstr ""
 
-#: src\events\message-search.ts:268
+#: src\events\message-search.ts:293
 msgid "Search type: ${ localisedType }"
 msgstr ""
 
-#: src\events\message-search.ts:265
+#: src\events\message-search.ts:290
 #, javascript-format
 msgid "Search language: **${ localisedInputLanguage }** (${ inputLanguage }). Check defaults with </locale get:${ id }> and configure with </locale set:${ id }>"
 msgstr ""
@@ -385,22 +385,22 @@ msgid "⚠️ You pinged me, but I am missing permissions in the channel!"
 msgstr ""
 
 #: src\events\message-ping.ts:94
-#: src\events\message-search.ts:182
+#: src\events\message-search.ts:192
 msgid "Please have a server administrator [fix this](https://github.com/DawnbrandBots/bastion-bot#discord-permissions)."
 msgstr ""
 
-#: src\events\message-search.ts:179
+#: src\events\message-search.ts:189
 msgid "⚠️ I am missing permissions in the channel!"
 msgstr ""
 
-#: src\commands\deck.ts:298
+#: src\commands\deck.ts:301
 #, javascript-format
 msgid "Extra Deck (${ deck.extra.length } card — ${ countDetail })"
 msgid_plural "Extra Deck (${ deck.extra.length } cards — ${ countDetail })"
 msgstr[0] ""
 msgstr[1] ""
 
-#: src\commands\deck.ts:312
+#: src\commands\deck.ts:315
 #, javascript-format
 msgid "Side Deck (${ deck.side.length } card — ${ countDetail })"
 msgid_plural "Side Deck (${ deck.side.length } cards — ${ countDetail })"
@@ -444,12 +444,12 @@ msgstr ""
 msgid "Konami ID #${ card.konami_id }"
 msgstr ""
 
-#: src\commands\deck.ts:453
-#: src\commands\rush-duel.ts:489
+#: src\commands\deck.ts:455
+#: src\commands\rush-duel.ts:486
 msgid "Buttons can only be used by the user who called Bastion."
 msgstr ""
 
-#: src\commands\rush-duel.ts:401
+#: src\commands\rush-duel.ts:398
 #, javascript-format
 msgid "Could not find art for `${ input }`!"
 msgstr ""
@@ -524,127 +524,127 @@ msgctxt "monster-type-race"
 msgid "Gemini"
 msgstr "Gemello"
 
-#: src\card.ts:66
+#: src\card.ts:72
 msgctxt "monster-type-race"
 msgid "Warrior"
 msgstr "Guerriero"
 
-#: src\card.ts:67
+#: src\card.ts:73
 msgctxt "monster-type-race"
 msgid "Spellcaster"
 msgstr "Incantatore"
 
-#: src\card.ts:68
+#: src\card.ts:74
 msgctxt "monster-type-race"
 msgid "Fairy"
 msgstr "Fata"
 
-#: src\card.ts:69
+#: src\card.ts:75
 msgctxt "monster-type-race"
 msgid "Fiend"
 msgstr "Demone"
 
-#: src\card.ts:70
+#: src\card.ts:76
 msgctxt "monster-type-race"
 msgid "Zombie"
 msgstr "Zombie"
 
-#: src\card.ts:71
+#: src\card.ts:77
 msgctxt "monster-type-race"
 msgid "Machine"
 msgstr "Macchina"
 
-#: src\card.ts:72
+#: src\card.ts:78
 msgctxt "monster-type-race"
 msgid "Aqua"
 msgstr "Acqua"
 
-#: src\card.ts:73
+#: src\card.ts:79
 msgctxt "monster-type-race"
 msgid "Pyro"
 msgstr "Pyro"
 
-#: src\card.ts:74
+#: src\card.ts:80
 msgctxt "monster-type-race"
 msgid "Rock"
 msgstr "Roccia"
 
-#: src\card.ts:75
+#: src\card.ts:81
 msgctxt "monster-type-race"
 msgid "Winged Beast"
 msgstr "Bestia Alata"
 
-#: src\card.ts:76
+#: src\card.ts:82
 msgctxt "monster-type-race"
 msgid "Plant"
 msgstr "Pianta"
 
-#: src\card.ts:77
+#: src\card.ts:83
 msgctxt "monster-type-race"
 msgid "Insect"
 msgstr "Insetto"
 
-#: src\card.ts:78
+#: src\card.ts:84
 msgctxt "monster-type-race"
 msgid "Thunder"
 msgstr "Tuono"
 
-#: src\card.ts:79
+#: src\card.ts:85
 msgctxt "monster-type-race"
 msgid "Dragon"
 msgstr "Drago"
 
-#: src\card.ts:80
+#: src\card.ts:86
 msgctxt "monster-type-race"
 msgid "Beast"
 msgstr "Bestia"
 
-#: src\card.ts:81
+#: src\card.ts:87
 msgctxt "monster-type-race"
 msgid "Beast-Warrior"
 msgstr "Guerriero-Bestia"
 
-#: src\card.ts:82
+#: src\card.ts:88
 msgctxt "monster-type-race"
 msgid "Dinosaur"
 msgstr "Dinosauro"
 
-#: src\card.ts:83
+#: src\card.ts:89
 msgctxt "monster-type-race"
 msgid "Fish"
 msgstr "Pesce"
 
-#: src\card.ts:84
+#: src\card.ts:90
 msgctxt "monster-type-race"
 msgid "Sea Serpent"
 msgstr "Serpente Marino"
 
-#: src\card.ts:85
+#: src\card.ts:91
 msgctxt "monster-type-race"
 msgid "Reptile"
 msgstr "Rettile"
 
-#: src\card.ts:86
+#: src\card.ts:92
 msgctxt "monster-type-race"
 msgid "Psychic"
 msgstr "Psichico"
 
-#: src\card.ts:87
+#: src\card.ts:93
 msgctxt "monster-type-race"
 msgid "Divine-Beast"
 msgstr "Divinità-Bestia"
 
-#: src\card.ts:88
+#: src\card.ts:94
 msgctxt "monster-type-race"
 msgid "Creator God"
 msgstr ""
 
-#: src\card.ts:89
+#: src\card.ts:95
 msgctxt "monster-type-race"
 msgid "Wyrm"
 msgstr "Wyrm"
 
-#: src\card.ts:90
+#: src\card.ts:96
 msgctxt "monster-type-race"
 msgid "Cyberse"
 msgstr "Cyberso"
@@ -694,54 +694,80 @@ msgctxt "spell-trap-property"
 msgid "Counter Trap"
 msgstr "Contro-Trappola"
 
-#: src\card.ts:96
+#: src\card.ts:62
+#. SpeedLimitRegulation is not converted to a number for display
+msgctxt "limit-regulation"
+msgid "Forbidden"
+msgstr "Proibita"
+
+#: src\card.ts:63
+msgctxt "limit-regulation"
+msgid "Limited 1"
+msgstr ""
+
+#: src\card.ts:64
+msgctxt "limit-regulation"
+msgid "Limited 2"
+msgstr ""
+
+#: src\card.ts:65
+msgctxt "limit-regulation"
+msgid "Limited 3"
+msgstr ""
+
+#: src\card.ts:66
+msgctxt "limit-regulation"
+msgid "Unlimited"
+msgstr ""
+
+#: src\card.ts:102
 msgctxt "attribute"
 msgid "EARTH"
 msgstr "TERRA"
 
-#: src\card.ts:97
+#: src\card.ts:103
 msgctxt "attribute"
 msgid "WATER"
 msgstr "ACQUA"
 
-#: src\card.ts:98
+#: src\card.ts:104
 msgctxt "attribute"
 msgid "FIRE"
 msgstr "FUOCO"
 
-#: src\card.ts:99
+#: src\card.ts:105
 msgctxt "attribute"
 msgid "WIND"
 msgstr "VENTO"
 
-#: src\card.ts:100
+#: src\card.ts:106
 msgctxt "attribute"
 msgid "LIGHT"
 msgstr "LUCE"
 
-#: src\card.ts:101
+#: src\card.ts:107
 msgctxt "attribute"
 msgid "DARK"
 msgstr "OSCURITÀ"
 
-#: src\card.ts:102
+#: src\card.ts:108
 msgctxt "attribute"
 msgid "DIVINE"
 msgstr "DIVINO"
 
-#: src\card.ts:367
-#: src\card.ts:378
+#: src\card.ts:427
+#: src\card.ts:438
 #: src\commands\rush-duel.ts:142
 msgctxt "card-embed"
 msgid "Card Text"
 msgstr "Testo carta"
 
-#: src\card.ts:372
+#: src\card.ts:432
 msgctxt "card-embed"
 msgid "Pendulum Effect"
 msgstr "Effetto Pendulum"
 
-#: src\card.ts:393
+#: src\card.ts:453
 msgctxt "card-embed"
 msgid "Card Effect"
 msgstr ""
@@ -768,27 +794,21 @@ msgctxt "card-embed"
 msgid "[MULTI-CHOICE EFFECT]"
 msgstr ""
 
-#: src\locale.ts:48
+#: src\locale.ts:71
 msgctxt "command-option"
 msgid "result-language"
 msgstr ""
 
-#: src\locale.ts:68
+#: src\locale.ts:131
 msgctxt "command-option"
 msgid "input-language"
 msgstr ""
 
-#: src\commands\art.ts:36
-#: src\commands\art.ts:46
-#: src\commands\art.ts:58
-#: src\commands\price.ts:64
-#: src\commands\price.ts:74
-#: src\commands\price.ts:86
 #: src\commands\rush-duel.ts:194
 #: src\commands\rush-duel.ts:206
-#: src\commands\search.ts:39
-#: src\commands\search.ts:49
-#: src\commands\search.ts:61
+#: src\locale.ts:147
+#: src\locale.ts:165
+#: src\locale.ts:181
 msgctxt "command-option"
 msgid "input"
 msgstr ""
@@ -808,50 +828,44 @@ msgctxt "command-option"
 msgid "page"
 msgstr ""
 
-#: src\commands\deck.ts:122
+#: src\commands\deck.ts:126
 msgctxt "command-option"
 msgid "url"
 msgstr ""
 
-#: src\commands\deck.ts:128
+#: src\commands\deck.ts:132
 msgctxt "command-option"
 msgid "file"
 msgstr ""
 
-#: src\commands\deck.ts:134
-#: src\commands\deck.ts:140
+#: src\commands\deck.ts:138
+#: src\commands\deck.ts:144
 msgctxt "command-option"
 msgid "deck"
 msgstr ""
 
-#: src\commands\deck.ts:146
+#: src\commands\deck.ts:150
 msgctxt "command-option"
 msgid "public"
 msgstr ""
 
-#: src\commands\deck.ts:153
+#: src\commands\deck.ts:157
 msgctxt "command-option"
 msgid "stacked"
 msgstr ""
 
-#: src\commands\art.ts:31
-#: src\commands\price.ts:59
-#: src\commands\search.ts:34
+#: src\locale.ts:142
 msgctxt "command-option"
 msgid "name"
 msgstr ""
 
-#: src\commands\art.ts:41
-#: src\commands\price.ts:69
-#: src\commands\search.ts:44
+#: src\locale.ts:160
 msgctxt "command-option"
 msgid "password"
 msgstr ""
 
-#: src\commands\art.ts:53
-#: src\commands\price.ts:81
 #: src\commands\rush-duel.ts:199
-#: src\commands\search.ts:56
+#: src\locale.ts:176
 msgctxt "command-option"
 msgid "konami-id"
 msgstr ""
@@ -876,7 +890,7 @@ msgctxt "command-option"
 msgid "locale"
 msgstr ""
 
-#: src\commands\price.ts:91
+#: src\commands\price.ts:65
 msgctxt "command-option"
 msgid "vendor"
 msgstr ""
@@ -896,12 +910,12 @@ msgctxt "command-option"
 msgid "art"
 msgstr ""
 
-#: src\locale.ts:51
+#: src\locale.ts:74
 msgctxt "command-option-description"
 msgid "The output language for the card embed, overriding other settings."
 msgstr ""
 
-#: src\locale.ts:71
+#: src\locale.ts:132
 msgctxt "command-option-description"
 msgid "The language to search in, defaulting to the result language."
 msgstr ""
@@ -916,85 +930,79 @@ msgctxt "command-option-description"
 msgid "The name of the Yugipedia page you want to search for."
 msgstr ""
 
-#: src\commands\deck.ts:125
+#: src\commands\deck.ts:129
 msgctxt "command-option-description"
 msgid "View a deck by entering a ydke:// URL."
 msgstr ""
 
-#: src\commands\deck.ts:131
+#: src\commands\deck.ts:135
 msgctxt "command-option-description"
 msgid "View a deck by uploading a .ydk file."
 msgstr ""
 
-#: src\commands\deck.ts:137
+#: src\commands\deck.ts:141
 msgctxt "command-option-description"
 msgid "The ydke:// URL of the deck you want to view."
 msgstr ""
 
-#: src\commands\deck.ts:143
+#: src\commands\deck.ts:147
 msgctxt "command-option-description"
 msgid "The .ydk file of the deck you want to view."
 msgstr ""
 
-#: src\commands\deck.ts:149
+#: src\commands\deck.ts:153
 msgctxt "command-option-description"
 msgid "Whether to display the deck details publicly in chat. This is false by default."
 msgstr ""
 
-#: src\commands\deck.ts:156
+#: src\commands\deck.ts:160
 msgctxt "command-option-description"
 msgid "Whether to display the deck sections as one stacked column. This is false (side-by-side) by default."
 msgstr ""
 
-#: src\commands\art.ts:32
+#: src\commands\art.ts:41
 msgctxt "command-option-description"
 msgid "Display the art for the card with this name."
 msgstr ""
 
-#: src\commands\art.ts:37
-#: src\commands\price.ts:65
 #: src\commands\rush-duel.ts:195
-#: src\commands\search.ts:40
+#: src\locale.ts:148
 msgctxt "command-option-description"
 msgid "Card name, fuzzy matching supported."
 msgstr ""
 
-#: src\commands\art.ts:42
+#: src\commands\art.ts:44
 msgctxt "command-option-description"
 msgid "Display the art for the card with this password."
 msgstr ""
 
-#: src\commands\art.ts:48
-#: src\commands\price.ts:76
-#: src\commands\search.ts:51
+#: src\locale.ts:167
 msgctxt "command-option-description"
 msgid "Card password, the eight-digit number printed on the bottom left corner."
 msgstr ""
 
-#: src\commands\art.ts:54
+#: src\commands\art.ts:47
 msgctxt "command-option-description"
 msgid "Display the art for the card with this official database ID."
 msgstr ""
 
-#: src\commands\art.ts:59
-#: src\commands\price.ts:87
 #: src\commands\rush-duel.ts:207
-#: src\commands\search.ts:62
+#: src\locale.ts:182
 msgctxt "command-option-description"
 msgid "Konami's official card database identifier."
 msgstr ""
 
-#: src\commands\search.ts:35
+#: src\commands\search.ts:40
 msgctxt "command-option-description"
 msgid "Find all information for the card with this name."
 msgstr ""
 
-#: src\commands\search.ts:45
+#: src\commands\search.ts:43
 msgctxt "command-option-description"
 msgid "Find all information for the card with this password."
 msgstr ""
 
-#: src\commands\search.ts:57
+#: src\commands\search.ts:46
 msgctxt "command-option-description"
 msgid "Find all information for the card with this official database ID."
 msgstr ""
@@ -1019,22 +1027,22 @@ msgctxt "command-option-description"
 msgid "The new default language to use in this channel or server."
 msgstr ""
 
-#: src\commands\price.ts:60
+#: src\commands\price.ts:69
 msgctxt "command-option-description"
 msgid "Display the price for the card with this name."
 msgstr ""
 
-#: src\commands\price.ts:70
+#: src\commands\price.ts:73
 msgctxt "command-option-description"
 msgid "Display the price for the card with this password."
 msgstr ""
 
-#: src\commands\price.ts:82
+#: src\commands\price.ts:76
 msgctxt "command-option-description"
 msgid "Display the price for the card with this official database ID."
 msgstr ""
 
-#: src\commands\price.ts:92
+#: src\commands\price.ts:66
 msgctxt "command-option-description"
 msgid "The vendor to fetch the price data from."
 msgstr ""
@@ -1064,7 +1072,7 @@ msgctxt "command-option-description"
 msgid "Display just the art for the Rush Duel card with this name."
 msgstr ""
 
-#: src\commands\art.ts:26
+#: src\commands\art.ts:37
 msgctxt "command-name"
 msgid "art"
 msgstr ""
@@ -1089,12 +1097,12 @@ msgctxt "command-name"
 msgid "yugipedia"
 msgstr ""
 
-#: src\commands\deck.ts:115
+#: src\commands\deck.ts:119
 msgctxt "command-name"
 msgid "deck"
 msgstr ""
 
-#: src\commands\search.ts:29
+#: src\commands\search.ts:36
 msgctxt "command-name"
 msgid "search"
 msgstr ""
@@ -1104,12 +1112,12 @@ msgctxt "command-name"
 msgid "locale"
 msgstr ""
 
-#: src\commands\random.ts:24
+#: src\commands\random.ts:30
 msgctxt "command-name"
 msgid "random"
 msgstr ""
 
-#: src\commands\price.ts:54
+#: src\commands\price.ts:60
 msgctxt "command-name"
 msgid "price"
 msgstr ""
@@ -1119,7 +1127,7 @@ msgctxt "command-name"
 msgid "rush-duel"
 msgstr ""
 
-#: src\commands\art.ts:27
+#: src\commands\art.ts:38
 msgctxt "command-description"
 msgid "Display the art for a card!"
 msgstr ""
@@ -1144,12 +1152,12 @@ msgctxt "command-description"
 msgid "Search the Yugipedia wiki for a page and link to it."
 msgstr ""
 
-#: src\commands\deck.ts:118
+#: src\commands\deck.ts:122
 msgctxt "command-description"
 msgid "Display a deck list from ydke:// or .ydk format, exported from a number of deck building programs."
 msgstr ""
 
-#: src\commands\search.ts:30
+#: src\commands\search.ts:37
 msgctxt "command-description"
 msgid "Find all information on a card!"
 msgstr ""
@@ -1159,12 +1167,12 @@ msgctxt "command-description"
 msgid "Check or set Bastion's locale for this channel or server."
 msgstr ""
 
-#: src\commands\random.ts:25
+#: src\commands\random.ts:31
 msgctxt "command-description"
 msgid "Get a random Yu-Gi-Oh! card."
 msgstr ""
 
-#: src\commands\price.ts:55
+#: src\commands\price.ts:61
 msgctxt "command-description"
 msgid "Display the price for a card!"
 msgstr ""

--- a/translations/ja.po
+++ b/translations/ja.po
@@ -6,183 +6,182 @@ msgstr ""
 "MIME-Version: 1.0\n"
 "Content-Transfer-Encoding: 8bit\n"
 
-#: src\card.ts:279
+#: src\card.ts:339
 #: src\commands\rush-duel.ts:60
 msgid "🔗 Links"
 msgstr "🔗 リンク集"
 
-#: src\card.ts:280
+#: src\card.ts:340
 #, javascript-format
 msgid "[Official Konami DB](${ official }) | [OCG Rulings](${ rulings }) | [Yugipedia](${ yugipedia }) | [YGOPRODECK](${ ygoprodeck })"
 msgstr "[Konami公式カードDB](${ official }) | [OCG公式裁定](${ rulings }) | [Yugipedia](${ yugipedia }) | [YGOPRODECK](${ ygoprodeck })"
 
-#: src\card.ts:283
+#: src\card.ts:343
 #, javascript-format
 msgid "[Yugipedia](${ yugipedia }) | [YGOPRODECK](${ ygoprodeck })"
 msgstr ""
-# No need to translate this one
 
-#: src\card.ts:343
+#: src\card.ts:403
 #: src\commands\rush-duel.ts:107
 #, javascript-format
 msgid "**Type**: ${ RaceIcon[race] } ${ localizedMonsterTypeLine }"
 msgstr "**種族**: ${ RaceIcon[race] } ${ localizedMonsterTypeLine }"
 
-#: src\card.ts:345
+#: src\card.ts:405
 #: src\commands\rush-duel.ts:109
 #, javascript-format
 msgid "**Attribute**: ${ AttributeIcon[card.attribute] } ${ localizedAttribute }"
 msgstr "**属性**: ${ AttributeIcon[card.attribute] } ${ localizedAttribute }"
 
-#: src\card.ts:349
+#: src\card.ts:409
 msgid "**Rank**: ${ Icon.Rank } ${ card.rank } **ATK**: ${ card.atk } **DEF**: ${ card.def }"
 msgstr "**ランク**: ${ Icon.Rank } ${ card.rank } **攻撃力**: ${ card.atk } **守備力**: ${ card.def }"
 
-#: src\card.ts:352
+#: src\card.ts:412
 #, javascript-format
 msgid "**Link Rating**: ${ card.link_arrows.length } **ATK**: ${ card.atk } **Link Arrows**: ${ arrows }"
 msgstr "**リンクの数字分**: ${ card.link_arrows.length } **攻撃力**: ${ card.atk } **リンクマーカー**: ${ arrows }"
 
-#: src\card.ts:354
+#: src\card.ts:414
 #: src\commands\rush-duel.ts:111
 #, javascript-format
 msgid "**Level**: ${ Icon.Level } ${ card.level } **ATK**: ${ card.atk } **DEF**: ${ card.def }"
 msgstr "**レベル**: ${ Icon.Level } ${ card.level } **攻撃力**: ${ card.atk } **守備力**: ${ card.def }"
 
-#: src\card.ts:361
+#: src\card.ts:421
 msgid "**Pendulum Scale**: ${ formattedScale }"
 msgstr "**ペンデュラムスケール**: ${ formattedScale }"
 
-#: src\card.ts:240
+#: src\card.ts:300
 #, javascript-format
 msgid "Password: ${ card.password } | Konami ID #${ card.konami_id }"
 msgstr "パスワード: ${ card.password } | Konami ID #${ card.konami_id }"
 
-#: src\card.ts:242
+#: src\card.ts:302
 msgid "No password | Konami ID #${ card.konami_id }"
 msgstr "パスワードなし | Konami ID #${ card.konami_id }"
 
-#: src\card.ts:244
+#: src\card.ts:304
 #, javascript-format
 msgid "Password: ${ card.password } | Not yet released"
 msgstr "パスワード: ${ card.password } | 未発売"
 
-#: src\card.ts:246
+#: src\card.ts:306
 #: src\commands\rush-duel.ts:161
 msgid "Not yet released"
 msgstr "未発売"
 
-#: src\card.ts:250
+#: src\card.ts:310
 #, javascript-format
 msgid "Placeholder ID: ${ card.fake_password }"
 msgstr ""
 
-#: src\utils.ts:45
+#: src\utils.ts:41
 msgid "🛠️ This command is in development."
 msgstr "🛠️ このコマンドは作成中です。"
 
-#: src\utils.ts:46
+#: src\utils.ts:42
 msgid "📨 Please send feedback to [our issue tracker](https://github.com/DawnbrandBots/bastion-bot) or the [support server](https://discord.gg/4aFuPyuE96)!"
 msgstr "📨 このボットへのご意見を[イシュートラッカー](https://github.com/DawnbrandBots/bastion-bot) か [ディスコードサーバ](https://discord.gg/4aFuPyuE96) に届けてもらえると嬉しいです！"
 
-#: src\utils.ts:57
+#: src\utils.ts:53
 msgid "Please consider supporting us!"
 msgstr "このボットの開発をサポートしてくれると嬉しいです！"
 
-#: src\utils.ts:58
+#: src\utils.ts:54
 msgid "Help keep Bastion online!"
 msgstr "Bastionが稼働し続けられるようにしましょう！"
 
-#: src\utils.ts:59
+#: src\utils.ts:55
 msgid "Please help keep Bastion online!"
 msgstr "Bastionが稼働し続けられるのはみなさんのおかけです！"
 
-#: src\utils.ts:60
+#: src\utils.ts:56
 msgid "Was Bastion helpful? Consider supporting us!"
 msgstr "Bastionがお好き？一緒に開発すればもっと好きになりますよ！"
 
-#: src\utils.ts:61
+#: src\utils.ts:57
 msgid "Was Bastion helpful? We need your support!"
 msgstr "Bastionがお好き？一緒に開発しませんか？"
 
-#: src\utils.ts:62
+#: src\utils.ts:58
 msgid "Did you find Bastion useful? Consider supporting us!"
 msgstr "Bastionがお役に立ちましたか？このボットの開発をサポートしてくれると嬉しいです！"
 
-#: src\utils.ts:63
+#: src\utils.ts:59
 msgid "Did you find Bastion useful? Help keep it online!"
 msgstr "Bastionがお役に立ちましたか？Bastionが稼働し続けられるようにしましょう！"
 
-#: src\utils.ts:64
+#: src\utils.ts:60
 msgid "Did you find Bastion useful? We need your support!"
 msgstr "Bastionがお役に立ちましたか？一緒に開発しませんか？"
 
-#: src\utils.ts:65
+#: src\utils.ts:61
 msgid "Enjoy Bastion? Help keep it online!"
 msgstr "Bastionがお好き？Bastionが稼働し続けられるようにしましょう！"
 
-#: src\utils.ts:66
+#: src\utils.ts:62
 msgid "Enjoy Bastion? Consider supporting us!"
 msgstr "Bastionがお好き？このボットの開発をサポートしてくれると嬉しいです！"
 
-#: src\utils.ts:67
+#: src\utils.ts:63
 msgid "Found what you were looking for? Consider supporting us!"
 msgstr "お探しの情報は見つかりましたか？このボットの開発をサポートしてくれると嬉しいです！"
 
-#: src\commands\art.ts:97
-#: src\commands\price.ts:148
-#: src\commands\rush-duel.ts:309
-#: src\commands\rush-duel.ts:342
-#: src\commands\search.ts:89
-#: src\events\message-search.ts:270
+#: src\commands\art.ts:69
+#: src\commands\price.ts:121
+#: src\commands\rush-duel.ts:306
+#: src\commands\rush-duel.ts:339
+#: src\commands\search.ts:62
+#: src\events\message-search.ts:295
 #, javascript-format
 msgid "Could not find a card matching `${ input }`!"
 msgstr "`${ input }`に一致するカードは見つかりませんでした！"
 
-#: src\commands\art.ts:107
+#: src\commands\art.ts:83
 msgid "Could not find art for `${ name }`!"
 msgstr "`${ name }`のカード画像は見つかりませんでした！"
 
-#: src\commands\deck.ts:245
+#: src\commands\deck.ts:248
 #, javascript-format
 msgid "${ counts.Monster } Monster"
 msgid_plural "${ counts.Monster } Monsters"
 msgstr[0] "モンスター ${ counts.Monster } 体"
 
-#: src\commands\deck.ts:248
+#: src\commands\deck.ts:251
 msgid "${ counts.Spell } Spell"
 msgid_plural "${ counts.Spell } Spells"
 msgstr[0] "魔法 ${ counts.Spell } 枚"
 
-#: src\commands\deck.ts:251
+#: src\commands\deck.ts:254
 #, javascript-format
 msgid "${ counts.Trap } Trap"
 msgid_plural "${ counts.Trap } Traps"
 msgstr[0] "罠 ${ counts.Trap } 枚"
 
-#: src\commands\deck.ts:279
+#: src\commands\deck.ts:282
 msgid "Your Deck"
 msgstr "あなたのデッキ"
 
-#: src\commands\deck.ts:284
+#: src\commands\deck.ts:287
 #, javascript-format
 msgid "Main Deck (${ deck.main.length } card — ${ countDetail })"
 msgid_plural "Main Deck (${ deck.main.length } cards — ${ countDetail })"
 msgstr[0] "メインデッキ (${ deck.main.length } 枚 — ${ countDetail })"
 
-#: src\commands\deck.ts:291
+#: src\commands\deck.ts:294
 msgid "Main Deck (continued)"
 msgstr "メインデッキ（続き）"
 
-#: src\commands\deck.ts:305
+#: src\commands\deck.ts:308
 msgid "Extra Deck (continued)"
 msgstr "エクストラデッキ（続き）"
 
-#: src\commands\deck.ts:319
+#: src\commands\deck.ts:322
 msgid "Side Deck (continued)"
 msgstr "サイドデッキ（続き）"
 
-#: src\commands\deck.ts:409
+#: src\commands\deck.ts:411
 msgid "Error: Your deck is empty."
 msgstr "エラー: デッキが空です。"
 
@@ -276,79 +275,79 @@ msgstr "自由でオープンソースな _Yu-Gi-Oh!_ ボット"
 msgid "Revision: ${ process.env.BOT_REVISION }."
 msgstr "リビジョン: ${ process.env.BOT_REVISION }."
 
-#: src\commands\deck.ts:329
+#: src\commands\deck.ts:332
 msgid ".ydk files must have the .ydk extension!"
 msgstr ".ydkファイルには.ydkの拡張子が必要です！"
 
-#: src\commands\deck.ts:332
+#: src\commands\deck.ts:335
 msgid ".ydk files should not be larger than 1 KB!"
 msgstr ".ydkファイルを 1 KB よりも大きくしないでください！"
 
-#: src\commands\deck.ts:322
+#: src\commands\deck.ts:325
 msgid "ydke URL"
 msgstr "ydkeのURL"
 
-#: src\card.ts:317
+#: src\card.ts:377
 #. Forbidden/Limited Lists or Limit Regulations in the OCG
 msgid "**Limit**: ${ limitRegulationDisplay }"
 msgstr "**リミットレギュレーション**: ${ limitRegulationDisplay }"
 
-#: src\commands\price.ts:38
+#: src\commands\price.ts:40
 msgid "TCGPlayer"
 msgstr ""
 
-#: src\commands\price.ts:39
+#: src\commands\price.ts:41
 msgid "Cardmarket"
 msgstr ""
 
-#: src\commands\price.ts:40
+#: src\commands\price.ts:42
 msgid "CoolStuffInc"
 msgstr ""
 
-#: src\commands\price.ts:118
+#: src\commands\price.ts:96
 #. TODO: future, determine localisation and relevance status of this error
 msgid "Sorry, I can't find the price for a card with no English name!"
 msgstr "すみません、英語名が無いカードの値段検索には非対応です！"
 
-#: src\commands\price.ts:162
+#: src\commands\price.ts:140
 msgid "No market price"
 msgstr "市場価格不明"
 
-#: src\commands\price.ts:170
+#: src\commands\price.ts:148
 #, javascript-format
 msgid "Prices for ${ card.name[resultLanguage] } - ${ vendorName }"
 msgstr "${ vendorName } の ${ card.name[resultLanguage] } の値段"
 
-#: src\commands\price.ts:184
+#: src\commands\price.ts:162
 msgid "Could not find prices for `${ name }`!"
 msgstr "`${ name }` の値段を見つけられませんでした！"
 
-#: src\commands\deck.ts:427
+#: src\commands\deck.ts:429
 #. prepare interaction button for FTP upload
 msgid "Upload to YGOPRODECK"
 msgstr "YGOPRODECKにアップロード"
 
-#: src\commands\deck.ts:485
+#: src\commands\deck.ts:487
 #. disable original button
 #. prepare row to disable button on original message
 msgid "Upload Complete"
 msgstr "アップロード完了"
 
-#: src\commands\deck.ts:472
+#: src\commands\deck.ts:474
 msgid "Deck upload failed!"
 msgstr "デッキのアップロードに失敗しました！"
 
-#: src\commands\deck.ts:493
+#: src\commands\deck.ts:495
 #. reply in affirmation
 #, javascript-format
 msgid "Deck successfully uploaded to <${ url }>!"
 msgstr "<${ url }>にデッキのアップロードを完了しました！"
 
-#: src\events\message-search.ts:275
+#: src\events\message-search.ts:300
 msgid "💬 Translations missing?"
 msgstr "💬 翻訳が存在しませんか？"
 
-#: src\events\message-search.ts:276
+#: src\events\message-search.ts:301
 msgid "Help translate Bastion at the links above."
 msgstr "このボットの翻訳プロジェクトへは上のリンクから。"
 
@@ -368,11 +367,11 @@ msgid ""
 "💬 Translations missing? Help translate Bastion on [GitHub](https://github.com/DawnbrandBots/bastion-bot)."
 msgstr ""
 
-#: src\events\message-search.ts:268
+#: src\events\message-search.ts:293
 msgid "Search type: ${ localisedType }"
 msgstr ""
 
-#: src\events\message-search.ts:265
+#: src\events\message-search.ts:290
 #, javascript-format
 msgid "Search language: **${ localisedInputLanguage }** (${ inputLanguage }). Check defaults with </locale get:${ id }> and configure with </locale set:${ id }>"
 msgstr ""
@@ -382,21 +381,21 @@ msgid "⚠️ You pinged me, but I am missing permissions in the channel!"
 msgstr "⚠️ Pingをもらいましたが、そのチャンネルにはこのボットに権限がありません！"
 
 #: src\events\message-ping.ts:94
-#: src\events\message-search.ts:182
+#: src\events\message-search.ts:192
 msgid "Please have a server administrator [fix this](https://github.com/DawnbrandBots/bastion-bot#discord-permissions)."
 msgstr "サーバ管理者の方に[この問題](https://github.com/DawnbrandBots/bastion-bot#discord-permissions)の対応をお願いいたします。"
 
-#: src\events\message-search.ts:179
+#: src\events\message-search.ts:189
 msgid "⚠️ I am missing permissions in the channel!"
 msgstr "⚠️ そのチャンネルではこのボットに権限がありません！"
 
-#: src\commands\deck.ts:298
+#: src\commands\deck.ts:301
 #, javascript-format
 msgid "Extra Deck (${ deck.extra.length } card — ${ countDetail })"
 msgid_plural "Extra Deck (${ deck.extra.length } cards — ${ countDetail })"
 msgstr[0] "エクストラデッキ (${ deck.extra.length } 枚 — ${ countDetail })"
 
-#: src\commands\deck.ts:312
+#: src\commands\deck.ts:315
 #, javascript-format
 msgid "Side Deck (${ deck.side.length } card — ${ countDetail })"
 msgid_plural "Side Deck (${ deck.side.length } cards — ${ countDetail })"
@@ -439,12 +438,12 @@ msgstr ""
 msgid "Konami ID #${ card.konami_id }"
 msgstr ""
 
-#: src\commands\deck.ts:453
-#: src\commands\rush-duel.ts:489
+#: src\commands\deck.ts:455
+#: src\commands\rush-duel.ts:486
 msgid "Buttons can only be used by the user who called Bastion."
 msgstr "ボタンはBastionにコマンドを送ったユーザーのみに有効です。"
 
-#: src\commands\rush-duel.ts:401
+#: src\commands\rush-duel.ts:398
 #, javascript-format
 msgid "Could not find art for `${ input }`!"
 msgstr "`${ input }`のイラストが見つかりませんでした！"
@@ -519,127 +518,127 @@ msgctxt "monster-type-race"
 msgid "Gemini"
 msgstr "デュアル"
 
-#: src\card.ts:66
+#: src\card.ts:72
 msgctxt "monster-type-race"
 msgid "Warrior"
 msgstr "戦士族"
 
-#: src\card.ts:67
+#: src\card.ts:73
 msgctxt "monster-type-race"
 msgid "Spellcaster"
 msgstr "魔法使い族"
 
-#: src\card.ts:68
+#: src\card.ts:74
 msgctxt "monster-type-race"
 msgid "Fairy"
 msgstr "天使族"
 
-#: src\card.ts:69
+#: src\card.ts:75
 msgctxt "monster-type-race"
 msgid "Fiend"
 msgstr "悪魔族"
 
-#: src\card.ts:70
+#: src\card.ts:76
 msgctxt "monster-type-race"
 msgid "Zombie"
 msgstr "アンデット族"
 
-#: src\card.ts:71
+#: src\card.ts:77
 msgctxt "monster-type-race"
 msgid "Machine"
 msgstr "機械族"
 
-#: src\card.ts:72
+#: src\card.ts:78
 msgctxt "monster-type-race"
 msgid "Aqua"
 msgstr "水族"
 
-#: src\card.ts:73
+#: src\card.ts:79
 msgctxt "monster-type-race"
 msgid "Pyro"
 msgstr "炎族"
 
-#: src\card.ts:74
+#: src\card.ts:80
 msgctxt "monster-type-race"
 msgid "Rock"
 msgstr "岩石族"
 
-#: src\card.ts:75
+#: src\card.ts:81
 msgctxt "monster-type-race"
 msgid "Winged Beast"
 msgstr "鳥獣族"
 
-#: src\card.ts:76
+#: src\card.ts:82
 msgctxt "monster-type-race"
 msgid "Plant"
 msgstr "植物族"
 
-#: src\card.ts:77
+#: src\card.ts:83
 msgctxt "monster-type-race"
 msgid "Insect"
 msgstr "昆虫族"
 
-#: src\card.ts:78
+#: src\card.ts:84
 msgctxt "monster-type-race"
 msgid "Thunder"
 msgstr "雷族"
 
-#: src\card.ts:79
+#: src\card.ts:85
 msgctxt "monster-type-race"
 msgid "Dragon"
 msgstr "ドラゴン族"
 
-#: src\card.ts:80
+#: src\card.ts:86
 msgctxt "monster-type-race"
 msgid "Beast"
 msgstr "獣族"
 
-#: src\card.ts:81
+#: src\card.ts:87
 msgctxt "monster-type-race"
 msgid "Beast-Warrior"
 msgstr "獣戦士族"
 
-#: src\card.ts:82
+#: src\card.ts:88
 msgctxt "monster-type-race"
 msgid "Dinosaur"
 msgstr "恐竜族"
 
-#: src\card.ts:83
+#: src\card.ts:89
 msgctxt "monster-type-race"
 msgid "Fish"
 msgstr "魚族"
 
-#: src\card.ts:84
+#: src\card.ts:90
 msgctxt "monster-type-race"
 msgid "Sea Serpent"
 msgstr "海竜族"
 
-#: src\card.ts:85
+#: src\card.ts:91
 msgctxt "monster-type-race"
 msgid "Reptile"
 msgstr "爬虫類族"
 
-#: src\card.ts:86
+#: src\card.ts:92
 msgctxt "monster-type-race"
 msgid "Psychic"
 msgstr "サイキック族"
 
-#: src\card.ts:87
+#: src\card.ts:93
 msgctxt "monster-type-race"
 msgid "Divine-Beast"
 msgstr "幻神獣族"
 
-#: src\card.ts:88
+#: src\card.ts:94
 msgctxt "monster-type-race"
 msgid "Creator God"
 msgstr "創造神族"
 
-#: src\card.ts:89
+#: src\card.ts:95
 msgctxt "monster-type-race"
 msgid "Wyrm"
 msgstr "幻竜族"
 
-#: src\card.ts:90
+#: src\card.ts:96
 msgctxt "monster-type-race"
 msgid "Cyberse"
 msgstr "サイバース族"
@@ -689,54 +688,80 @@ msgctxt "spell-trap-property"
 msgid "Counter Trap"
 msgstr "カウンター罠"
 
-#: src\card.ts:96
+#: src\card.ts:62
+#. SpeedLimitRegulation is not converted to a number for display
+msgctxt "limit-regulation"
+msgid "Forbidden"
+msgstr ""
+
+#: src\card.ts:63
+msgctxt "limit-regulation"
+msgid "Limited 1"
+msgstr ""
+
+#: src\card.ts:64
+msgctxt "limit-regulation"
+msgid "Limited 2"
+msgstr ""
+
+#: src\card.ts:65
+msgctxt "limit-regulation"
+msgid "Limited 3"
+msgstr ""
+
+#: src\card.ts:66
+msgctxt "limit-regulation"
+msgid "Unlimited"
+msgstr ""
+
+#: src\card.ts:102
 msgctxt "attribute"
 msgid "EARTH"
 msgstr "地"
 
-#: src\card.ts:97
+#: src\card.ts:103
 msgctxt "attribute"
 msgid "WATER"
 msgstr "水"
 
-#: src\card.ts:98
+#: src\card.ts:104
 msgctxt "attribute"
 msgid "FIRE"
 msgstr "炎"
 
-#: src\card.ts:99
+#: src\card.ts:105
 msgctxt "attribute"
 msgid "WIND"
 msgstr "風"
 
-#: src\card.ts:100
+#: src\card.ts:106
 msgctxt "attribute"
 msgid "LIGHT"
 msgstr "光"
 
-#: src\card.ts:101
+#: src\card.ts:107
 msgctxt "attribute"
 msgid "DARK"
 msgstr "闇"
 
-#: src\card.ts:102
+#: src\card.ts:108
 msgctxt "attribute"
 msgid "DIVINE"
 msgstr "神"
 
-#: src\card.ts:367
-#: src\card.ts:378
+#: src\card.ts:427
+#: src\card.ts:438
 #: src\commands\rush-duel.ts:142
 msgctxt "card-embed"
 msgid "Card Text"
 msgstr "カードテキスト"
 
-#: src\card.ts:372
+#: src\card.ts:432
 msgctxt "card-embed"
 msgid "Pendulum Effect"
 msgstr "ペンデュラム効果"
 
-#: src\card.ts:393
+#: src\card.ts:453
 msgctxt "card-embed"
 msgid "Card Effect"
 msgstr "カード効果"
@@ -763,27 +788,21 @@ msgctxt "card-embed"
 msgid "[MULTI-CHOICE EFFECT]"
 msgstr "【選択効果】"
 
-#: src\locale.ts:48
+#: src\locale.ts:71
 msgctxt "command-option"
 msgid "result-language"
 msgstr "出力用言語"
 
-#: src\locale.ts:68
+#: src\locale.ts:131
 msgctxt "command-option"
 msgid "input-language"
 msgstr "入力用言語"
 
-#: src\commands\art.ts:36
-#: src\commands\art.ts:46
-#: src\commands\art.ts:58
-#: src\commands\price.ts:64
-#: src\commands\price.ts:74
-#: src\commands\price.ts:86
 #: src\commands\rush-duel.ts:194
 #: src\commands\rush-duel.ts:206
-#: src\commands\search.ts:39
-#: src\commands\search.ts:49
-#: src\commands\search.ts:61
+#: src\locale.ts:147
+#: src\locale.ts:165
+#: src\locale.ts:181
 msgctxt "command-option"
 msgid "input"
 msgstr "入力"
@@ -803,50 +822,44 @@ msgctxt "command-option"
 msgid "page"
 msgstr "ページ"
 
-#: src\commands\deck.ts:122
+#: src\commands\deck.ts:126
 msgctxt "command-option"
 msgid "url"
 msgstr ""
 
-#: src\commands\deck.ts:128
+#: src\commands\deck.ts:132
 msgctxt "command-option"
 msgid "file"
 msgstr "ファイル"
 
-#: src\commands\deck.ts:134
-#: src\commands\deck.ts:140
+#: src\commands\deck.ts:138
+#: src\commands\deck.ts:144
 msgctxt "command-option"
 msgid "deck"
 msgstr "デッキ"
 
-#: src\commands\deck.ts:146
+#: src\commands\deck.ts:150
 msgctxt "command-option"
 msgid "public"
 msgstr "チャンネルに公開"
 
-#: src\commands\deck.ts:153
+#: src\commands\deck.ts:157
 msgctxt "command-option"
 msgid "stacked"
 msgstr "一行表示"
 
-#: src\commands\art.ts:31
-#: src\commands\price.ts:59
-#: src\commands\search.ts:34
+#: src\locale.ts:142
 msgctxt "command-option"
 msgid "name"
 msgstr "カード名"
 
-#: src\commands\art.ts:41
-#: src\commands\price.ts:69
-#: src\commands\search.ts:44
+#: src\locale.ts:160
 msgctxt "command-option"
 msgid "password"
 msgstr "パスワード"
 
-#: src\commands\art.ts:53
-#: src\commands\price.ts:81
 #: src\commands\rush-duel.ts:199
-#: src\commands\search.ts:56
+#: src\locale.ts:176
 msgctxt "command-option"
 msgid "konami-id"
 msgstr "コナミid"
@@ -871,7 +884,7 @@ msgctxt "command-option"
 msgid "locale"
 msgstr "使用言語"
 
-#: src\commands\price.ts:91
+#: src\commands\price.ts:65
 msgctxt "command-option"
 msgid "vendor"
 msgstr "販売店"
@@ -891,12 +904,12 @@ msgctxt "command-option"
 msgid "art"
 msgstr "イラスト"
 
-#: src\locale.ts:51
+#: src\locale.ts:74
 msgctxt "command-option-description"
 msgid "The output language for the card embed, overriding other settings."
 msgstr "カード情報の表示言語を設定します。デフォルトの設定より優先されます。"
 
-#: src\locale.ts:71
+#: src\locale.ts:132
 msgctxt "command-option-description"
 msgid "The language to search in, defaulting to the result language."
 msgstr ""
@@ -911,85 +924,79 @@ msgctxt "command-option-description"
 msgid "The name of the Yugipedia page you want to search for."
 msgstr "検索したいYugipediaのページの名前"
 
-#: src\commands\deck.ts:125
+#: src\commands\deck.ts:129
 msgctxt "command-option-description"
 msgid "View a deck by entering a ydke:// URL."
 msgstr "ydke://形式のURLを入力すると、そのデッキ内容を表示します。"
 
-#: src\commands\deck.ts:131
+#: src\commands\deck.ts:135
 msgctxt "command-option-description"
 msgid "View a deck by uploading a .ydk file."
 msgstr ".ydk形式のファイルをアップロードすると、そのデッキ内容を表示します。"
 
-#: src\commands\deck.ts:137
+#: src\commands\deck.ts:141
 msgctxt "command-option-description"
 msgid "The ydke:// URL of the deck you want to view."
 msgstr "デッキ内容を表示したいydke://形式のURL"
 
-#: src\commands\deck.ts:143
+#: src\commands\deck.ts:147
 msgctxt "command-option-description"
 msgid "The .ydk file of the deck you want to view."
 msgstr "デッキ内容を表示したい.ydk形式のファイル"
 
-#: src\commands\deck.ts:149
+#: src\commands\deck.ts:153
 msgctxt "command-option-description"
 msgid "Whether to display the deck details publicly in chat. This is false by default."
 msgstr "デッキ内容を自分以外の人にも見せるか否かを設定できます。デフォルトでは他の人には非表示になっています。"
 
-#: src\commands\deck.ts:156
+#: src\commands\deck.ts:160
 msgctxt "command-option-description"
 msgid "Whether to display the deck sections as one stacked column. This is false (side-by-side) by default."
 msgstr "デッキ内容を一行で表示するか否かを設定できます。デフォルトでは左右の二行に分けて表示します。"
 
-#: src\commands\art.ts:32
+#: src\commands\art.ts:41
 msgctxt "command-option-description"
 msgid "Display the art for the card with this name."
 msgstr "この名称のカードのイラストを表示します"
 
-#: src\commands\art.ts:37
-#: src\commands\price.ts:65
 #: src\commands\rush-duel.ts:195
-#: src\commands\search.ts:40
+#: src\locale.ts:148
 msgctxt "command-option-description"
 msgid "Card name, fuzzy matching supported."
 msgstr "カード名（あいまい検索に対応しています）"
 
-#: src\commands\art.ts:42
+#: src\commands\art.ts:44
 msgctxt "command-option-description"
 msgid "Display the art for the card with this password."
 msgstr "このパスワードのカードのイラストを表示します"
 
-#: src\commands\art.ts:48
-#: src\commands\price.ts:76
-#: src\commands\search.ts:51
+#: src\locale.ts:167
 msgctxt "command-option-description"
 msgid "Card password, the eight-digit number printed on the bottom left corner."
 msgstr "カードパスワード（カード左下の8桁の数字）"
 
-#: src\commands\art.ts:54
+#: src\commands\art.ts:47
 msgctxt "command-option-description"
 msgid "Display the art for the card with this official database ID."
 msgstr "このパスワードのカードのイラストを表示します"
 
-#: src\commands\art.ts:59
-#: src\commands\price.ts:87
 #: src\commands\rush-duel.ts:207
-#: src\commands\search.ts:62
+#: src\locale.ts:182
 msgctxt "command-option-description"
 msgid "Konami's official card database identifier."
 msgstr "Konami公式カードDBでのカードID"
 
-#: src\commands\search.ts:35
+#: src\commands\search.ts:40
 msgctxt "command-option-description"
 msgid "Find all information for the card with this name."
 msgstr "この名称のカードの情報を表示します"
 
-#: src\commands\search.ts:45
+#: src\commands\search.ts:43
 msgctxt "command-option-description"
 msgid "Find all information for the card with this password."
 msgstr "このパスワードのカードの情報を表示します"
 
-#: src\commands\search.ts:57
+#: src\commands\search.ts:46
 msgctxt "command-option-description"
 msgid "Find all information for the card with this official database ID."
 msgstr "この公式カードDBのIDを持つカードの情報を表示します"
@@ -1014,22 +1021,22 @@ msgctxt "command-option-description"
 msgid "The new default language to use in this channel or server."
 msgstr "このチャンネルあるいはサーバ全体で使う新しい言語設定"
 
-#: src\commands\price.ts:60
+#: src\commands\price.ts:69
 msgctxt "command-option-description"
 msgid "Display the price for the card with this name."
 msgstr "この名称のカードの価格を表示します"
 
-#: src\commands\price.ts:70
+#: src\commands\price.ts:73
 msgctxt "command-option-description"
 msgid "Display the price for the card with this password."
 msgstr "このパスワードのカードの価格を表示します"
 
-#: src\commands\price.ts:82
+#: src\commands\price.ts:76
 msgctxt "command-option-description"
 msgid "Display the price for the card with this official database ID."
 msgstr "この公式カードDBのIDを持つカードの価格を表示します"
 
-#: src\commands\price.ts:92
+#: src\commands\price.ts:66
 msgctxt "command-option-description"
 msgid "The vendor to fetch the price data from."
 msgstr "価格情報の参照先"
@@ -1059,7 +1066,7 @@ msgctxt "command-option-description"
 msgid "Display just the art for the Rush Duel card with this name."
 msgstr "ラッシュデュエル用カードのイラストを表示します"
 
-#: src\commands\art.ts:26
+#: src\commands\art.ts:37
 msgctxt "command-name"
 msgid "art"
 msgstr "いらすと"
@@ -1084,12 +1091,12 @@ msgctxt "command-name"
 msgid "yugipedia"
 msgstr ""
 
-#: src\commands\deck.ts:115
+#: src\commands\deck.ts:119
 msgctxt "command-name"
 msgid "deck"
 msgstr "でっき"
 
-#: src\commands\search.ts:29
+#: src\commands\search.ts:36
 msgctxt "command-name"
 msgid "search"
 msgstr "けんさく"
@@ -1099,12 +1106,12 @@ msgctxt "command-name"
 msgid "locale"
 msgstr "げんごせってい"
 
-#: src\commands\random.ts:24
+#: src\commands\random.ts:30
 msgctxt "command-name"
 msgid "random"
 msgstr "おみくじ"
 
-#: src\commands\price.ts:54
+#: src\commands\price.ts:60
 msgctxt "command-name"
 msgid "price"
 msgstr "かかく"
@@ -1114,7 +1121,7 @@ msgctxt "command-name"
 msgid "rush-duel"
 msgstr "らっしゅ"
 
-#: src\commands\art.ts:27
+#: src\commands\art.ts:38
 msgctxt "command-description"
 msgid "Display the art for a card!"
 msgstr "カードの画像（イラスト）を表示します。"
@@ -1139,12 +1146,12 @@ msgctxt "command-description"
 msgid "Search the Yugipedia wiki for a page and link to it."
 msgstr "Yugipediaを検索します。"
 
-#: src\commands\deck.ts:118
+#: src\commands\deck.ts:122
 msgctxt "command-description"
 msgid "Display a deck list from ydke:// or .ydk format, exported from a number of deck building programs."
 msgstr "ydke:// か .ydk 形式のデッキ情報を表示します。（多くのデッキ構築アプリで使われている形式です。）"
 
-#: src\commands\search.ts:30
+#: src\commands\search.ts:37
 msgctxt "command-description"
 msgid "Find all information on a card!"
 msgstr "とあるカードのすべての情報を表示します！"
@@ -1154,12 +1161,12 @@ msgctxt "command-description"
 msgid "Check or set Bastion's locale for this channel or server."
 msgstr "このチャンネル（あるいはサーバー）のBastionのロケールを確認（あるいは変更）します。"
 
-#: src\commands\random.ts:25
+#: src\commands\random.ts:31
 msgctxt "command-description"
 msgid "Get a random Yu-Gi-Oh! card."
 msgstr "遊戯王カードをランダムに表示します。"
 
-#: src\commands\price.ts:55
+#: src\commands\price.ts:61
 msgctxt "command-description"
 msgid "Display the price for a card!"
 msgstr "カードの値段を表示します！"

--- a/translations/ko.po
+++ b/translations/ko.po
@@ -6,139 +6,139 @@ msgstr ""
 "MIME-Version: 1.0\n"
 "Content-Transfer-Encoding: 8bit\n"
 
-#: src\card.ts:279
+#: src\card.ts:339
 #: src\commands\rush-duel.ts:60
 msgid "🔗 Links"
 msgstr "🔗 링크"
 
-#: src\card.ts:280
+#: src\card.ts:340
 #, javascript-format
 msgid "[Official Konami DB](${ official }) | [OCG Rulings](${ rulings }) | [Yugipedia](${ yugipedia }) | [YGOPRODECK](${ ygoprodeck })"
 msgstr "[코나미 공식 카드 DB](${ official }) | [OCG 공식 재정](${ rulings }) | [Yugipedia](${ yugipedia }) | [YGOPRODECK](${ ygoprodeck })"
 
-#: src\card.ts:283
+#: src\card.ts:343
 #, javascript-format
 msgid "[Yugipedia](${ yugipedia }) | [YGOPRODECK](${ ygoprodeck })"
 msgstr "[Yugipedia](${ yugipedia }) | [YGOPRODECK](${ ygoprodeck })"
 
-#: src\card.ts:343
+#: src\card.ts:403
 #: src\commands\rush-duel.ts:107
 #, javascript-format
 msgid "**Type**: ${ RaceIcon[race] } ${ localizedMonsterTypeLine }"
 msgstr "**종족**: ${ RaceIcon[race] } ${ localizedMonsterTypeLine }"
 
-#: src\card.ts:345
+#: src\card.ts:405
 #: src\commands\rush-duel.ts:109
 #, javascript-format
 msgid "**Attribute**: ${ AttributeIcon[card.attribute] } ${ localizedAttribute }"
 msgstr "**속성**: ${ AttributeIcon[card.attribute] } ${ localizedAttribute }"
 
-#: src\card.ts:349
+#: src\card.ts:409
 msgid "**Rank**: ${ Icon.Rank } ${ card.rank } **ATK**: ${ card.atk } **DEF**: ${ card.def }"
 msgstr "**랭크**: ${ Icon.Rank } ${ card.rank } **공격력**: ${ card.atk } **수비력**: ${ card.def }"
 
-#: src\card.ts:352
+#: src\card.ts:412
 #, javascript-format
 msgid "**Link Rating**: ${ card.link_arrows.length } **ATK**: ${ card.atk } **Link Arrows**: ${ arrows }"
 msgstr "**LINK**: ${ card.link_arrows.length } **공격력**: ${ card.atk } **링크 마커**: ${ arrows }"
 
-#: src\card.ts:354
+#: src\card.ts:414
 #: src\commands\rush-duel.ts:111
 #, javascript-format
 msgid "**Level**: ${ Icon.Level } ${ card.level } **ATK**: ${ card.atk } **DEF**: ${ card.def }"
 msgstr "**레벨**: ${ Icon.Level } ${ card.level } **공격력**: ${ card.atk } **수비력**: ${ card.def }"
 
-#: src\card.ts:361
+#: src\card.ts:421
 msgid "**Pendulum Scale**: ${ formattedScale }"
 msgstr "**펜듈럼 스케일**: ${ formattedScale }"
 
-#: src\card.ts:240
+#: src\card.ts:300
 #, javascript-format
 msgid "Password: ${ card.password } | Konami ID #${ card.konami_id }"
 msgstr "패스워드: ${ card.password } | 코나미 ID #${ card.konami_id }"
 
-#: src\card.ts:242
+#: src\card.ts:302
 msgid "No password | Konami ID #${ card.konami_id }"
 msgstr "패스워드 없음 | 코나미 ID #${ card.konami_id }"
 
-#: src\card.ts:244
+#: src\card.ts:304
 #, javascript-format
 msgid "Password: ${ card.password } | Not yet released"
 msgstr "패스워드: ${ card.password } | Not yet released"
 
-#: src\card.ts:246
+#: src\card.ts:306
 #: src\commands\rush-duel.ts:161
 msgid "Not yet released"
 msgstr "미발매"
 
-#: src\card.ts:250
+#: src\card.ts:310
 #, javascript-format
 msgid "Placeholder ID: ${ card.fake_password }"
 msgstr "플레이스홀더 ID: ${ card.fake_password }"
 
-#: src\utils.ts:45
+#: src\utils.ts:41
 msgid "🛠️ This command is in development."
 msgstr "🛠️ 이 명령은 개발 중입니다."
 
-#: src\utils.ts:46
+#: src\utils.ts:42
 msgid "📨 Please send feedback to [our issue tracker](https://github.com/DawnbrandBots/bastion-bot) or the [support server](https://discord.gg/4aFuPyuE96)!"
 msgstr "📨 [문제 추적기](https://github.com/DawnbrandBots/bastion-bot) 또는 [지원 서버](https://discord.gg/4aFuPyuE96)로 피드백을 보내주십시오!"
 
-#: src\utils.ts:57
+#: src\utils.ts:53
 msgid "Please consider supporting us!"
 msgstr "저희를 지원해 주세요!"
 
-#: src\utils.ts:58
+#: src\utils.ts:54
 msgid "Help keep Bastion online!"
 msgstr "Bastion을 온라인 상태로 유지하는 것을 도와 주세요!"
 
-#: src\utils.ts:59
+#: src\utils.ts:55
 msgid "Please help keep Bastion online!"
 msgstr "저희가 Bastion을 온라인 상태로 유지하는 것을 도와 주세요!"
 
-#: src\utils.ts:60
+#: src\utils.ts:56
 msgid "Was Bastion helpful? Consider supporting us!"
 msgstr "Bastion이 도움이 되었나요? 저희를 지원해 주세요!"
 
-#: src\utils.ts:61
+#: src\utils.ts:57
 msgid "Was Bastion helpful? We need your support!"
 msgstr "Bastion이 도움이 되었나요? 여러분의 지원이 필요해요!"
 
-#: src\utils.ts:62
+#: src\utils.ts:58
 msgid "Did you find Bastion useful? Consider supporting us!"
 msgstr "Bastion이 유용하다고 생각했나요? 저희를 지원해 주시는 건 어떤가요?"
 
-#: src\utils.ts:63
+#: src\utils.ts:59
 msgid "Did you find Bastion useful? Help keep it online!"
 msgstr "Bastion이 유용하다고 생각했나요? 온라인 상태로 유지하는 것을 도와 주세요!"
 
-#: src\utils.ts:64
+#: src\utils.ts:60
 msgid "Did you find Bastion useful? We need your support!"
 msgstr "Bastion이 유용하다고 생각했나요? 여러분의 지원이 필요해요!"
 
-#: src\utils.ts:65
+#: src\utils.ts:61
 msgid "Enjoy Bastion? Help keep it online!"
 msgstr "Bastion을 잘 사용하고 계신가요? 온라인 상태로 유지하는 것을 도와 주세요!"
 
-#: src\utils.ts:66
+#: src\utils.ts:62
 msgid "Enjoy Bastion? Consider supporting us!"
 msgstr "Bastion을 잘 사용하고 계신가요? 저희를 지원해 주시는 건 어떤가요?"
 
-#: src\utils.ts:67
+#: src\utils.ts:63
 msgid "Found what you were looking for? Consider supporting us!"
 msgstr "찾으시려던 것을 찾으셨나요? 저희를 지원해 주시는 건 어떤가요?"
 
-#: src\commands\art.ts:97
-#: src\commands\price.ts:148
-#: src\commands\rush-duel.ts:309
-#: src\commands\rush-duel.ts:342
-#: src\commands\search.ts:89
-#: src\events\message-search.ts:270
+#: src\commands\art.ts:69
+#: src\commands\price.ts:121
+#: src\commands\rush-duel.ts:306
+#: src\commands\rush-duel.ts:339
+#: src\commands\search.ts:62
+#: src\events\message-search.ts:295
 #, javascript-format
 msgid "Could not find a card matching `${ input }`!"
 msgstr "`${ input }`에 일치하는 카드를 찾을 수 없습니다!"
 
-#: src\commands\art.ts:107
+#: src\commands\art.ts:83
 msgid "Could not find art for `${ name }`!"
 msgstr "`${ name }`의 카드 일러스트를 찾을 수 없습니다!"
 
@@ -223,46 +223,46 @@ msgstr "총 지연 시간: ${ latency } ms"
 msgid "Could not find a Yugipedia page named `${ page }`."
 msgstr "`${ page }`라는 이름의 Yugipedia 페이지를 찾을 수 없습니다."
 
-#: src\commands\deck.ts:245
+#: src\commands\deck.ts:248
 #, javascript-format
 msgid "${ counts.Monster } Monster"
 msgid_plural "${ counts.Monster } Monsters"
 msgstr[0] "몬스터 ${ counts.Monster } 장"
 
-#: src\commands\deck.ts:248
+#: src\commands\deck.ts:251
 msgid "${ counts.Spell } Spell"
 msgid_plural "${ counts.Spell } Spells"
 msgstr[0] "마법 ${ counts.Spell } 장"
 
-#: src\commands\deck.ts:251
+#: src\commands\deck.ts:254
 #, javascript-format
 msgid "${ counts.Trap } Trap"
 msgid_plural "${ counts.Trap } Traps"
 msgstr[0] "함정 ${ counts.Trap } 장"
 
-#: src\commands\deck.ts:279
+#: src\commands\deck.ts:282
 msgid "Your Deck"
 msgstr "덱"
 
-#: src\commands\deck.ts:284
+#: src\commands\deck.ts:287
 #, javascript-format
 msgid "Main Deck (${ deck.main.length } card — ${ countDetail })"
 msgid_plural "Main Deck (${ deck.main.length } cards — ${ countDetail })"
 msgstr[0] "메인 덱 (${ deck.main.length } card — ${ countDetail })"
 
-#: src\commands\deck.ts:291
+#: src\commands\deck.ts:294
 msgid "Main Deck (continued)"
 msgstr "메인 덱 (계속)"
 
-#: src\commands\deck.ts:305
+#: src\commands\deck.ts:308
 msgid "Extra Deck (continued)"
 msgstr "엑스트라 덱 (계속)"
 
-#: src\commands\deck.ts:319
+#: src\commands\deck.ts:322
 msgid "Side Deck (continued)"
 msgstr "사이드 덱 (계속)"
 
-#: src\commands\deck.ts:409
+#: src\commands\deck.ts:411
 msgid "Error: Your deck is empty."
 msgstr "오류: 덱이 비었습니다."
 
@@ -275,79 +275,79 @@ msgstr "자유-오픈 소스 유희왕 봇"
 msgid "Revision: ${ process.env.BOT_REVISION }."
 msgstr "수정: ${ process.env.BOT_REVISION }."
 
-#: src\commands\deck.ts:329
+#: src\commands\deck.ts:332
 msgid ".ydk files must have the .ydk extension!"
 msgstr ".ydk 파일의 확장자는 .ydk여야 합니다!"
 
-#: src\commands\deck.ts:332
+#: src\commands\deck.ts:335
 msgid ".ydk files should not be larger than 1 KB!"
 msgstr ".ydk 파일은 1 KB보다 크면 안 됩니다!"
 
-#: src\commands\deck.ts:322
+#: src\commands\deck.ts:325
 msgid "ydke URL"
 msgstr ""
 
-#: src\card.ts:317
+#: src\card.ts:377
 #. Forbidden/Limited Lists or Limit Regulations in the OCG
 msgid "**Limit**: ${ limitRegulationDisplay }"
 msgstr "**제한**: ${ limitRegulationDisplay }"
 
-#: src\commands\price.ts:38
+#: src\commands\price.ts:40
 msgid "TCGPlayer"
 msgstr ""
 
-#: src\commands\price.ts:39
+#: src\commands\price.ts:41
 msgid "Cardmarket"
 msgstr ""
 
-#: src\commands\price.ts:40
+#: src\commands\price.ts:42
 msgid "CoolStuffInc"
 msgstr ""
 
-#: src\commands\price.ts:118
+#: src\commands\price.ts:96
 #. TODO: future, determine localisation and relevance status of this error
 msgid "Sorry, I can't find the price for a card with no English name!"
 msgstr "죄송합니다. 영어 이름이 없는 카드의 가격을 찾을 수 없습니다!"
 
-#: src\commands\price.ts:162
+#: src\commands\price.ts:140
 msgid "No market price"
 msgstr "시장 가격 불명"
 
-#: src\commands\price.ts:170
+#: src\commands\price.ts:148
 #, javascript-format
 msgid "Prices for ${ card.name[resultLanguage] } - ${ vendorName }"
 msgstr "${ vendorName } 의 ${ card.name[resultLanguage] } 가격"
 
-#: src\commands\price.ts:184
+#: src\commands\price.ts:162
 msgid "Could not find prices for `${ name }`!"
 msgstr "`${ name }`의 가격을 찾을 수 없습니다!"
 
-#: src\commands\deck.ts:427
+#: src\commands\deck.ts:429
 #. prepare interaction button for FTP upload
 msgid "Upload to YGOPRODECK"
 msgstr "YGOPRODECK에 업로드"
 
-#: src\commands\deck.ts:485
+#: src\commands\deck.ts:487
 #. disable original button
 #. prepare row to disable button on original message
 msgid "Upload Complete"
 msgstr "업로드 완료"
 
-#: src\commands\deck.ts:472
+#: src\commands\deck.ts:474
 msgid "Deck upload failed!"
 msgstr "덱 업로드에 실패했습니다!"
 
-#: src\commands\deck.ts:493
+#: src\commands\deck.ts:495
 #. reply in affirmation
 #, javascript-format
 msgid "Deck successfully uploaded to <${ url }>!"
 msgstr "<${ url }>에 덱 업로드를 완료했습니다!"
 
-#: src\events\message-search.ts:275
+#: src\events\message-search.ts:300
 msgid "💬 Translations missing?"
 msgstr "💬 번역이 존재합니까?"
 
-#: src\events\message-search.ts:276
+#: src\events\message-search.ts:301
 msgid "Help translate Bastion at the links above."
 msgstr "위 링크에서 Bastion 번역을 도와주세요."
 
@@ -367,11 +367,11 @@ msgid ""
 "💬 Translations missing? Help translate Bastion on [GitHub](https://github.com/DawnbrandBots/bastion-bot)."
 msgstr ""
 
-#: src\events\message-search.ts:268
+#: src\events\message-search.ts:293
 msgid "Search type: ${ localisedType }"
 msgstr "검색 종류: ${ localisedType }"
 
-#: src\events\message-search.ts:265
+#: src\events\message-search.ts:290
 #, javascript-format
 msgid "Search language: **${ localisedInputLanguage }** (${ inputLanguage }). Check defaults with </locale get:${ id }> and configure with </locale set:${ id }>"
 msgstr "검색 언어: **${ localisedInputLanguage }** (${ inputLanguage }). </locale get:${ id }>의 기본값을 확인하고 </locale set:${ id }>를 설정합니다."
@@ -381,21 +381,21 @@ msgid "⚠️ You pinged me, but I am missing permissions in the channel!"
 msgstr "⚠️ 당신은 저를 부르셨지만, 해당 채널에서 권한이 없습니다!"
 
 #: src\events\message-ping.ts:94
-#: src\events\message-search.ts:182
+#: src\events\message-search.ts:192
 msgid "Please have a server administrator [fix this](https://github.com/DawnbrandBots/bastion-bot#discord-permissions)."
 msgstr "서버 관리자에게 문의하십시오 [문제 해결](https://github.com/DawnbrandBots/bastion-bot#discord-permissions)."
 
-#: src\events\message-search.ts:179
+#: src\events\message-search.ts:189
 msgid "⚠️ I am missing permissions in the channel!"
 msgstr "⚠️ 해당 채널에서 권한이 없습니다!"
 
-#: src\commands\deck.ts:298
+#: src\commands\deck.ts:301
 #, javascript-format
 msgid "Extra Deck (${ deck.extra.length } card — ${ countDetail })"
 msgid_plural "Extra Deck (${ deck.extra.length } cards — ${ countDetail })"
 msgstr[0] "엑스트라 덱 (${ deck.extra.length } cards — ${ countDetail })"
 
-#: src\commands\deck.ts:312
+#: src\commands\deck.ts:315
 #, javascript-format
 msgid "Side Deck (${ deck.side.length } card — ${ countDetail })"
 msgid_plural "Side Deck (${ deck.side.length } cards — ${ countDetail })"
@@ -438,12 +438,12 @@ msgstr ""
 msgid "Konami ID #${ card.konami_id }"
 msgstr "코나미 ID #${ card.konami_id }"
 
-#: src\commands\deck.ts:453
-#: src\commands\rush-duel.ts:489
+#: src\commands\deck.ts:455
+#: src\commands\rush-duel.ts:486
 msgid "Buttons can only be used by the user who called Bastion."
 msgstr "Bastion은 호출한 사용자만 이용할 수 있습니다."
 
-#: src\commands\rush-duel.ts:401
+#: src\commands\rush-duel.ts:398
 #, javascript-format
 msgid "Could not find art for `${ input }`!"
 msgstr "`${ input }`에 대한 일러스트를 찾을 수 없습니다!"
@@ -518,127 +518,127 @@ msgctxt "monster-type-race"
 msgid "Gemini"
 msgstr "듀얼"
 
-#: src\card.ts:66
+#: src\card.ts:72
 msgctxt "monster-type-race"
 msgid "Warrior"
 msgstr "전사족"
 
-#: src\card.ts:67
+#: src\card.ts:73
 msgctxt "monster-type-race"
 msgid "Spellcaster"
 msgstr "마법사족"
 
-#: src\card.ts:68
+#: src\card.ts:74
 msgctxt "monster-type-race"
 msgid "Fairy"
 msgstr "천사족"
 
-#: src\card.ts:69
+#: src\card.ts:75
 msgctxt "monster-type-race"
 msgid "Fiend"
 msgstr "악마족"
 
-#: src\card.ts:70
+#: src\card.ts:76
 msgctxt "monster-type-race"
 msgid "Zombie"
 msgstr "언데드족"
 
-#: src\card.ts:71
+#: src\card.ts:77
 msgctxt "monster-type-race"
 msgid "Machine"
 msgstr "기계족"
 
-#: src\card.ts:72
+#: src\card.ts:78
 msgctxt "monster-type-race"
 msgid "Aqua"
 msgstr "물족"
 
-#: src\card.ts:73
+#: src\card.ts:79
 msgctxt "monster-type-race"
 msgid "Pyro"
 msgstr "화염족"
 
-#: src\card.ts:74
+#: src\card.ts:80
 msgctxt "monster-type-race"
 msgid "Rock"
 msgstr "암석족"
 
-#: src\card.ts:75
+#: src\card.ts:81
 msgctxt "monster-type-race"
 msgid "Winged Beast"
 msgstr "비행야수족"
 
-#: src\card.ts:76
+#: src\card.ts:82
 msgctxt "monster-type-race"
 msgid "Plant"
 msgstr "식물족"
 
-#: src\card.ts:77
+#: src\card.ts:83
 msgctxt "monster-type-race"
 msgid "Insect"
 msgstr "곤충족"
 
-#: src\card.ts:78
+#: src\card.ts:84
 msgctxt "monster-type-race"
 msgid "Thunder"
 msgstr "번개족"
 
-#: src\card.ts:79
+#: src\card.ts:85
 msgctxt "monster-type-race"
 msgid "Dragon"
 msgstr "드래곤족"
 
-#: src\card.ts:80
+#: src\card.ts:86
 msgctxt "monster-type-race"
 msgid "Beast"
 msgstr "야수족"
 
-#: src\card.ts:81
+#: src\card.ts:87
 msgctxt "monster-type-race"
 msgid "Beast-Warrior"
 msgstr "야수전사족"
 
-#: src\card.ts:82
+#: src\card.ts:88
 msgctxt "monster-type-race"
 msgid "Dinosaur"
 msgstr "공룡족"
 
-#: src\card.ts:83
+#: src\card.ts:89
 msgctxt "monster-type-race"
 msgid "Fish"
 msgstr "어류족"
 
-#: src\card.ts:84
+#: src\card.ts:90
 msgctxt "monster-type-race"
 msgid "Sea Serpent"
 msgstr "해룡족"
 
-#: src\card.ts:85
+#: src\card.ts:91
 msgctxt "monster-type-race"
 msgid "Reptile"
 msgstr "파충류족"
 
-#: src\card.ts:86
+#: src\card.ts:92
 msgctxt "monster-type-race"
 msgid "Psychic"
 msgstr "사이킥족"
 
-#: src\card.ts:87
+#: src\card.ts:93
 msgctxt "monster-type-race"
 msgid "Divine-Beast"
 msgstr "환신야수족"
 
-#: src\card.ts:88
+#: src\card.ts:94
 msgctxt "monster-type-race"
 msgid "Creator God"
 msgstr "창조신족"
 
-#: src\card.ts:89
+#: src\card.ts:95
 msgctxt "monster-type-race"
 msgid "Wyrm"
 msgstr "환룡족"
 
-#: src\card.ts:90
+#: src\card.ts:96
 msgctxt "monster-type-race"
 msgid "Cyberse"
 msgstr "사이버스족"
@@ -688,54 +688,80 @@ msgctxt "spell-trap-property"
 msgid "Counter Trap"
 msgstr "카운터 함정"
 
-#: src\card.ts:96
+#: src\card.ts:62
+#. SpeedLimitRegulation is not converted to a number for display
+msgctxt "limit-regulation"
+msgid "Forbidden"
+msgstr ""
+
+#: src\card.ts:63
+msgctxt "limit-regulation"
+msgid "Limited 1"
+msgstr ""
+
+#: src\card.ts:64
+msgctxt "limit-regulation"
+msgid "Limited 2"
+msgstr ""
+
+#: src\card.ts:65
+msgctxt "limit-regulation"
+msgid "Limited 3"
+msgstr ""
+
+#: src\card.ts:66
+msgctxt "limit-regulation"
+msgid "Unlimited"
+msgstr ""
+
+#: src\card.ts:102
 msgctxt "attribute"
 msgid "EARTH"
 msgstr "땅"
 
-#: src\card.ts:97
+#: src\card.ts:103
 msgctxt "attribute"
 msgid "WATER"
 msgstr "물"
 
-#: src\card.ts:98
+#: src\card.ts:104
 msgctxt "attribute"
 msgid "FIRE"
 msgstr "화염"
 
-#: src\card.ts:99
+#: src\card.ts:105
 msgctxt "attribute"
 msgid "WIND"
 msgstr "바람"
 
-#: src\card.ts:100
+#: src\card.ts:106
 msgctxt "attribute"
 msgid "LIGHT"
 msgstr "빛"
 
-#: src\card.ts:101
+#: src\card.ts:107
 msgctxt "attribute"
 msgid "DARK"
 msgstr "어둠"
 
-#: src\card.ts:102
+#: src\card.ts:108
 msgctxt "attribute"
 msgid "DIVINE"
 msgstr "신"
 
-#: src\card.ts:367
-#: src\card.ts:378
+#: src\card.ts:427
+#: src\card.ts:438
 #: src\commands\rush-duel.ts:142
 msgctxt "card-embed"
 msgid "Card Text"
 msgstr "카드 텍스트"
 
-#: src\card.ts:372
+#: src\card.ts:432
 msgctxt "card-embed"
 msgid "Pendulum Effect"
 msgstr "펜듈럼 효과"
 
-#: src\card.ts:393
+#: src\card.ts:453
 msgctxt "card-embed"
 msgid "Card Effect"
 msgstr "카드 효과"
@@ -762,27 +788,21 @@ msgctxt "card-embed"
 msgid "[MULTI-CHOICE EFFECT]"
 msgstr "【선택 효과】"
 
-#: src\locale.ts:48
+#: src\locale.ts:71
 msgctxt "command-option"
 msgid "result-language"
 msgstr "출력언어"
 
-#: src\locale.ts:68
+#: src\locale.ts:131
 msgctxt "command-option"
 msgid "input-language"
 msgstr "입력언어"
 
-#: src\commands\art.ts:36
-#: src\commands\art.ts:46
-#: src\commands\art.ts:58
-#: src\commands\price.ts:64
-#: src\commands\price.ts:74
-#: src\commands\price.ts:86
 #: src\commands\rush-duel.ts:194
 #: src\commands\rush-duel.ts:206
-#: src\commands\search.ts:39
-#: src\commands\search.ts:49
-#: src\commands\search.ts:61
+#: src\locale.ts:147
+#: src\locale.ts:165
+#: src\locale.ts:181
 msgctxt "command-option"
 msgid "input"
 msgstr "입력"
@@ -802,50 +822,44 @@ msgctxt "command-option"
 msgid "command"
 msgstr "명령"
 
-#: src\commands\deck.ts:122
+#: src\commands\deck.ts:126
 msgctxt "command-option"
 msgid "url"
 msgstr ""
 
-#: src\commands\deck.ts:128
+#: src\commands\deck.ts:132
 msgctxt "command-option"
 msgid "file"
 msgstr "파일"
 
-#: src\commands\deck.ts:134
-#: src\commands\deck.ts:140
+#: src\commands\deck.ts:138
+#: src\commands\deck.ts:144
 msgctxt "command-option"
 msgid "deck"
 msgstr "덱"
 
-#: src\commands\deck.ts:146
+#: src\commands\deck.ts:150
 msgctxt "command-option"
 msgid "public"
 msgstr "공개"
 
-#: src\commands\deck.ts:153
+#: src\commands\deck.ts:157
 msgctxt "command-option"
 msgid "stacked"
 msgstr "다량"
 
-#: src\commands\art.ts:31
-#: src\commands\price.ts:59
-#: src\commands\search.ts:34
+#: src\locale.ts:142
 msgctxt "command-option"
 msgid "name"
 msgstr "이름"
 
-#: src\commands\art.ts:41
-#: src\commands\price.ts:69
-#: src\commands\search.ts:44
+#: src\locale.ts:160
 msgctxt "command-option"
 msgid "password"
 msgstr "패스워드"
 
-#: src\commands\art.ts:53
-#: src\commands\price.ts:81
 #: src\commands\rush-duel.ts:199
-#: src\commands\search.ts:56
+#: src\locale.ts:176
 msgctxt "command-option"
 msgid "konami-id"
 msgstr ""
@@ -870,7 +884,7 @@ msgctxt "command-option"
 msgid "locale"
 msgstr "로케일"
 
-#: src\commands\price.ts:91
+#: src\commands\price.ts:65
 msgctxt "command-option"
 msgid "vendor"
 msgstr "상점"
@@ -890,12 +904,12 @@ msgctxt "command-option"
 msgid "art"
 msgstr "일러스트"
 
-#: src\locale.ts:51
+#: src\locale.ts:74
 msgctxt "command-option-description"
 msgid "The output language for the card embed, overriding other settings."
 msgstr "다른 설정을 재정의하는 카드 임베드의 출력 언어입니다."
 
-#: src\locale.ts:71
+#: src\locale.ts:132
 msgctxt "command-option-description"
 msgid "The language to search in, defaulting to the result language."
 msgstr "검색할 언어로, 기본적으로 출력 언어로 설정됩니다."
@@ -910,85 +924,79 @@ msgctxt "command-option-description"
 msgid "The name of a specific Slash Command."
 msgstr "특정 단축 명령의 이름입니다."
 
-#: src\commands\deck.ts:125
+#: src\commands\deck.ts:129
 msgctxt "command-option-description"
 msgid "View a deck by entering a ydke:// URL."
 msgstr "ydke:// URL을 입력하여 덱을 봅니다."
 
-#: src\commands\deck.ts:131
+#: src\commands\deck.ts:135
 msgctxt "command-option-description"
 msgid "View a deck by uploading a .ydk file."
 msgstr "ydk 파일을 업로드 후 덱을 봅니다."
 
-#: src\commands\deck.ts:137
+#: src\commands\deck.ts:141
 msgctxt "command-option-description"
 msgid "The ydke:// URL of the deck you want to view."
 msgstr "보려는 덱의 ydke:// URL입니다."
 
-#: src\commands\deck.ts:143
+#: src\commands\deck.ts:147
 msgctxt "command-option-description"
 msgid "The .ydk file of the deck you want to view."
 msgstr "보려는 덱의 ydk 파일입니다."
 
-#: src\commands\deck.ts:149
+#: src\commands\deck.ts:153
 msgctxt "command-option-description"
 msgid "Whether to display the deck details publicly in chat. This is false by default."
 msgstr "대화에서 덱 세부 정보를 공개적으로 표시할지 여부입니다.이것은 기본적으로 거짓입니다."
 
-#: src\commands\deck.ts:156
+#: src\commands\deck.ts:160
 msgctxt "command-option-description"
 msgid "Whether to display the deck sections as one stacked column. This is false (side-by-side) by default."
 msgstr ""
 
-#: src\commands\art.ts:32
+#: src\commands\art.ts:41
 msgctxt "command-option-description"
 msgid "Display the art for the card with this name."
 msgstr "이 이름으로 카드에 대한 일러스트를 표시합니다."
 
-#: src\commands\art.ts:37
-#: src\commands\price.ts:65
 #: src\commands\rush-duel.ts:195
-#: src\commands\search.ts:40
+#: src\locale.ts:148
 msgctxt "command-option-description"
 msgid "Card name, fuzzy matching supported."
 msgstr "카드 이름, 퍼지 매칭이 지원됩니다."
 
-#: src\commands\art.ts:42
+#: src\commands\art.ts:44
 msgctxt "command-option-description"
 msgid "Display the art for the card with this password."
 msgstr "이 패스워드로 카드의 일러스트를 표시합니다."
 
-#: src\commands\art.ts:48
-#: src\commands\price.ts:76
-#: src\commands\search.ts:51
+#: src\locale.ts:167
 msgctxt "command-option-description"
 msgid "Card password, the eight-digit number printed on the bottom left corner."
 msgstr "카드 패스워드, 왼쪽 하단에 인쇄된 8자리 숫자."
 
-#: src\commands\art.ts:54
+#: src\commands\art.ts:47
 msgctxt "command-option-description"
 msgid "Display the art for the card with this official database ID."
 msgstr "이 공식 데이터베이스 ID로 카드의 일러스트를 표시합니다."
 
-#: src\commands\art.ts:59
-#: src\commands\price.ts:87
 #: src\commands\rush-duel.ts:207
-#: src\commands\search.ts:62
+#: src\locale.ts:182
 msgctxt "command-option-description"
 msgid "Konami's official card database identifier."
 msgstr "코나미의 공식 카드 데이터베이스 식별자입니다."
 
-#: src\commands\search.ts:35
+#: src\commands\search.ts:40
 msgctxt "command-option-description"
 msgid "Find all information for the card with this name."
 msgstr "이 이름으로 카드에 대한 모든 정보를 찾습니다."
 
-#: src\commands\search.ts:45
+#: src\commands\search.ts:43
 msgctxt "command-option-description"
 msgid "Find all information for the card with this password."
 msgstr "이 패스워드로 카드에 대한 모든 정보를 찾습니다."
 
-#: src\commands\search.ts:57
+#: src\commands\search.ts:46
 msgctxt "command-option-description"
 msgid "Find all information for the card with this official database ID."
 msgstr "이 공식 데이터베이스 ID로 카드에 대한 모든 정보를 찾습니다."
@@ -1013,22 +1021,22 @@ msgctxt "command-option-description"
 msgid "The new default language to use in this channel or server."
 msgstr "이 채널 또는 서버에서 사용할 새 기본 언어입니다."
 
-#: src\commands\price.ts:60
+#: src\commands\price.ts:69
 msgctxt "command-option-description"
 msgid "Display the price for the card with this name."
 msgstr "이 이름으로 카드 가격을 표시합니다."
 
-#: src\commands\price.ts:70
+#: src\commands\price.ts:73
 msgctxt "command-option-description"
 msgid "Display the price for the card with this password."
 msgstr "이 패스워드로 카드 가격을 표시합니다."
 
-#: src\commands\price.ts:82
+#: src\commands\price.ts:76
 msgctxt "command-option-description"
 msgid "Display the price for the card with this official database ID."
 msgstr "이 공식 데이터베이스 ID로 카드 가격을 표시합니다."
 
-#: src\commands\price.ts:92
+#: src\commands\price.ts:66
 msgctxt "command-option-description"
 msgid "The vendor to fetch the price data from."
 msgstr "가격 데이터를 가져올 업체입니다."
@@ -1058,7 +1066,7 @@ msgctxt "command-option-description"
 msgid "Display just the art for the Rush Duel card with this name."
 msgstr "이 이름으로 러시 듀얼 카드에 대한 일러스트만 표시합니다."
 
-#: src\commands\art.ts:26
+#: src\commands\art.ts:37
 msgctxt "command-name"
 msgid "art"
 msgstr "일러스트"
@@ -1083,12 +1091,12 @@ msgctxt "command-name"
 msgid "help"
 msgstr "도움말"
 
-#: src\commands\deck.ts:115
+#: src\commands\deck.ts:119
 msgctxt "command-name"
 msgid "deck"
 msgstr "덱"
 
-#: src\commands\search.ts:29
+#: src\commands\search.ts:36
 msgctxt "command-name"
 msgid "search"
 msgstr "검색"
@@ -1098,12 +1106,12 @@ msgctxt "command-name"
 msgid "locale"
 msgstr "로케일"
 
-#: src\commands\random.ts:24
+#: src\commands\random.ts:30
 msgctxt "command-name"
 msgid "random"
 msgstr "무작위"
 
-#: src\commands\price.ts:54
+#: src\commands\price.ts:60
 msgctxt "command-name"
 msgid "price"
 msgstr "가격"
@@ -1113,7 +1121,7 @@ msgctxt "command-name"
 msgid "rush-duel"
 msgstr "러시듀얼"
 
-#: src\commands\art.ts:27
+#: src\commands\art.ts:38
 msgctxt "command-description"
 msgid "Display the art for a card!"
 msgstr "카드의 일러스트를 표시합니다."
@@ -1138,12 +1146,12 @@ msgctxt "command-description"
 msgid "Get help with a Slash Command."
 msgstr "슬래시 명령에 도움을 받으십시오."
 
-#: src\commands\deck.ts:118
+#: src\commands\deck.ts:122
 msgctxt "command-description"
 msgid "Display a deck list from ydke:// or .ydk format, exported from a number of deck building programs."
 msgstr "여러 덱 제작 프로그램에서 내보낸 덱 목록을ydke:// 또는 .ydk 형식으로 표시합니다."
 
-#: src\commands\search.ts:30
+#: src\commands\search.ts:37
 msgctxt "command-description"
 msgid "Find all information on a card!"
 msgstr "카드의 모든 정보를 찾으세요!"
@@ -1153,12 +1161,12 @@ msgctxt "command-description"
 msgid "Check or set Bastion's locale for this channel or server."
 msgstr "이 채널 또는 서버에 대한 Bastion의 로케일을 확인하거나 설정합니다."
 
-#: src\commands\random.ts:25
+#: src\commands\random.ts:31
 msgctxt "command-description"
 msgid "Get a random Yu-Gi-Oh! card."
 msgstr "유희왕 카드를 무작위로 받으십시오."
 
-#: src\commands\price.ts:55
+#: src\commands\price.ts:61
 msgctxt "command-description"
 msgid "Display the price for a card!"
 msgstr "카드 가격 표시"

--- a/translations/pt.po
+++ b/translations/pt.po
@@ -6,186 +6,186 @@ msgstr ""
 "MIME-Version: 1.0\n"
 "Content-Transfer-Encoding: 8bit\n"
 
-#: src\card.ts:279
+#: src\card.ts:339
 #: src\commands\rush-duel.ts:60
 msgid "🔗 Links"
 msgstr ""
 
-#: src\card.ts:280
+#: src\card.ts:340
 #, javascript-format
 msgid "[Official Konami DB](${ official }) | [OCG Rulings](${ rulings }) | [Yugipedia](${ yugipedia }) | [YGOPRODECK](${ ygoprodeck })"
 msgstr "[Database oficial da Konami](${ official }) | [Regras no OCG](${ rulings }) | [Yugipedia](${ yugipedia }) | [YGOPRODECK](${ ygoprodeck })"
 
-#: src\card.ts:283
+#: src\card.ts:343
 #, javascript-format
 msgid "[Yugipedia](${ yugipedia }) | [YGOPRODECK](${ ygoprodeck })"
 msgstr ""
 
-#: src\card.ts:343
+#: src\card.ts:403
 #: src\commands\rush-duel.ts:107
 #, javascript-format
 msgid "**Type**: ${ RaceIcon[race] } ${ localizedMonsterTypeLine }"
 msgstr "**Tipo**: ${ RaceIcon[race] } ${ localizedMonsterTypeLine }"
 
-#: src\card.ts:345
+#: src\card.ts:405
 #: src\commands\rush-duel.ts:109
 #, javascript-format
 msgid "**Attribute**: ${ AttributeIcon[card.attribute] } ${ localizedAttribute }"
 msgstr "**Atributo**: ${ AttributeIcon[card.attribute] } ${ localizedAttribute }"
 
-#: src\card.ts:349
+#: src\card.ts:409
 msgid "**Rank**: ${ Icon.Rank } ${ card.rank } **ATK**: ${ card.atk } **DEF**: ${ card.def }"
 msgstr "**Classe**: ${ Icon.Rank } ${ card.rank } **ATK**: ${ card.atk } **DEF**: ${ card.def }"
 
-#: src\card.ts:352
+#: src\card.ts:412
 #, javascript-format
 msgid "**Link Rating**: ${ card.link_arrows.length } **ATK**: ${ card.atk } **Link Arrows**: ${ arrows }"
 msgstr "**Valor Link**: ${ card.link_arrows.length } **ATK**: ${ card.atk } **Link Flechas Link**: ${ arrows }"
 
-#: src\card.ts:354
+#: src\card.ts:414
 #: src\commands\rush-duel.ts:111
 #, javascript-format
 msgid "**Level**: ${ Icon.Level } ${ card.level } **ATK**: ${ card.atk } **DEF**: ${ card.def }"
 msgstr "**Nível**: ${ Icon.Level } ${ card.level } **ATK**: ${ card.atk } **DEF**: ${ card.def }"
 
-#: src\card.ts:361
+#: src\card.ts:421
 msgid "**Pendulum Scale**: ${ formattedScale }"
 msgstr "**Escala Pêndulo**: ${ formattedScale }"
 
-#: src\card.ts:240
+#: src\card.ts:300
 #, javascript-format
 msgid "Password: ${ card.password } | Konami ID #${ card.konami_id }"
 msgstr "Senha: ${ card.password } | Konami ID #${ card.konami_id }"
 
-#: src\card.ts:242
+#: src\card.ts:302
 msgid "No password | Konami ID #${ card.konami_id }"
 msgstr ""
 
-#: src\card.ts:244
+#: src\card.ts:304
 #, javascript-format
 msgid "Password: ${ card.password } | Not yet released"
 msgstr "Senha: ${ card.password } | Not yet released"
 
-#: src\card.ts:246
+#: src\card.ts:306
 #: src\commands\rush-duel.ts:161
 msgid "Not yet released"
 msgstr ""
 
-#: src\card.ts:250
+#: src\card.ts:310
 #, javascript-format
 msgid "Placeholder ID: ${ card.fake_password }"
 msgstr ""
 
-#: src\utils.ts:45
+#: src\utils.ts:41
 msgid "🛠️ This command is in development."
 msgstr "🛠️ Este comando está em desenvolvimento."
 
-#: src\utils.ts:46
+#: src\utils.ts:42
 msgid "📨 Please send feedback to [our issue tracker](https://github.com/DawnbrandBots/bastion-bot) or the [support server](https://discord.gg/4aFuPyuE96)!"
 msgstr "📨 Por favor, envie um feedback para o [nosso Github](https://github.com/DawnbrandBots/bastion-bot)ou no nosso [servidor no Discord](https://discord.gg/4aFuPyuE96)!"
 
-#: src\utils.ts:57
+#: src\utils.ts:53
 msgid "Please consider supporting us!"
 msgstr "Por favor, considere nos apoiar!"
 
-#: src\utils.ts:58
+#: src\utils.ts:54
 msgid "Help keep Bastion online!"
 msgstr "Ajude a manter o Bastion online!"
 
-#: src\utils.ts:59
+#: src\utils.ts:55
 msgid "Please help keep Bastion online!"
 msgstr "Por favor, ajude a manter o Bastion online!"
 
-#: src\utils.ts:60
+#: src\utils.ts:56
 msgid "Was Bastion helpful? Consider supporting us!"
 msgstr ""
 
-#: src\utils.ts:61
+#: src\utils.ts:57
 msgid "Was Bastion helpful? We need your support!"
 msgstr "Bastion foi útil? Nós precisamos do seu apoio!"
 
-#: src\utils.ts:62
+#: src\utils.ts:58
 msgid "Did you find Bastion useful? Consider supporting us!"
 msgstr "Você acha que o Bastion foi útil? Conside nos apoiar!"
 
-#: src\utils.ts:63
+#: src\utils.ts:59
 msgid "Did you find Bastion useful? Help keep it online!"
 msgstr "Você acha que o Bastion foi útil? Ajude a mantê-lo online!"
 
-#: src\utils.ts:64
+#: src\utils.ts:60
 msgid "Did you find Bastion useful? We need your support!"
 msgstr "Você acha que o Bastion foi útil? Nós precisamos do seu apoio!"
 
-#: src\utils.ts:65
+#: src\utils.ts:61
 msgid "Enjoy Bastion? Help keep it online!"
 msgstr "Você está gostando do Bastion? Ajude a mantê-lo online!"
 
-#: src\utils.ts:66
+#: src\utils.ts:62
 msgid "Enjoy Bastion? Consider supporting us!"
 msgstr "Você está gostando do Bastion? Considere nos apoiar!"
 
-#: src\utils.ts:67
+#: src\utils.ts:63
 msgid "Found what you were looking for? Consider supporting us!"
 msgstr "Você encontrou o que procurava? Considere nos apoiar!"
 
-#: src\commands\art.ts:97
-#: src\commands\price.ts:148
-#: src\commands\rush-duel.ts:309
-#: src\commands\rush-duel.ts:342
-#: src\commands\search.ts:89
-#: src\events\message-search.ts:270
+#: src\commands\art.ts:69
+#: src\commands\price.ts:121
+#: src\commands\rush-duel.ts:306
+#: src\commands\rush-duel.ts:339
+#: src\commands\search.ts:62
+#: src\events\message-search.ts:295
 #, javascript-format
 msgid "Could not find a card matching `${ input }`!"
 msgstr "Não foi possível encontrar uma carta compatível com `${ input }`!"
 
-#: src\commands\art.ts:107
+#: src\commands\art.ts:83
 msgid "Could not find art for `${ name }`!"
 msgstr "Não foi possível encontrar uma arte para `${ name }`!"
 
-#: src\commands\deck.ts:245
+#: src\commands\deck.ts:248
 #, javascript-format
 msgid "${ counts.Monster } Monster"
 msgid_plural "${ counts.Monster } Monsters"
 msgstr[0] "${ counts.Monster } Monstro"
 msgstr[1] "${ counts.Monster } Monstros"
 
-#: src\commands\deck.ts:248
+#: src\commands\deck.ts:251
 msgid "${ counts.Spell } Spell"
 msgid_plural "${ counts.Spell } Spells"
 msgstr[0] "${ counts.Spell } Magia"
 msgstr[1] "${ counts.Spell } Magias"
 
-#: src\commands\deck.ts:251
+#: src\commands\deck.ts:254
 #, javascript-format
 msgid "${ counts.Trap } Trap"
 msgid_plural "${ counts.Trap } Traps"
 msgstr[0] "${ counts.Trap } Armadilha"
 msgstr[1] "${ counts.Trap } Armadilhas"
 
-#: src\commands\deck.ts:279
+#: src\commands\deck.ts:282
 msgid "Your Deck"
 msgstr "Seu Deck"
 
-#: src\commands\deck.ts:284
+#: src\commands\deck.ts:287
 #, javascript-format
 msgid "Main Deck (${ deck.main.length } card — ${ countDetail })"
 msgid_plural "Main Deck (${ deck.main.length } cards — ${ countDetail })"
 msgstr[0] "Deck Principal (${ deck.main.length } carta — ${ countDetail })"
 msgstr[1] "Deck Principal (${ deck.main.length } cartas — ${ countDetail })"
 
-#: src\commands\deck.ts:291
+#: src\commands\deck.ts:294
 msgid "Main Deck (continued)"
 msgstr "Deck Principal (continuação)"
 
-#: src\commands\deck.ts:305
+#: src\commands\deck.ts:308
 msgid "Extra Deck (continued)"
 msgstr "Deck Adicional (continuação)"
 
-#: src\commands\deck.ts:319
+#: src\commands\deck.ts:322
 msgid "Side Deck (continued)"
 msgstr "Deck Auxiliar (continuação)"
 
-#: src\commands\deck.ts:409
+#: src\commands\deck.ts:411
 msgid "Error: Your deck is empty."
 msgstr "Erro: Seu deck está vazio"
 
@@ -279,79 +279,79 @@ msgstr "Um bot de _Yu-Gi-Oh!_ gratuito e de código aberto"
 msgid "Revision: ${ process.env.BOT_REVISION }."
 msgstr "Revisão: ${ process.env.BOT_REVISION }."
 
-#: src\commands\deck.ts:329
+#: src\commands\deck.ts:332
 msgid ".ydk files must have the .ydk extension!"
 msgstr ""
 
-#: src\commands\deck.ts:332
+#: src\commands\deck.ts:335
 msgid ".ydk files should not be larger than 1 KB!"
 msgstr ""
 
-#: src\commands\deck.ts:322
+#: src\commands\deck.ts:325
 msgid "ydke URL"
 msgstr ""
 
-#: src\card.ts:317
+#: src\card.ts:377
 #. Forbidden/Limited Lists or Limit Regulations in the OCG
 msgid "**Limit**: ${ limitRegulationDisplay }"
 msgstr ""
 
-#: src\commands\price.ts:38
+#: src\commands\price.ts:40
 msgid "TCGPlayer"
 msgstr ""
 
-#: src\commands\price.ts:39
+#: src\commands\price.ts:41
 msgid "Cardmarket"
 msgstr ""
 
-#: src\commands\price.ts:40
+#: src\commands\price.ts:42
 msgid "CoolStuffInc"
 msgstr ""
 
-#: src\commands\price.ts:118
+#: src\commands\price.ts:96
 #. TODO: future, determine localisation and relevance status of this error
 msgid "Sorry, I can't find the price for a card with no English name!"
 msgstr ""
 
-#: src\commands\price.ts:162
+#: src\commands\price.ts:140
 msgid "No market price"
 msgstr ""
 
-#: src\commands\price.ts:170
+#: src\commands\price.ts:148
 #, javascript-format
 msgid "Prices for ${ card.name[resultLanguage] } - ${ vendorName }"
 msgstr ""
 
-#: src\commands\price.ts:184
+#: src\commands\price.ts:162
 msgid "Could not find prices for `${ name }`!"
 msgstr ""
 
-#: src\commands\deck.ts:427
+#: src\commands\deck.ts:429
 #. prepare interaction button for FTP upload
 msgid "Upload to YGOPRODECK"
 msgstr ""
 
-#: src\commands\deck.ts:485
+#: src\commands\deck.ts:487
 #. disable original button
 #. prepare row to disable button on original message
 msgid "Upload Complete"
 msgstr ""
 
-#: src\commands\deck.ts:472
+#: src\commands\deck.ts:474
 msgid "Deck upload failed!"
 msgstr ""
 
-#: src\commands\deck.ts:493
+#: src\commands\deck.ts:495
 #. reply in affirmation
 #, javascript-format
 msgid "Deck successfully uploaded to <${ url }>!"
 msgstr ""
 
-#: src\events\message-search.ts:275
+#: src\events\message-search.ts:300
 msgid "💬 Translations missing?"
 msgstr ""
 
-#: src\events\message-search.ts:276
+#: src\events\message-search.ts:301
 msgid "Help translate Bastion at the links above."
 msgstr ""
 
@@ -371,11 +371,11 @@ msgid ""
 "💬 Translations missing? Help translate Bastion on [GitHub](https://github.com/DawnbrandBots/bastion-bot)."
 msgstr ""
 
-#: src\events\message-search.ts:268
+#: src\events\message-search.ts:293
 msgid "Search type: ${ localisedType }"
 msgstr ""
 
-#: src\events\message-search.ts:265
+#: src\events\message-search.ts:290
 #, javascript-format
 msgid "Search language: **${ localisedInputLanguage }** (${ inputLanguage }). Check defaults with </locale get:${ id }> and configure with </locale set:${ id }>"
 msgstr ""
@@ -385,22 +385,22 @@ msgid "⚠️ You pinged me, but I am missing permissions in the channel!"
 msgstr ""
 
 #: src\events\message-ping.ts:94
-#: src\events\message-search.ts:182
+#: src\events\message-search.ts:192
 msgid "Please have a server administrator [fix this](https://github.com/DawnbrandBots/bastion-bot#discord-permissions)."
 msgstr ""
 
-#: src\events\message-search.ts:179
+#: src\events\message-search.ts:189
 msgid "⚠️ I am missing permissions in the channel!"
 msgstr ""
 
-#: src\commands\deck.ts:298
+#: src\commands\deck.ts:301
 #, javascript-format
 msgid "Extra Deck (${ deck.extra.length } card — ${ countDetail })"
 msgid_plural "Extra Deck (${ deck.extra.length } cards — ${ countDetail })"
 msgstr[0] "Deck Adicional (${ deck.extra.length } carta — ${ countDetail })"
 msgstr[1] "Deck Adicional (${ deck.extra.length } cartas — ${ countDetail })"
 
-#: src\commands\deck.ts:312
+#: src\commands\deck.ts:315
 #, javascript-format
 msgid "Side Deck (${ deck.side.length } card — ${ countDetail })"
 msgid_plural "Side Deck (${ deck.side.length } cards — ${ countDetail })"
@@ -444,12 +444,12 @@ msgstr ""
 msgid "Konami ID #${ card.konami_id }"
 msgstr ""
 
-#: src\commands\deck.ts:453
-#: src\commands\rush-duel.ts:489
+#: src\commands\deck.ts:455
+#: src\commands\rush-duel.ts:486
 msgid "Buttons can only be used by the user who called Bastion."
 msgstr ""
 
-#: src\commands\rush-duel.ts:401
+#: src\commands\rush-duel.ts:398
 #, javascript-format
 msgid "Could not find art for `${ input }`!"
 msgstr ""
@@ -524,127 +524,127 @@ msgctxt "monster-type-race"
 msgid "Gemini"
 msgstr "Gêmeo"
 
-#: src\card.ts:66
+#: src\card.ts:72
 msgctxt "monster-type-race"
 msgid "Warrior"
 msgstr "Guerreiro"
 
-#: src\card.ts:67
+#: src\card.ts:73
 msgctxt "monster-type-race"
 msgid "Spellcaster"
 msgstr "Mago"
 
-#: src\card.ts:68
+#: src\card.ts:74
 msgctxt "monster-type-race"
 msgid "Fairy"
 msgstr "Fada"
 
-#: src\card.ts:69
+#: src\card.ts:75
 msgctxt "monster-type-race"
 msgid "Fiend"
 msgstr "Demônio"
 
-#: src\card.ts:70
+#: src\card.ts:76
 msgctxt "monster-type-race"
 msgid "Zombie"
 msgstr "Zumbi"
 
-#: src\card.ts:71
+#: src\card.ts:77
 msgctxt "monster-type-race"
 msgid "Machine"
 msgstr "Máquina"
 
-#: src\card.ts:72
+#: src\card.ts:78
 msgctxt "monster-type-race"
 msgid "Aqua"
 msgstr "Aqua"
 
-#: src\card.ts:73
+#: src\card.ts:79
 msgctxt "monster-type-race"
 msgid "Pyro"
 msgstr "Piro"
 
-#: src\card.ts:74
+#: src\card.ts:80
 msgctxt "monster-type-race"
 msgid "Rock"
 msgstr "Rocha"
 
-#: src\card.ts:75
+#: src\card.ts:81
 msgctxt "monster-type-race"
 msgid "Winged Beast"
 msgstr "Fera Alada"
 
-#: src\card.ts:76
+#: src\card.ts:82
 msgctxt "monster-type-race"
 msgid "Plant"
 msgstr "Planta"
 
-#: src\card.ts:77
+#: src\card.ts:83
 msgctxt "monster-type-race"
 msgid "Insect"
 msgstr "Inseto"
 
-#: src\card.ts:78
+#: src\card.ts:84
 msgctxt "monster-type-race"
 msgid "Thunder"
 msgstr "Trovão"
 
-#: src\card.ts:79
+#: src\card.ts:85
 msgctxt "monster-type-race"
 msgid "Dragon"
 msgstr ""
 
-#: src\card.ts:80
+#: src\card.ts:86
 msgctxt "monster-type-race"
 msgid "Beast"
 msgstr "Fera"
 
-#: src\card.ts:81
+#: src\card.ts:87
 msgctxt "monster-type-race"
 msgid "Beast-Warrior"
 msgstr "Fera Guerreira"
 
-#: src\card.ts:82
+#: src\card.ts:88
 msgctxt "monster-type-race"
 msgid "Dinosaur"
 msgstr "Dinossauro"
 
-#: src\card.ts:83
+#: src\card.ts:89
 msgctxt "monster-type-race"
 msgid "Fish"
 msgstr "Peixe"
 
-#: src\card.ts:84
+#: src\card.ts:90
 msgctxt "monster-type-race"
 msgid "Sea Serpent"
 msgstr "Serpente Marinha"
 
-#: src\card.ts:85
+#: src\card.ts:91
 msgctxt "monster-type-race"
 msgid "Reptile"
 msgstr "Réptil"
 
-#: src\card.ts:86
+#: src\card.ts:92
 msgctxt "monster-type-race"
 msgid "Psychic"
 msgstr "Psíquico"
 
-#: src\card.ts:87
+#: src\card.ts:93
 msgctxt "monster-type-race"
 msgid "Divine-Beast"
 msgstr "Fera Divina"
 
-#: src\card.ts:88
+#: src\card.ts:94
 msgctxt "monster-type-race"
 msgid "Creator God"
 msgstr "Deus Creator"
 
-#: src\card.ts:89
+#: src\card.ts:95
 msgctxt "monster-type-race"
 msgid "Wyrm"
 msgstr "Wyrm"
 
-#: src\card.ts:90
+#: src\card.ts:96
 msgctxt "monster-type-race"
 msgid "Cyberse"
 msgstr "Ciberso"
@@ -694,54 +694,80 @@ msgctxt "spell-trap-property"
 msgid "Counter Trap"
 msgstr "Armadilha de Contra-Ataque"
 
-#: src\card.ts:96
+#: src\card.ts:62
+#. SpeedLimitRegulation is not converted to a number for display
+msgctxt "limit-regulation"
+msgid "Forbidden"
+msgstr ""
+
+#: src\card.ts:63
+msgctxt "limit-regulation"
+msgid "Limited 1"
+msgstr ""
+
+#: src\card.ts:64
+msgctxt "limit-regulation"
+msgid "Limited 2"
+msgstr ""
+
+#: src\card.ts:65
+msgctxt "limit-regulation"
+msgid "Limited 3"
+msgstr ""
+
+#: src\card.ts:66
+msgctxt "limit-regulation"
+msgid "Unlimited"
+msgstr ""
+
+#: src\card.ts:102
 msgctxt "attribute"
 msgid "EARTH"
 msgstr "TERRA"
 
-#: src\card.ts:97
+#: src\card.ts:103
 msgctxt "attribute"
 msgid "WATER"
 msgstr "ÁGUA"
 
-#: src\card.ts:98
+#: src\card.ts:104
 msgctxt "attribute"
 msgid "FIRE"
 msgstr "FOGO"
 
-#: src\card.ts:99
+#: src\card.ts:105
 msgctxt "attribute"
 msgid "WIND"
 msgstr "VENTO"
 
-#: src\card.ts:100
+#: src\card.ts:106
 msgctxt "attribute"
 msgid "LIGHT"
 msgstr "LUZ"
 
-#: src\card.ts:101
+#: src\card.ts:107
 msgctxt "attribute"
 msgid "DARK"
 msgstr "TREVAS"
 
-#: src\card.ts:102
+#: src\card.ts:108
 msgctxt "attribute"
 msgid "DIVINE"
 msgstr "DIVINO"
 
-#: src\card.ts:367
-#: src\card.ts:378
+#: src\card.ts:427
+#: src\card.ts:438
 #: src\commands\rush-duel.ts:142
 msgctxt "card-embed"
 msgid "Card Text"
 msgstr "Texto da carta"
 
-#: src\card.ts:372
+#: src\card.ts:432
 msgctxt "card-embed"
 msgid "Pendulum Effect"
 msgstr "Efeito Pêndulo"
 
-#: src\card.ts:393
+#: src\card.ts:453
 msgctxt "card-embed"
 msgid "Card Effect"
 msgstr "Efeito da Carta"
@@ -768,27 +794,21 @@ msgctxt "card-embed"
 msgid "[MULTI-CHOICE EFFECT]"
 msgstr ""
 
-#: src\locale.ts:48
+#: src\locale.ts:71
 msgctxt "command-option"
 msgid "result-language"
 msgstr ""
 
-#: src\locale.ts:68
+#: src\locale.ts:131
 msgctxt "command-option"
 msgid "input-language"
 msgstr "idioma-de-entrada"
 
-#: src\commands\art.ts:36
-#: src\commands\art.ts:46
-#: src\commands\art.ts:58
-#: src\commands\price.ts:64
-#: src\commands\price.ts:74
-#: src\commands\price.ts:86
 #: src\commands\rush-duel.ts:194
 #: src\commands\rush-duel.ts:206
-#: src\commands\search.ts:39
-#: src\commands\search.ts:49
-#: src\commands\search.ts:61
+#: src\locale.ts:147
+#: src\locale.ts:165
+#: src\locale.ts:181
 msgctxt "command-option"
 msgid "input"
 msgstr "entrada"
@@ -808,50 +828,44 @@ msgctxt "command-option"
 msgid "command"
 msgstr ""
 
-#: src\commands\deck.ts:122
+#: src\commands\deck.ts:126
 msgctxt "command-option"
 msgid "url"
 msgstr ""
 
-#: src\commands\deck.ts:128
+#: src\commands\deck.ts:132
 msgctxt "command-option"
 msgid "file"
 msgstr ""
 
-#: src\commands\deck.ts:134
-#: src\commands\deck.ts:140
+#: src\commands\deck.ts:138
+#: src\commands\deck.ts:144
 msgctxt "command-option"
 msgid "deck"
 msgstr ""
 
-#: src\commands\deck.ts:146
+#: src\commands\deck.ts:150
 msgctxt "command-option"
 msgid "public"
 msgstr ""
 
-#: src\commands\deck.ts:153
+#: src\commands\deck.ts:157
 msgctxt "command-option"
 msgid "stacked"
 msgstr ""
 
-#: src\commands\art.ts:31
-#: src\commands\price.ts:59
-#: src\commands\search.ts:34
+#: src\locale.ts:142
 msgctxt "command-option"
 msgid "name"
 msgstr ""
 
-#: src\commands\art.ts:41
-#: src\commands\price.ts:69
-#: src\commands\search.ts:44
+#: src\locale.ts:160
 msgctxt "command-option"
 msgid "password"
 msgstr ""
 
-#: src\commands\art.ts:53
-#: src\commands\price.ts:81
 #: src\commands\rush-duel.ts:199
-#: src\commands\search.ts:56
+#: src\locale.ts:176
 msgctxt "command-option"
 msgid "konami-id"
 msgstr ""
@@ -876,7 +890,7 @@ msgctxt "command-option"
 msgid "locale"
 msgstr ""
 
-#: src\commands\price.ts:91
+#: src\commands\price.ts:65
 msgctxt "command-option"
 msgid "vendor"
 msgstr ""
@@ -896,12 +910,12 @@ msgctxt "command-option"
 msgid "art"
 msgstr ""
 
-#: src\locale.ts:51
+#: src\locale.ts:74
 msgctxt "command-option-description"
 msgid "The output language for the card embed, overriding other settings."
 msgstr ""
 
-#: src\locale.ts:71
+#: src\locale.ts:132
 msgctxt "command-option-description"
 msgid "The language to search in, defaulting to the result language."
 msgstr "O idioma no qual procurar, tendo como padrão o idioma do resultado"
@@ -916,85 +930,79 @@ msgctxt "command-option-description"
 msgid "The name of a specific Slash Command."
 msgstr ""
 
-#: src\commands\deck.ts:125
+#: src\commands\deck.ts:129
 msgctxt "command-option-description"
 msgid "View a deck by entering a ydke:// URL."
 msgstr ""
 
-#: src\commands\deck.ts:131
+#: src\commands\deck.ts:135
 msgctxt "command-option-description"
 msgid "View a deck by uploading a .ydk file."
 msgstr ""
 
-#: src\commands\deck.ts:137
+#: src\commands\deck.ts:141
 msgctxt "command-option-description"
 msgid "The ydke:// URL of the deck you want to view."
 msgstr ""
 
-#: src\commands\deck.ts:143
+#: src\commands\deck.ts:147
 msgctxt "command-option-description"
 msgid "The .ydk file of the deck you want to view."
 msgstr ""
 
-#: src\commands\deck.ts:149
+#: src\commands\deck.ts:153
 msgctxt "command-option-description"
 msgid "Whether to display the deck details publicly in chat. This is false by default."
 msgstr ""
 
-#: src\commands\deck.ts:156
+#: src\commands\deck.ts:160
 msgctxt "command-option-description"
 msgid "Whether to display the deck sections as one stacked column. This is false (side-by-side) by default."
 msgstr ""
 
-#: src\commands\art.ts:32
+#: src\commands\art.ts:41
 msgctxt "command-option-description"
 msgid "Display the art for the card with this name."
 msgstr ""
 
-#: src\commands\art.ts:37
-#: src\commands\price.ts:65
 #: src\commands\rush-duel.ts:195
-#: src\commands\search.ts:40
+#: src\locale.ts:148
 msgctxt "command-option-description"
 msgid "Card name, fuzzy matching supported."
 msgstr ""
 
-#: src\commands\art.ts:42
+#: src\commands\art.ts:44
 msgctxt "command-option-description"
 msgid "Display the art for the card with this password."
 msgstr ""
 
-#: src\commands\art.ts:48
-#: src\commands\price.ts:76
-#: src\commands\search.ts:51
+#: src\locale.ts:167
 msgctxt "command-option-description"
 msgid "Card password, the eight-digit number printed on the bottom left corner."
 msgstr ""
 
-#: src\commands\art.ts:54
+#: src\commands\art.ts:47
 msgctxt "command-option-description"
 msgid "Display the art for the card with this official database ID."
 msgstr ""
 
-#: src\commands\art.ts:59
-#: src\commands\price.ts:87
 #: src\commands\rush-duel.ts:207
-#: src\commands\search.ts:62
+#: src\locale.ts:182
 msgctxt "command-option-description"
 msgid "Konami's official card database identifier."
 msgstr ""
 
-#: src\commands\search.ts:35
+#: src\commands\search.ts:40
 msgctxt "command-option-description"
 msgid "Find all information for the card with this name."
 msgstr ""
 
-#: src\commands\search.ts:45
+#: src\commands\search.ts:43
 msgctxt "command-option-description"
 msgid "Find all information for the card with this password."
 msgstr ""
 
-#: src\commands\search.ts:57
+#: src\commands\search.ts:46
 msgctxt "command-option-description"
 msgid "Find all information for the card with this official database ID."
 msgstr ""
@@ -1019,22 +1027,22 @@ msgctxt "command-option-description"
 msgid "The new default language to use in this channel or server."
 msgstr ""
 
-#: src\commands\price.ts:60
+#: src\commands\price.ts:69
 msgctxt "command-option-description"
 msgid "Display the price for the card with this name."
 msgstr ""
 
-#: src\commands\price.ts:70
+#: src\commands\price.ts:73
 msgctxt "command-option-description"
 msgid "Display the price for the card with this password."
 msgstr ""
 
-#: src\commands\price.ts:82
+#: src\commands\price.ts:76
 msgctxt "command-option-description"
 msgid "Display the price for the card with this official database ID."
 msgstr ""
 
-#: src\commands\price.ts:92
+#: src\commands\price.ts:66
 msgctxt "command-option-description"
 msgid "The vendor to fetch the price data from."
 msgstr ""
@@ -1064,7 +1072,7 @@ msgctxt "command-option-description"
 msgid "Display just the art for the Rush Duel card with this name."
 msgstr ""
 
-#: src\commands\art.ts:26
+#: src\commands\art.ts:37
 msgctxt "command-name"
 msgid "art"
 msgstr "arte"
@@ -1089,12 +1097,12 @@ msgctxt "command-name"
 msgid "help"
 msgstr ""
 
-#: src\commands\deck.ts:115
+#: src\commands\deck.ts:119
 msgctxt "command-name"
 msgid "deck"
 msgstr ""
 
-#: src\commands\search.ts:29
+#: src\commands\search.ts:36
 msgctxt "command-name"
 msgid "search"
 msgstr ""
@@ -1104,12 +1112,12 @@ msgctxt "command-name"
 msgid "locale"
 msgstr ""
 
-#: src\commands\random.ts:24
+#: src\commands\random.ts:30
 msgctxt "command-name"
 msgid "random"
 msgstr ""
 
-#: src\commands\price.ts:54
+#: src\commands\price.ts:60
 msgctxt "command-name"
 msgid "price"
 msgstr ""
@@ -1119,7 +1127,7 @@ msgctxt "command-name"
 msgid "rush-duel"
 msgstr ""
 
-#: src\commands\art.ts:27
+#: src\commands\art.ts:38
 msgctxt "command-description"
 msgid "Display the art for a card!"
 msgstr "Mostra a arte de uma carta!"
@@ -1144,12 +1152,12 @@ msgctxt "command-description"
 msgid "Get help with a Slash Command."
 msgstr ""
 
-#: src\commands\deck.ts:118
+#: src\commands\deck.ts:122
 msgctxt "command-description"
 msgid "Display a deck list from ydke:// or .ydk format, exported from a number of deck building programs."
 msgstr ""
 
-#: src\commands\search.ts:30
+#: src\commands\search.ts:37
 msgctxt "command-description"
 msgid "Find all information on a card!"
 msgstr ""
@@ -1159,12 +1167,12 @@ msgctxt "command-description"
 msgid "Check or set Bastion's locale for this channel or server."
 msgstr ""
 
-#: src\commands\random.ts:25
+#: src\commands\random.ts:31
 msgctxt "command-description"
 msgid "Get a random Yu-Gi-Oh! card."
 msgstr ""
 
-#: src\commands\price.ts:55
+#: src\commands\price.ts:61
 msgctxt "command-description"
 msgid "Display the price for a card!"
 msgstr ""

--- a/translations/zh-CN.po
+++ b/translations/zh-CN.po
@@ -6,139 +6,139 @@ msgstr ""
 "MIME-Version: 1.0\n"
 "Content-Transfer-Encoding: 8bit\n"
 
-#: src\card.ts:279
+#: src\card.ts:339
 #: src\commands\rush-duel.ts:60
 msgid "🔗 Links"
 msgstr "🔗 链接"
 
-#: src\card.ts:280
+#: src\card.ts:340
 #, javascript-format
 msgid "[Official Konami DB](${ official }) | [OCG Rulings](${ rulings }) | [Yugipedia](${ yugipedia }) | [YGOPRODECK](${ ygoprodeck })"
 msgstr "[K社官方数据库](${ official }) | [事务局FAQ](${ rulings }) | [Yugipedia](${ yugipedia }) | [YGOPRODECK](${ ygoprodeck })"
 
-#: src\card.ts:283
+#: src\card.ts:343
 #, javascript-format
 msgid "[Yugipedia](${ yugipedia }) | [YGOPRODECK](${ ygoprodeck })"
 msgstr "[Yugipedia](${ yugipedia }) | [YGOPRODECK](${ ygoprodeck })"
 
-#: src\card.ts:343
+#: src\card.ts:403
 #: src\commands\rush-duel.ts:107
 #, javascript-format
 msgid "**Type**: ${ RaceIcon[race] } ${ localizedMonsterTypeLine }"
 msgstr "**种族**: ${ RaceIcon[race] } ${ localizedMonsterTypeLine }"
 
-#: src\card.ts:345
+#: src\card.ts:405
 #: src\commands\rush-duel.ts:109
 #, javascript-format
 msgid "**Attribute**: ${ AttributeIcon[card.attribute] } ${ localizedAttribute }"
 msgstr "**属性**: ${ AttributeIcon[card.attribute] } ${ localizedAttribute }"
 
-#: src\card.ts:349
+#: src\card.ts:409
 msgid "**Rank**: ${ Icon.Rank } ${ card.rank } **ATK**: ${ card.atk } **DEF**: ${ card.def }"
 msgstr "**阶级**: ${ Icon.Rank } ${ card.rank } **攻击力**: ${ card.atk } **守备力**: ${ card.def }"
 
-#: src\card.ts:352
+#: src\card.ts:412
 #, javascript-format
 msgid "**Link Rating**: ${ card.link_arrows.length } **ATK**: ${ card.atk } **Link Arrows**: ${ arrows }"
 msgstr "**连接数值**: ${ card.link_arrows.length } **攻击力**: ${ card.atk } **连接标记**: ${ arrows }"
 
-#: src\card.ts:354
+#: src\card.ts:414
 #: src\commands\rush-duel.ts:111
 #, javascript-format
 msgid "**Level**: ${ Icon.Level } ${ card.level } **ATK**: ${ card.atk } **DEF**: ${ card.def }"
 msgstr "**等级**: ${ Icon.Level } ${ card.level } **攻击力**: ${ card.atk } **守备力**: ${ card.def }"
 
-#: src\card.ts:361
+#: src\card.ts:421
 msgid "**Pendulum Scale**: ${ formattedScale }"
 msgstr "**灵摆刻度**: ${ formattedScale }"
 
-#: src\card.ts:240
+#: src\card.ts:300
 #, javascript-format
 msgid "Password: ${ card.password } | Konami ID #${ card.konami_id }"
 msgstr "卡片密码: ${ card.password } | 官方编号${ card.konami_id }"
 
-#: src\card.ts:242
+#: src\card.ts:302
 msgid "No password | Konami ID #${ card.konami_id }"
 msgstr "无卡密 | 官方编号${ card.konami_id }"
 
-#: src\card.ts:244
+#: src\card.ts:304
 #, javascript-format
 msgid "Password: ${ card.password } | Not yet released"
 msgstr "卡片密码: ${ card.password } | 未发行"
 
-#: src\card.ts:246
+#: src\card.ts:306
 #: src\commands\rush-duel.ts:161
 msgid "Not yet released"
 msgstr "未发行"
 
-#: src\card.ts:250
+#: src\card.ts:310
 #, javascript-format
 msgid "Placeholder ID: ${ card.fake_password }"
 msgstr "假卡密: ${ card.fake_password }"
 
-#: src\utils.ts:45
+#: src\utils.ts:41
 msgid "🛠️ This command is in development."
 msgstr "🛠️ 这个指令正在开发中"
 
-#: src\utils.ts:46
+#: src\utils.ts:42
 msgid "📨 Please send feedback to [our issue tracker](https://github.com/DawnbrandBots/bastion-bot) or the [support server](https://discord.gg/4aFuPyuE96)!"
 msgstr "📨 如有意见或建议请反馈至[GitHub issue](https://github.com/DawnbrandBots/bastion-bot)或者[Discord服务器](https://discord.gg/4aFuPyuE96)!"
 
-#: src\utils.ts:57
+#: src\utils.ts:53
 msgid "Please consider supporting us!"
 msgstr "请考虑捐助我们！"
 
-#: src\utils.ts:58
+#: src\utils.ts:54
 msgid "Help keep Bastion online!"
 msgstr "帮帮Bastion吧，宝宝快饿死了"
 
-#: src\utils.ts:59
+#: src\utils.ts:55
 msgid "Please help keep Bastion online!"
 msgstr "请帮帮Bastion吧，宝宝真的快饿死了"
 
-#: src\utils.ts:60
+#: src\utils.ts:56
 msgid "Was Bastion helpful? Consider supporting us!"
 msgstr "Bastion有用么？请考虑捐助我们！"
 
-#: src\utils.ts:61
+#: src\utils.ts:57
 msgid "Was Bastion helpful? We need your support!"
 msgstr "Bastion有用么？我们需要你的支持！"
 
-#: src\utils.ts:62
+#: src\utils.ts:58
 msgid "Did you find Bastion useful? Consider supporting us!"
 msgstr "你觉得Bastion好用么？请考虑捐助我们！"
 
-#: src\utils.ts:63
+#: src\utils.ts:59
 msgid "Did you find Bastion useful? Help keep it online!"
 msgstr "你觉得Bastion好用么？那帮帮TA吧，孩子快饿死了"
 
-#: src\utils.ts:64
+#: src\utils.ts:60
 msgid "Did you find Bastion useful? We need your support!"
 msgstr "你觉得Bastion好用么？我们需要你的支持！"
 
-#: src\utils.ts:65
+#: src\utils.ts:61
 msgid "Enjoy Bastion? Help keep it online!"
 msgstr "你觉得Bastion好用么？那帮帮TA吧，孩子快饿死了"
 
-#: src\utils.ts:66
+#: src\utils.ts:62
 msgid "Enjoy Bastion? Consider supporting us!"
 msgstr "觉得Bastion怎么样？请考虑捐助我们！"
 
-#: src\utils.ts:67
+#: src\utils.ts:63
 msgid "Found what you were looking for? Consider supporting us!"
 msgstr "找到你要的东西了吗？请考虑捐助我们！"
 
-#: src\commands\art.ts:97
-#: src\commands\price.ts:148
-#: src\commands\rush-duel.ts:309
-#: src\commands\rush-duel.ts:342
-#: src\commands\search.ts:89
-#: src\events\message-search.ts:270
+#: src\commands\art.ts:69
+#: src\commands\price.ts:121
+#: src\commands\rush-duel.ts:306
+#: src\commands\rush-duel.ts:339
+#: src\commands\search.ts:62
+#: src\events\message-search.ts:295
 #, javascript-format
 msgid "Could not find a card matching `${ input }`!"
 msgstr "查无此卡：`${ input }`"
 
-#: src\commands\art.ts:107
+#: src\commands\art.ts:83
 msgid "Could not find art for `${ name }`!"
 msgstr "没找到`${ name }`的卡图！"
 
@@ -217,58 +217,58 @@ msgstr "延迟${ latency }ms"
 msgid "Could not find a Yugipedia page named `${ page }`."
 msgstr "Yugipedia上找不到`${ page }`"
 
-#: src\commands\deck.ts:245
+#: src\commands\deck.ts:248
 #, javascript-format
 msgid "${ counts.Monster } Monster"
 msgid_plural "${ counts.Monster } Monsters"
 msgstr[0] "${ counts.Monster }张怪兽卡"
 
-#: src\commands\deck.ts:248
+#: src\commands\deck.ts:251
 msgid "${ counts.Spell } Spell"
 msgid_plural "${ counts.Spell } Spells"
 msgstr[0] "${ counts.Spell }张魔法卡"
 
-#: src\commands\deck.ts:251
+#: src\commands\deck.ts:254
 #, javascript-format
 msgid "${ counts.Trap } Trap"
 msgid_plural "${ counts.Trap } Traps"
 msgstr[0] "${ counts.Trap }张陷阱卡"
 
-#: src\commands\deck.ts:279
+#: src\commands\deck.ts:282
 msgid "Your Deck"
 msgstr "你的卡组"
 
-#: src\commands\deck.ts:284
+#: src\commands\deck.ts:287
 #, javascript-format
 msgid "Main Deck (${ deck.main.length } card — ${ countDetail })"
 msgid_plural "Main Deck (${ deck.main.length } cards — ${ countDetail })"
 msgstr[0] "牌组（${ deck.main.length }张 — ${ countDetail }）"
 
-#: src\commands\deck.ts:298
+#: src\commands\deck.ts:301
 #, javascript-format
 msgid "Extra Deck (${ deck.extra.length } card — ${ countDetail })"
 msgid_plural "Extra Deck (${ deck.extra.length } cards — ${ countDetail })"
 msgstr[0] "额外卡组（${ deck.extra.length }张 — ${ countDetail }）"
 
-#: src\commands\deck.ts:312
+#: src\commands\deck.ts:315
 #, javascript-format
 msgid "Side Deck (${ deck.side.length } card — ${ countDetail })"
 msgid_plural "Side Deck (${ deck.side.length } cards — ${ countDetail })"
 msgstr[0] "备牌（${ deck.side.length }张 — ${ countDetail }）"
 
-#: src\commands\deck.ts:291
+#: src\commands\deck.ts:294
 msgid "Main Deck (continued)"
 msgstr "牌组（续）"
 
-#: src\commands\deck.ts:305
+#: src\commands\deck.ts:308
 msgid "Extra Deck (continued)"
 msgstr "额外卡组（续）"
 
-#: src\commands\deck.ts:319
+#: src\commands\deck.ts:322
 msgid "Side Deck (continued)"
 msgstr "备牌（续）"
 
-#: src\commands\deck.ts:409
+#: src\commands\deck.ts:411
 msgid "Error: Your deck is empty."
 msgstr "错误：卡组是空的。"
 
@@ -287,79 +287,79 @@ msgstr "自由开源游戏王聊天机器人"
 msgid "Revision: ${ process.env.BOT_REVISION }."
 msgstr "修订：${ process.env.BOT_REVISION }"
 
-#: src\commands\deck.ts:329
+#: src\commands\deck.ts:332
 msgid ".ydk files must have the .ydk extension!"
 msgstr ""
 
-#: src\commands\deck.ts:332
+#: src\commands\deck.ts:335
 msgid ".ydk files should not be larger than 1 KB!"
 msgstr ""
 
-#: src\commands\deck.ts:322
+#: src\commands\deck.ts:325
 msgid "ydke URL"
 msgstr ""
 
-#: src\card.ts:317
+#: src\card.ts:377
 #. Forbidden/Limited Lists or Limit Regulations in the OCG
 msgid "**Limit**: ${ limitRegulationDisplay }"
 msgstr "**限制**：${ limitRegulationDisplay }"
 
-#: src\commands\price.ts:38
+#: src\commands\price.ts:40
 msgid "TCGPlayer"
 msgstr ""
 
-#: src\commands\price.ts:39
+#: src\commands\price.ts:41
 msgid "Cardmarket"
 msgstr ""
 
-#: src\commands\price.ts:40
+#: src\commands\price.ts:42
 msgid "CoolStuffInc"
 msgstr ""
 
-#: src\commands\price.ts:118
+#: src\commands\price.ts:96
 #. TODO: future, determine localisation and relevance status of this error
 msgid "Sorry, I can't find the price for a card with no English name!"
 msgstr ""
 
-#: src\commands\price.ts:162
+#: src\commands\price.ts:140
 msgid "No market price"
 msgstr ""
 
-#: src\commands\price.ts:170
+#: src\commands\price.ts:148
 #, javascript-format
 msgid "Prices for ${ card.name[resultLanguage] } - ${ vendorName }"
 msgstr ""
 
-#: src\commands\price.ts:184
+#: src\commands\price.ts:162
 msgid "Could not find prices for `${ name }`!"
 msgstr ""
 
-#: src\commands\deck.ts:427
+#: src\commands\deck.ts:429
 #. prepare interaction button for FTP upload
 msgid "Upload to YGOPRODECK"
 msgstr "上传至YGOPRODECK"
 
-#: src\commands\deck.ts:485
+#: src\commands\deck.ts:487
 #. disable original button
 #. prepare row to disable button on original message
 msgid "Upload Complete"
 msgstr "上传成功"
 
-#: src\commands\deck.ts:472
+#: src\commands\deck.ts:474
 msgid "Deck upload failed!"
 msgstr "上传失败"
 
-#: src\commands\deck.ts:493
+#: src\commands\deck.ts:495
 #. reply in affirmation
 #, javascript-format
 msgid "Deck successfully uploaded to <${ url }>!"
 msgstr "卡组成功上传到<${ url }>!"
 
-#: src\events\message-search.ts:275
+#: src\events\message-search.ts:300
 msgid "💬 Translations missing?"
 msgstr "💬缺少翻译？"
 
-#: src\events\message-search.ts:276
+#: src\events\message-search.ts:301
 msgid "Help translate Bastion at the links above."
 msgstr "在以上的网址帮忙翻译Bastion"
 
@@ -379,11 +379,11 @@ msgid ""
 "💬 Translations missing? Help translate Bastion on [GitHub](https://github.com/DawnbrandBots/bastion-bot)."
 msgstr ""
 
-#: src\events\message-search.ts:268
+#: src\events\message-search.ts:293
 msgid "Search type: ${ localisedType }"
 msgstr "搜索类型：${ localisedType }"
 
-#: src\events\message-search.ts:265
+#: src\events\message-search.ts:290
 #, javascript-format
 msgid "Search language: **${ localisedInputLanguage }** (${ inputLanguage }). Check defaults with </locale get:${ id }> and configure with </locale set:${ id }>"
 msgstr ""
@@ -393,11 +393,11 @@ msgid "⚠️ You pinged me, but I am missing permissions in the channel!"
 msgstr ""
 
 #: src\events\message-ping.ts:94
-#: src\events\message-search.ts:182
+#: src\events\message-search.ts:192
 msgid "Please have a server administrator [fix this](https://github.com/DawnbrandBots/bastion-bot#discord-permissions)."
 msgstr ""
 
-#: src\events\message-search.ts:179
+#: src\events\message-search.ts:189
 msgid "⚠️ I am missing permissions in the channel!"
 msgstr ""
 
@@ -438,12 +438,12 @@ msgstr ""
 msgid "Konami ID #${ card.konami_id }"
 msgstr "官方编号${ card.konami_id }"
 
-#: src\commands\deck.ts:453
-#: src\commands\rush-duel.ts:489
+#: src\commands\deck.ts:455
+#: src\commands\rush-duel.ts:486
 msgid "Buttons can only be used by the user who called Bastion."
 msgstr ""
 
-#: src\commands\rush-duel.ts:401
+#: src\commands\rush-duel.ts:398
 #, javascript-format
 msgid "Could not find art for `${ input }`!"
 msgstr ""
@@ -518,127 +518,127 @@ msgctxt "monster-type-race"
 msgid "Gemini"
 msgstr "双重"
 
-#: src\card.ts:66
+#: src\card.ts:72
 msgctxt "monster-type-race"
 msgid "Warrior"
 msgstr "战士族"
 
-#: src\card.ts:67
+#: src\card.ts:73
 msgctxt "monster-type-race"
 msgid "Spellcaster"
 msgstr "魔法师族"
 
-#: src\card.ts:68
+#: src\card.ts:74
 msgctxt "monster-type-race"
 msgid "Fairy"
 msgstr "天使族"
 
-#: src\card.ts:69
+#: src\card.ts:75
 msgctxt "monster-type-race"
 msgid "Fiend"
 msgstr "恶魔族"
 
-#: src\card.ts:70
+#: src\card.ts:76
 msgctxt "monster-type-race"
 msgid "Zombie"
 msgstr "不死族"
 
-#: src\card.ts:71
+#: src\card.ts:77
 msgctxt "monster-type-race"
 msgid "Machine"
 msgstr "机械族"
 
-#: src\card.ts:72
+#: src\card.ts:78
 msgctxt "monster-type-race"
 msgid "Aqua"
 msgstr "水族"
 
-#: src\card.ts:73
+#: src\card.ts:79
 msgctxt "monster-type-race"
 msgid "Pyro"
 msgstr "炎族"
 
-#: src\card.ts:74
+#: src\card.ts:80
 msgctxt "monster-type-race"
 msgid "Rock"
 msgstr "岩石族"
 
-#: src\card.ts:75
+#: src\card.ts:81
 msgctxt "monster-type-race"
 msgid "Winged Beast"
 msgstr "鸟兽族"
 
-#: src\card.ts:76
+#: src\card.ts:82
 msgctxt "monster-type-race"
 msgid "Plant"
 msgstr "植物族"
 
-#: src\card.ts:77
+#: src\card.ts:83
 msgctxt "monster-type-race"
 msgid "Insect"
 msgstr "昆虫族"
 
-#: src\card.ts:78
+#: src\card.ts:84
 msgctxt "monster-type-race"
 msgid "Thunder"
 msgstr "雷族"
 
-#: src\card.ts:79
+#: src\card.ts:85
 msgctxt "monster-type-race"
 msgid "Dragon"
 msgstr "龙族"
 
-#: src\card.ts:80
+#: src\card.ts:86
 msgctxt "monster-type-race"
 msgid "Beast"
 msgstr "兽族"
 
-#: src\card.ts:81
+#: src\card.ts:87
 msgctxt "monster-type-race"
 msgid "Beast-Warrior"
 msgstr "兽战士族"
 
-#: src\card.ts:82
+#: src\card.ts:88
 msgctxt "monster-type-race"
 msgid "Dinosaur"
 msgstr "恐龙族"
 
-#: src\card.ts:83
+#: src\card.ts:89
 msgctxt "monster-type-race"
 msgid "Fish"
 msgstr "鱼族"
 
-#: src\card.ts:84
+#: src\card.ts:90
 msgctxt "monster-type-race"
 msgid "Sea Serpent"
 msgstr "海龙族"
 
-#: src\card.ts:85
+#: src\card.ts:91
 msgctxt "monster-type-race"
 msgid "Reptile"
 msgstr "爬虫族"
 
-#: src\card.ts:86
+#: src\card.ts:92
 msgctxt "monster-type-race"
 msgid "Psychic"
 msgstr "念动力族"
 
-#: src\card.ts:87
+#: src\card.ts:93
 msgctxt "monster-type-race"
 msgid "Divine-Beast"
 msgstr "幻神兽族"
 
-#: src\card.ts:88
+#: src\card.ts:94
 msgctxt "monster-type-race"
 msgid "Creator God"
 msgstr "创造神族"
 
-#: src\card.ts:89
+#: src\card.ts:95
 msgctxt "monster-type-race"
 msgid "Wyrm"
 msgstr "幻龙族"
 
-#: src\card.ts:90
+#: src\card.ts:96
 msgctxt "monster-type-race"
 msgid "Cyberse"
 msgstr "电子界族"
@@ -688,54 +688,80 @@ msgctxt "spell-trap-property"
 msgid "Counter Trap"
 msgstr "反击陷阱"
 
-#: src\card.ts:96
+#: src\card.ts:62
+#. SpeedLimitRegulation is not converted to a number for display
+msgctxt "limit-regulation"
+msgid "Forbidden"
+msgstr ""
+
+#: src\card.ts:63
+msgctxt "limit-regulation"
+msgid "Limited 1"
+msgstr ""
+
+#: src\card.ts:64
+msgctxt "limit-regulation"
+msgid "Limited 2"
+msgstr ""
+
+#: src\card.ts:65
+msgctxt "limit-regulation"
+msgid "Limited 3"
+msgstr ""
+
+#: src\card.ts:66
+msgctxt "limit-regulation"
+msgid "Unlimited"
+msgstr ""
+
+#: src\card.ts:102
 msgctxt "attribute"
 msgid "EARTH"
 msgstr "地"
 
-#: src\card.ts:97
+#: src\card.ts:103
 msgctxt "attribute"
 msgid "WATER"
 msgstr "水"
 
-#: src\card.ts:98
+#: src\card.ts:104
 msgctxt "attribute"
 msgid "FIRE"
 msgstr "炎"
 
-#: src\card.ts:99
+#: src\card.ts:105
 msgctxt "attribute"
 msgid "WIND"
 msgstr "风"
 
-#: src\card.ts:100
+#: src\card.ts:106
 msgctxt "attribute"
 msgid "LIGHT"
 msgstr "光"
 
-#: src\card.ts:101
+#: src\card.ts:107
 msgctxt "attribute"
 msgid "DARK"
 msgstr "暗"
 
-#: src\card.ts:102
+#: src\card.ts:108
 msgctxt "attribute"
 msgid "DIVINE"
 msgstr "神"
 
-#: src\card.ts:367
-#: src\card.ts:378
+#: src\card.ts:427
+#: src\card.ts:438
 #: src\commands\rush-duel.ts:142
 msgctxt "card-embed"
 msgid "Card Text"
 msgstr "卡片文本"
 
-#: src\card.ts:372
+#: src\card.ts:432
 msgctxt "card-embed"
 msgid "Pendulum Effect"
 msgstr "灵摆效果"
 
-#: src\card.ts:393
+#: src\card.ts:453
 msgctxt "card-embed"
 msgid "Card Effect"
 msgstr "卡片效果"
@@ -762,27 +788,21 @@ msgctxt "card-embed"
 msgid "[MULTI-CHOICE EFFECT]"
 msgstr "【选择效果】"
 
-#: src\locale.ts:48
+#: src\locale.ts:71
 msgctxt "command-option"
 msgid "result-language"
 msgstr "查询结果语言"
 
-#: src\locale.ts:68
+#: src\locale.ts:131
 msgctxt "command-option"
 msgid "input-language"
 msgstr "输入语言"
 
-#: src\commands\art.ts:36
-#: src\commands\art.ts:46
-#: src\commands\art.ts:58
-#: src\commands\price.ts:64
-#: src\commands\price.ts:74
-#: src\commands\price.ts:86
 #: src\commands\rush-duel.ts:194
 #: src\commands\rush-duel.ts:206
-#: src\commands\search.ts:39
-#: src\commands\search.ts:49
-#: src\commands\search.ts:61
+#: src\locale.ts:147
+#: src\locale.ts:165
+#: src\locale.ts:181
 msgctxt "command-option"
 msgid "input"
 msgstr "输入"
@@ -802,50 +822,44 @@ msgctxt "command-option"
 msgid "command"
 msgstr ""
 
-#: src\commands\deck.ts:122
+#: src\commands\deck.ts:126
 msgctxt "command-option"
 msgid "url"
 msgstr ""
 
-#: src\commands\deck.ts:128
+#: src\commands\deck.ts:132
 msgctxt "command-option"
 msgid "file"
 msgstr ""
 
-#: src\commands\deck.ts:134
-#: src\commands\deck.ts:140
+#: src\commands\deck.ts:138
+#: src\commands\deck.ts:144
 msgctxt "command-option"
 msgid "deck"
 msgstr ""
 
-#: src\commands\deck.ts:146
+#: src\commands\deck.ts:150
 msgctxt "command-option"
 msgid "public"
 msgstr ""
 
-#: src\commands\deck.ts:153
+#: src\commands\deck.ts:157
 msgctxt "command-option"
 msgid "stacked"
 msgstr ""
 
-#: src\commands\art.ts:31
-#: src\commands\price.ts:59
-#: src\commands\search.ts:34
+#: src\locale.ts:142
 msgctxt "command-option"
 msgid "name"
 msgstr ""
 
-#: src\commands\art.ts:41
-#: src\commands\price.ts:69
-#: src\commands\search.ts:44
+#: src\locale.ts:160
 msgctxt "command-option"
 msgid "password"
 msgstr ""
 
-#: src\commands\art.ts:53
-#: src\commands\price.ts:81
 #: src\commands\rush-duel.ts:199
-#: src\commands\search.ts:56
+#: src\locale.ts:176
 msgctxt "command-option"
 msgid "konami-id"
 msgstr ""
@@ -870,7 +884,7 @@ msgctxt "command-option"
 msgid "locale"
 msgstr ""
 
-#: src\commands\price.ts:91
+#: src\commands\price.ts:65
 msgctxt "command-option"
 msgid "vendor"
 msgstr ""
@@ -890,12 +904,12 @@ msgctxt "command-option"
 msgid "art"
 msgstr ""
 
-#: src\locale.ts:51
+#: src\locale.ts:74
 msgctxt "command-option-description"
 msgid "The output language for the card embed, overriding other settings."
 msgstr "卡片查询结果的语言，覆盖其他设置"
 
-#: src\locale.ts:71
+#: src\locale.ts:132
 msgctxt "command-option-description"
 msgid "The language to search in, defaulting to the result language."
 msgstr "查询用的语言，默认与查询结果语言相同"
@@ -910,85 +924,79 @@ msgctxt "command-option-description"
 msgid "The name of a specific Slash Command."
 msgstr ""
 
-#: src\commands\deck.ts:125
+#: src\commands\deck.ts:129
 msgctxt "command-option-description"
 msgid "View a deck by entering a ydke:// URL."
 msgstr ""
 
-#: src\commands\deck.ts:131
+#: src\commands\deck.ts:135
 msgctxt "command-option-description"
 msgid "View a deck by uploading a .ydk file."
 msgstr ""
 
-#: src\commands\deck.ts:137
+#: src\commands\deck.ts:141
 msgctxt "command-option-description"
 msgid "The ydke:// URL of the deck you want to view."
 msgstr ""
 
-#: src\commands\deck.ts:143
+#: src\commands\deck.ts:147
 msgctxt "command-option-description"
 msgid "The .ydk file of the deck you want to view."
 msgstr ""
 
-#: src\commands\deck.ts:149
+#: src\commands\deck.ts:153
 msgctxt "command-option-description"
 msgid "Whether to display the deck details publicly in chat. This is false by default."
 msgstr ""
 
-#: src\commands\deck.ts:156
+#: src\commands\deck.ts:160
 msgctxt "command-option-description"
 msgid "Whether to display the deck sections as one stacked column. This is false (side-by-side) by default."
 msgstr ""
 
-#: src\commands\art.ts:32
+#: src\commands\art.ts:41
 msgctxt "command-option-description"
 msgid "Display the art for the card with this name."
 msgstr ""
 
-#: src\commands\art.ts:37
-#: src\commands\price.ts:65
 #: src\commands\rush-duel.ts:195
-#: src\commands\search.ts:40
+#: src\locale.ts:148
 msgctxt "command-option-description"
 msgid "Card name, fuzzy matching supported."
 msgstr ""
 
-#: src\commands\art.ts:42
+#: src\commands\art.ts:44
 msgctxt "command-option-description"
 msgid "Display the art for the card with this password."
 msgstr ""
 
-#: src\commands\art.ts:48
-#: src\commands\price.ts:76
-#: src\commands\search.ts:51
+#: src\locale.ts:167
 msgctxt "command-option-description"
 msgid "Card password, the eight-digit number printed on the bottom left corner."
 msgstr ""
 
-#: src\commands\art.ts:54
+#: src\commands\art.ts:47
 msgctxt "command-option-description"
 msgid "Display the art for the card with this official database ID."
 msgstr ""
 
-#: src\commands\art.ts:59
-#: src\commands\price.ts:87
 #: src\commands\rush-duel.ts:207
-#: src\commands\search.ts:62
+#: src\locale.ts:182
 msgctxt "command-option-description"
 msgid "Konami's official card database identifier."
 msgstr ""
 
-#: src\commands\search.ts:35
+#: src\commands\search.ts:40
 msgctxt "command-option-description"
 msgid "Find all information for the card with this name."
 msgstr ""
 
-#: src\commands\search.ts:45
+#: src\commands\search.ts:43
 msgctxt "command-option-description"
 msgid "Find all information for the card with this password."
 msgstr ""
 
-#: src\commands\search.ts:57
+#: src\commands\search.ts:46
 msgctxt "command-option-description"
 msgid "Find all information for the card with this official database ID."
 msgstr ""
@@ -1013,22 +1021,22 @@ msgctxt "command-option-description"
 msgid "The new default language to use in this channel or server."
 msgstr ""
 
-#: src\commands\price.ts:60
+#: src\commands\price.ts:69
 msgctxt "command-option-description"
 msgid "Display the price for the card with this name."
 msgstr ""
 
-#: src\commands\price.ts:70
+#: src\commands\price.ts:73
 msgctxt "command-option-description"
 msgid "Display the price for the card with this password."
 msgstr ""
 
-#: src\commands\price.ts:82
+#: src\commands\price.ts:76
 msgctxt "command-option-description"
 msgid "Display the price for the card with this official database ID."
 msgstr ""
 
-#: src\commands\price.ts:92
+#: src\commands\price.ts:66
 msgctxt "command-option-description"
 msgid "The vendor to fetch the price data from."
 msgstr ""
@@ -1058,7 +1066,7 @@ msgctxt "command-option-description"
 msgid "Display just the art for the Rush Duel card with this name."
 msgstr ""
 
-#: src\commands\art.ts:26
+#: src\commands\art.ts:37
 msgctxt "command-name"
 msgid "art"
 msgstr "卡图"
@@ -1083,12 +1091,12 @@ msgctxt "command-name"
 msgid "help"
 msgstr ""
 
-#: src\commands\deck.ts:115
+#: src\commands\deck.ts:119
 msgctxt "command-name"
 msgid "deck"
 msgstr ""
 
-#: src\commands\search.ts:29
+#: src\commands\search.ts:36
 msgctxt "command-name"
 msgid "search"
 msgstr ""
@@ -1098,12 +1106,12 @@ msgctxt "command-name"
 msgid "locale"
 msgstr ""
 
-#: src\commands\random.ts:24
+#: src\commands\random.ts:30
 msgctxt "command-name"
 msgid "random"
 msgstr ""
 
-#: src\commands\price.ts:54
+#: src\commands\price.ts:60
 msgctxt "command-name"
 msgid "price"
 msgstr ""
@@ -1113,7 +1121,7 @@ msgctxt "command-name"
 msgid "rush-duel"
 msgstr ""
 
-#: src\commands\art.ts:27
+#: src\commands\art.ts:38
 msgctxt "command-description"
 msgid "Display the art for a card!"
 msgstr "显示卡片图。"
@@ -1138,12 +1146,12 @@ msgctxt "command-description"
 msgid "Get help with a Slash Command."
 msgstr ""
 
-#: src\commands\deck.ts:118
+#: src\commands\deck.ts:122
 msgctxt "command-description"
 msgid "Display a deck list from ydke:// or .ydk format, exported from a number of deck building programs."
 msgstr ""
 
-#: src\commands\search.ts:30
+#: src\commands\search.ts:37
 msgctxt "command-description"
 msgid "Find all information on a card!"
 msgstr ""
@@ -1153,12 +1161,12 @@ msgctxt "command-description"
 msgid "Check or set Bastion's locale for this channel or server."
 msgstr ""
 
-#: src\commands\random.ts:25
+#: src\commands\random.ts:31
 msgctxt "command-description"
 msgid "Get a random Yu-Gi-Oh! card."
 msgstr ""
 
-#: src\commands\price.ts:55
+#: src\commands\price.ts:61
 msgctxt "command-description"
 msgid "Display the price for a card!"
 msgstr ""

--- a/translations/zh-TW.po
+++ b/translations/zh-TW.po
@@ -6,139 +6,139 @@ msgstr ""
 "MIME-Version: 1.0\n"
 "Content-Transfer-Encoding: 8bit\n"
 
-#: src\card.ts:279
+#: src\card.ts:339
 #: src\commands\rush-duel.ts:60
 msgid "🔗 Links"
 msgstr "鏈接"
 
-#: src\card.ts:280
+#: src\card.ts:340
 #, javascript-format
 msgid "[Official Konami DB](${ official }) | [OCG Rulings](${ rulings }) | [Yugipedia](${ yugipedia }) | [YGOPRODECK](${ ygoprodeck })"
 msgstr "[K社官方數據庫](${ official }) | [事務局FAQ](${ rulings }) | [Yugipedia](${ yugipedia }) | [YGOPRODECK](${ ygoprodeck })"
 
-#: src\card.ts:283
+#: src\card.ts:343
 #, javascript-format
 msgid "[Yugipedia](${ yugipedia }) | [YGOPRODECK](${ ygoprodeck })"
 msgstr "[Yugipedia](${ yugipedia }) | [YGOPRODECK](${ ygoprodeck })"
 
-#: src\card.ts:343
+#: src\card.ts:403
 #: src\commands\rush-duel.ts:107
 #, javascript-format
 msgid "**Type**: ${ RaceIcon[race] } ${ localizedMonsterTypeLine }"
 msgstr "**種族**: ${ RaceIcon[race] } ${ localizedMonsterTypeLine }"
 
-#: src\card.ts:345
+#: src\card.ts:405
 #: src\commands\rush-duel.ts:109
 #, javascript-format
 msgid "**Attribute**: ${ AttributeIcon[card.attribute] } ${ localizedAttribute }"
 msgstr "**屬性**: ${ AttributeIcon[card.attribute] } ${ localizedAttribute }"
 
-#: src\card.ts:349
+#: src\card.ts:409
 msgid "**Rank**: ${ Icon.Rank } ${ card.rank } **ATK**: ${ card.atk } **DEF**: ${ card.def }"
 msgstr "**階級**: ${ Icon.Rank } ${ card.rank } **攻擊力**: ${ card.atk } **守備力**: ${ card.def }"
 
-#: src\card.ts:352
+#: src\card.ts:412
 #, javascript-format
 msgid "**Link Rating**: ${ card.link_arrows.length } **ATK**: ${ card.atk } **Link Arrows**: ${ arrows }"
 msgstr "**連接數值**: ${ card.link_arrows.length } **攻擊力**: ${ card.atk } **連接標記**: ${ arrows }"
 
-#: src\card.ts:354
+#: src\card.ts:414
 #: src\commands\rush-duel.ts:111
 #, javascript-format
 msgid "**Level**: ${ Icon.Level } ${ card.level } **ATK**: ${ card.atk } **DEF**: ${ card.def }"
 msgstr "**等級**: ${ Icon.Level } ${ card.level } **攻擊力**: ${ card.atk } **守備力**: ${ card.def }"
 
-#: src\card.ts:361
+#: src\card.ts:421
 msgid "**Pendulum Scale**: ${ formattedScale }"
 msgstr "**靈擺刻度**: ${ formattedScale }"
 
-#: src\card.ts:240
+#: src\card.ts:300
 #, javascript-format
 msgid "Password: ${ card.password } | Konami ID #${ card.konami_id }"
 msgstr "卡片密碼: ${ card.password } | 官方編號${ card.konami_id }"
 
-#: src\card.ts:242
+#: src\card.ts:302
 msgid "No password | Konami ID #${ card.konami_id }"
 msgstr "無卡密 | 官方編號${ card.konami_id }"
 
-#: src\card.ts:244
+#: src\card.ts:304
 #, javascript-format
 msgid "Password: ${ card.password } | Not yet released"
 msgstr "卡片密碼: ${ card.password } | 未發行"
 
-#: src\card.ts:246
+#: src\card.ts:306
 #: src\commands\rush-duel.ts:161
 msgid "Not yet released"
 msgstr "未發行"
 
-#: src\card.ts:250
+#: src\card.ts:310
 #, javascript-format
 msgid "Placeholder ID: ${ card.fake_password }"
 msgstr "假卡密: ${ card.fake_password }"
 
-#: src\utils.ts:45
+#: src\utils.ts:41
 msgid "🛠️ This command is in development."
 msgstr "🛠️ 這個指令正在開發中"
 
-#: src\utils.ts:46
+#: src\utils.ts:42
 msgid "📨 Please send feedback to [our issue tracker](https://github.com/DawnbrandBots/bastion-bot) or the [support server](https://discord.gg/4aFuPyuE96)!"
 msgstr "📨 如有意見或建議請反饋至[GitHub issue](https://github.com/DawnbrandBots/bastion-bot)或者[Discord服務器](https://discord.gg/4aFuPyuE96)!"
 
-#: src\utils.ts:57
+#: src\utils.ts:53
 msgid "Please consider supporting us!"
 msgstr "請考慮捐助我們！"
 
-#: src\utils.ts:58
+#: src\utils.ts:54
 msgid "Help keep Bastion online!"
 msgstr "幫幫Bastion吧，寶寶快餓死了"
 
-#: src\utils.ts:59
+#: src\utils.ts:55
 msgid "Please help keep Bastion online!"
 msgstr "請幫幫Bastion吧，寶寶真的快餓死了"
 
-#: src\utils.ts:60
+#: src\utils.ts:56
 msgid "Was Bastion helpful? Consider supporting us!"
 msgstr "Bastion有用麼？請考慮捐助我們！"
 
-#: src\utils.ts:61
+#: src\utils.ts:57
 msgid "Was Bastion helpful? We need your support!"
 msgstr "Bastion有用麼？我們需要你的支持！"
 
-#: src\utils.ts:62
+#: src\utils.ts:58
 msgid "Did you find Bastion useful? Consider supporting us!"
 msgstr "你覺得Bastion好用麼？請考慮捐助我們！"
 
-#: src\utils.ts:63
+#: src\utils.ts:59
 msgid "Did you find Bastion useful? Help keep it online!"
 msgstr "你覺得Bastion好用麼？那幫幫TA吧，孩子快餓死了"
 
-#: src\utils.ts:64
+#: src\utils.ts:60
 msgid "Did you find Bastion useful? We need your support!"
 msgstr "你覺得Bastion好用麼？我們需要你的支持！"
 
-#: src\utils.ts:65
+#: src\utils.ts:61
 msgid "Enjoy Bastion? Help keep it online!"
 msgstr "你覺得Bastion好用麼？那幫幫TA吧，孩子快餓死了"
 
-#: src\utils.ts:66
+#: src\utils.ts:62
 msgid "Enjoy Bastion? Consider supporting us!"
 msgstr "覺得Bastion怎麼樣？請考慮捐助我們！"
 
-#: src\utils.ts:67
+#: src\utils.ts:63
 msgid "Found what you were looking for? Consider supporting us!"
 msgstr "找到你要的東西了嗎？請考慮捐助我們！"
 
-#: src\commands\art.ts:97
-#: src\commands\price.ts:148
-#: src\commands\rush-duel.ts:309
-#: src\commands\rush-duel.ts:342
-#: src\commands\search.ts:89
-#: src\events\message-search.ts:270
+#: src\commands\art.ts:69
+#: src\commands\price.ts:121
+#: src\commands\rush-duel.ts:306
+#: src\commands\rush-duel.ts:339
+#: src\commands\search.ts:62
+#: src\events\message-search.ts:295
 #, javascript-format
 msgid "Could not find a card matching `${ input }`!"
 msgstr "查無此卡：`${ input }`"
 
-#: src\commands\art.ts:107
+#: src\commands\art.ts:83
 msgid "Could not find art for `${ name }`!"
 msgstr "沒找到`${ name }`的卡圖！"
 
@@ -217,58 +217,58 @@ msgstr "延遲${ latency }ms"
 msgid "Could not find a Yugipedia page named `${ page }`."
 msgstr "Yugipedia上找不到`${ page }`"
 
-#: src\commands\deck.ts:245
+#: src\commands\deck.ts:248
 #, javascript-format
 msgid "${ counts.Monster } Monster"
 msgid_plural "${ counts.Monster } Monsters"
 msgstr[0] "${ counts.Monster }張怪獸卡"
 
-#: src\commands\deck.ts:248
+#: src\commands\deck.ts:251
 msgid "${ counts.Spell } Spell"
 msgid_plural "${ counts.Spell } Spells"
 msgstr[0] "${ counts.Spell }張魔法卡"
 
-#: src\commands\deck.ts:251
+#: src\commands\deck.ts:254
 #, javascript-format
 msgid "${ counts.Trap } Trap"
 msgid_plural "${ counts.Trap } Traps"
 msgstr[0] "${ counts.Trap }張陷阱卡"
 
-#: src\commands\deck.ts:279
+#: src\commands\deck.ts:282
 msgid "Your Deck"
 msgstr "你的卡組"
 
-#: src\commands\deck.ts:284
+#: src\commands\deck.ts:287
 #, javascript-format
 msgid "Main Deck (${ deck.main.length } card — ${ countDetail })"
 msgid_plural "Main Deck (${ deck.main.length } cards — ${ countDetail })"
 msgstr[0] "牌組（${ deck.main.length })張 — ${ countDetail }）"
 
-#: src\commands\deck.ts:298
+#: src\commands\deck.ts:301
 #, javascript-format
 msgid "Extra Deck (${ deck.extra.length } card — ${ countDetail })"
 msgid_plural "Extra Deck (${ deck.extra.length } cards — ${ countDetail })"
 msgstr[0] "額外卡組（${ deck.extra.length }張 — ${ countDetail }）"
 
-#: src\commands\deck.ts:312
+#: src\commands\deck.ts:315
 #, javascript-format
 msgid "Side Deck (${ deck.side.length } card — ${ countDetail })"
 msgid_plural "Side Deck (${ deck.side.length } cards — ${ countDetail })"
 msgstr[0] "備牌（${ deck.side.length }張 — ${ countDetail }）"
 
-#: src\commands\deck.ts:291
+#: src\commands\deck.ts:294
 msgid "Main Deck (continued)"
 msgstr "牌組（續）"
 
-#: src\commands\deck.ts:305
+#: src\commands\deck.ts:308
 msgid "Extra Deck (continued)"
 msgstr "額外卡組（續）"
 
-#: src\commands\deck.ts:319
+#: src\commands\deck.ts:322
 msgid "Side Deck (continued)"
 msgstr "備牌（續）"
 
-#: src\commands\deck.ts:409
+#: src\commands\deck.ts:411
 msgid "Error: Your deck is empty."
 msgstr "錯誤：卡組是空的。"
 
@@ -287,79 +287,79 @@ msgstr "自由開源遊戲王聊天機器人"
 msgid "Revision: ${ process.env.BOT_REVISION }."
 msgstr "修訂：${ process.env.BOT_REVISION }"
 
-#: src\commands\deck.ts:329
+#: src\commands\deck.ts:332
 msgid ".ydk files must have the .ydk extension!"
 msgstr ""
 
-#: src\commands\deck.ts:332
+#: src\commands\deck.ts:335
 msgid ".ydk files should not be larger than 1 KB!"
 msgstr ""
 
-#: src\commands\deck.ts:322
+#: src\commands\deck.ts:325
 msgid "ydke URL"
 msgstr ""
 
-#: src\card.ts:317
+#: src\card.ts:377
 #. Forbidden/Limited Lists or Limit Regulations in the OCG
 msgid "**Limit**: ${ limitRegulationDisplay }"
 msgstr "**限制**：${ limitRegulationDisplay }"
 
-#: src\commands\price.ts:38
+#: src\commands\price.ts:40
 msgid "TCGPlayer"
 msgstr ""
 
-#: src\commands\price.ts:39
+#: src\commands\price.ts:41
 msgid "Cardmarket"
 msgstr ""
 
-#: src\commands\price.ts:40
+#: src\commands\price.ts:42
 msgid "CoolStuffInc"
 msgstr ""
 
-#: src\commands\price.ts:118
+#: src\commands\price.ts:96
 #. TODO: future, determine localisation and relevance status of this error
 msgid "Sorry, I can't find the price for a card with no English name!"
 msgstr ""
 
-#: src\commands\price.ts:162
+#: src\commands\price.ts:140
 msgid "No market price"
 msgstr ""
 
-#: src\commands\price.ts:170
+#: src\commands\price.ts:148
 #, javascript-format
 msgid "Prices for ${ card.name[resultLanguage] } - ${ vendorName }"
 msgstr ""
 
-#: src\commands\price.ts:184
+#: src\commands\price.ts:162
 msgid "Could not find prices for `${ name }`!"
 msgstr ""
 
-#: src\commands\deck.ts:427
+#: src\commands\deck.ts:429
 #. prepare interaction button for FTP upload
 msgid "Upload to YGOPRODECK"
 msgstr "上傳至YGOPRODECK"
 
-#: src\commands\deck.ts:485
+#: src\commands\deck.ts:487
 #. disable original button
 #. prepare row to disable button on original message
 msgid "Upload Complete"
 msgstr "上傳成功"
 
-#: src\commands\deck.ts:472
+#: src\commands\deck.ts:474
 msgid "Deck upload failed!"
 msgstr "上傳失敗"
 
-#: src\commands\deck.ts:493
+#: src\commands\deck.ts:495
 #. reply in affirmation
 #, javascript-format
 msgid "Deck successfully uploaded to <${ url }>!"
 msgstr "卡組成功上傳到<${ url }>!"
 
-#: src\events\message-search.ts:275
+#: src\events\message-search.ts:300
 msgid "💬 Translations missing?"
 msgstr "💬缺少翻譯？"
 
-#: src\events\message-search.ts:276
+#: src\events\message-search.ts:301
 msgid "Help translate Bastion at the links above."
 msgstr "在以上的網址幫忙翻譯Bastion"
 
@@ -379,11 +379,11 @@ msgid ""
 "💬 Translations missing? Help translate Bastion on [GitHub](https://github.com/DawnbrandBots/bastion-bot)."
 msgstr ""
 
-#: src\events\message-search.ts:268
+#: src\events\message-search.ts:293
 msgid "Search type: ${ localisedType }"
 msgstr "搜索類型：${ localisedType }"
 
-#: src\events\message-search.ts:265
+#: src\events\message-search.ts:290
 #, javascript-format
 msgid "Search language: **${ localisedInputLanguage }** (${ inputLanguage }). Check defaults with </locale get:${ id }> and configure with </locale set:${ id }>"
 msgstr ""
@@ -393,11 +393,11 @@ msgid "⚠️ You pinged me, but I am missing permissions in the channel!"
 msgstr ""
 
 #: src\events\message-ping.ts:94
-#: src\events\message-search.ts:182
+#: src\events\message-search.ts:192
 msgid "Please have a server administrator [fix this](https://github.com/DawnbrandBots/bastion-bot#discord-permissions)."
 msgstr ""
 
-#: src\events\message-search.ts:179
+#: src\events\message-search.ts:189
 msgid "⚠️ I am missing permissions in the channel!"
 msgstr ""
 
@@ -438,12 +438,12 @@ msgstr ""
 msgid "Konami ID #${ card.konami_id }"
 msgstr "官方編號${ card.konami_id }"
 
-#: src\commands\deck.ts:453
-#: src\commands\rush-duel.ts:489
+#: src\commands\deck.ts:455
+#: src\commands\rush-duel.ts:486
 msgid "Buttons can only be used by the user who called Bastion."
 msgstr ""
 
-#: src\commands\rush-duel.ts:401
+#: src\commands\rush-duel.ts:398
 #, javascript-format
 msgid "Could not find art for `${ input }`!"
 msgstr ""
@@ -518,127 +518,127 @@ msgctxt "monster-type-race"
 msgid "Gemini"
 msgstr "雙重"
 
-#: src\card.ts:66
+#: src\card.ts:72
 msgctxt "monster-type-race"
 msgid "Warrior"
 msgstr "戰士族"
 
-#: src\card.ts:67
+#: src\card.ts:73
 msgctxt "monster-type-race"
 msgid "Spellcaster"
 msgstr "魔法師族"
 
-#: src\card.ts:68
+#: src\card.ts:74
 msgctxt "monster-type-race"
 msgid "Fairy"
 msgstr "天使族"
 
-#: src\card.ts:69
+#: src\card.ts:75
 msgctxt "monster-type-race"
 msgid "Fiend"
 msgstr "惡魔族"
 
-#: src\card.ts:70
+#: src\card.ts:76
 msgctxt "monster-type-race"
 msgid "Zombie"
 msgstr "不死族"
 
-#: src\card.ts:71
+#: src\card.ts:77
 msgctxt "monster-type-race"
 msgid "Machine"
 msgstr "機械族"
 
-#: src\card.ts:72
+#: src\card.ts:78
 msgctxt "monster-type-race"
 msgid "Aqua"
 msgstr "水族"
 
-#: src\card.ts:73
+#: src\card.ts:79
 msgctxt "monster-type-race"
 msgid "Pyro"
 msgstr "炎族"
 
-#: src\card.ts:74
+#: src\card.ts:80
 msgctxt "monster-type-race"
 msgid "Rock"
 msgstr "岩石族"
 
-#: src\card.ts:75
+#: src\card.ts:81
 msgctxt "monster-type-race"
 msgid "Winged Beast"
 msgstr "鳥獸族"
 
-#: src\card.ts:76
+#: src\card.ts:82
 msgctxt "monster-type-race"
 msgid "Plant"
 msgstr "植物族"
 
-#: src\card.ts:77
+#: src\card.ts:83
 msgctxt "monster-type-race"
 msgid "Insect"
 msgstr "昆虫族"
 
-#: src\card.ts:78
+#: src\card.ts:84
 msgctxt "monster-type-race"
 msgid "Thunder"
 msgstr "雷族"
 
-#: src\card.ts:79
+#: src\card.ts:85
 msgctxt "monster-type-race"
 msgid "Dragon"
 msgstr "龍族"
 
-#: src\card.ts:80
+#: src\card.ts:86
 msgctxt "monster-type-race"
 msgid "Beast"
 msgstr "獸族"
 
-#: src\card.ts:81
+#: src\card.ts:87
 msgctxt "monster-type-race"
 msgid "Beast-Warrior"
 msgstr "獸戰士族"
 
-#: src\card.ts:82
+#: src\card.ts:88
 msgctxt "monster-type-race"
 msgid "Dinosaur"
 msgstr "恐龍族"
 
-#: src\card.ts:83
+#: src\card.ts:89
 msgctxt "monster-type-race"
 msgid "Fish"
 msgstr "魚族"
 
-#: src\card.ts:84
+#: src\card.ts:90
 msgctxt "monster-type-race"
 msgid "Sea Serpent"
 msgstr "海龍族"
 
-#: src\card.ts:85
+#: src\card.ts:91
 msgctxt "monster-type-race"
 msgid "Reptile"
 msgstr "爬虫族"
 
-#: src\card.ts:86
+#: src\card.ts:92
 msgctxt "monster-type-race"
 msgid "Psychic"
 msgstr "念動力族"
 
-#: src\card.ts:87
+#: src\card.ts:93
 msgctxt "monster-type-race"
 msgid "Divine-Beast"
 msgstr "幻神獸族"
 
-#: src\card.ts:88
+#: src\card.ts:94
 msgctxt "monster-type-race"
 msgid "Creator God"
 msgstr "創造神族"
 
-#: src\card.ts:89
+#: src\card.ts:95
 msgctxt "monster-type-race"
 msgid "Wyrm"
 msgstr "幻龍族"
 
-#: src\card.ts:90
+#: src\card.ts:96
 msgctxt "monster-type-race"
 msgid "Cyberse"
 msgstr "電子界族"
@@ -688,54 +688,80 @@ msgctxt "spell-trap-property"
 msgid "Counter Trap"
 msgstr "反擊陷阱"
 
-#: src\card.ts:96
+#: src\card.ts:62
+#. SpeedLimitRegulation is not converted to a number for display
+msgctxt "limit-regulation"
+msgid "Forbidden"
+msgstr ""
+
+#: src\card.ts:63
+msgctxt "limit-regulation"
+msgid "Limited 1"
+msgstr ""
+
+#: src\card.ts:64
+msgctxt "limit-regulation"
+msgid "Limited 2"
+msgstr ""
+
+#: src\card.ts:65
+msgctxt "limit-regulation"
+msgid "Limited 3"
+msgstr ""
+
+#: src\card.ts:66
+msgctxt "limit-regulation"
+msgid "Unlimited"
+msgstr ""
+
+#: src\card.ts:102
 msgctxt "attribute"
 msgid "EARTH"
 msgstr "地"
 
-#: src\card.ts:97
+#: src\card.ts:103
 msgctxt "attribute"
 msgid "WATER"
 msgstr "水"
 
-#: src\card.ts:98
+#: src\card.ts:104
 msgctxt "attribute"
 msgid "FIRE"
 msgstr "炎"
 
-#: src\card.ts:99
+#: src\card.ts:105
 msgctxt "attribute"
 msgid "WIND"
 msgstr "風"
 
-#: src\card.ts:100
+#: src\card.ts:106
 msgctxt "attribute"
 msgid "LIGHT"
 msgstr "光"
 
-#: src\card.ts:101
+#: src\card.ts:107
 msgctxt "attribute"
 msgid "DARK"
 msgstr "暗"
 
-#: src\card.ts:102
+#: src\card.ts:108
 msgctxt "attribute"
 msgid "DIVINE"
 msgstr "神"
 
-#: src\card.ts:367
-#: src\card.ts:378
+#: src\card.ts:427
+#: src\card.ts:438
 #: src\commands\rush-duel.ts:142
 msgctxt "card-embed"
 msgid "Card Text"
 msgstr "卡片文本"
 
-#: src\card.ts:372
+#: src\card.ts:432
 msgctxt "card-embed"
 msgid "Pendulum Effect"
 msgstr "靈擺效果"
 
-#: src\card.ts:393
+#: src\card.ts:453
 msgctxt "card-embed"
 msgid "Card Effect"
 msgstr "卡片效果"
@@ -762,27 +788,21 @@ msgctxt "card-embed"
 msgid "[MULTI-CHOICE EFFECT]"
 msgstr "【選擇效果】"
 
-#: src\locale.ts:48
+#: src\locale.ts:71
 msgctxt "command-option"
 msgid "result-language"
 msgstr "查詢結果語言"
 
-#: src\locale.ts:68
+#: src\locale.ts:131
 msgctxt "command-option"
 msgid "input-language"
 msgstr "輸入語言"
 
-#: src\commands\art.ts:36
-#: src\commands\art.ts:46
-#: src\commands\art.ts:58
-#: src\commands\price.ts:64
-#: src\commands\price.ts:74
-#: src\commands\price.ts:86
 #: src\commands\rush-duel.ts:194
 #: src\commands\rush-duel.ts:206
-#: src\commands\search.ts:39
-#: src\commands\search.ts:49
-#: src\commands\search.ts:61
+#: src\locale.ts:147
+#: src\locale.ts:165
+#: src\locale.ts:181
 msgctxt "command-option"
 msgid "input"
 msgstr "輸入"
@@ -802,50 +822,44 @@ msgctxt "command-option"
 msgid "command"
 msgstr ""
 
-#: src\commands\deck.ts:122
+#: src\commands\deck.ts:126
 msgctxt "command-option"
 msgid "url"
 msgstr ""
 
-#: src\commands\deck.ts:128
+#: src\commands\deck.ts:132
 msgctxt "command-option"
 msgid "file"
 msgstr ""
 
-#: src\commands\deck.ts:134
-#: src\commands\deck.ts:140
+#: src\commands\deck.ts:138
+#: src\commands\deck.ts:144
 msgctxt "command-option"
 msgid "deck"
 msgstr ""
 
-#: src\commands\deck.ts:146
+#: src\commands\deck.ts:150
 msgctxt "command-option"
 msgid "public"
 msgstr ""
 
-#: src\commands\deck.ts:153
+#: src\commands\deck.ts:157
 msgctxt "command-option"
 msgid "stacked"
 msgstr ""
 
-#: src\commands\art.ts:31
-#: src\commands\price.ts:59
-#: src\commands\search.ts:34
+#: src\locale.ts:142
 msgctxt "command-option"
 msgid "name"
 msgstr ""
 
-#: src\commands\art.ts:41
-#: src\commands\price.ts:69
-#: src\commands\search.ts:44
+#: src\locale.ts:160
 msgctxt "command-option"
 msgid "password"
 msgstr ""
 
-#: src\commands\art.ts:53
-#: src\commands\price.ts:81
 #: src\commands\rush-duel.ts:199
-#: src\commands\search.ts:56
+#: src\locale.ts:176
 msgctxt "command-option"
 msgid "konami-id"
 msgstr ""
@@ -870,7 +884,7 @@ msgctxt "command-option"
 msgid "locale"
 msgstr ""
 
-#: src\commands\price.ts:91
+#: src\commands\price.ts:65
 msgctxt "command-option"
 msgid "vendor"
 msgstr ""
@@ -890,12 +904,12 @@ msgctxt "command-option"
 msgid "art"
 msgstr ""
 
-#: src\locale.ts:51
+#: src\locale.ts:74
 msgctxt "command-option-description"
 msgid "The output language for the card embed, overriding other settings."
 msgstr "卡片查詢結果的語言，覆蓋其他設置"
 
-#: src\locale.ts:71
+#: src\locale.ts:132
 msgctxt "command-option-description"
 msgid "The language to search in, defaulting to the result language."
 msgstr "查詢用的語言，默認與查詢結果語言相同"
@@ -910,85 +924,79 @@ msgctxt "command-option-description"
 msgid "The name of a specific Slash Command."
 msgstr ""
 
-#: src\commands\deck.ts:125
+#: src\commands\deck.ts:129
 msgctxt "command-option-description"
 msgid "View a deck by entering a ydke:// URL."
 msgstr ""
 
-#: src\commands\deck.ts:131
+#: src\commands\deck.ts:135
 msgctxt "command-option-description"
 msgid "View a deck by uploading a .ydk file."
 msgstr ""
 
-#: src\commands\deck.ts:137
+#: src\commands\deck.ts:141
 msgctxt "command-option-description"
 msgid "The ydke:// URL of the deck you want to view."
 msgstr ""
 
-#: src\commands\deck.ts:143
+#: src\commands\deck.ts:147
 msgctxt "command-option-description"
 msgid "The .ydk file of the deck you want to view."
 msgstr ""
 
-#: src\commands\deck.ts:149
+#: src\commands\deck.ts:153
 msgctxt "command-option-description"
 msgid "Whether to display the deck details publicly in chat. This is false by default."
 msgstr ""
 
-#: src\commands\deck.ts:156
+#: src\commands\deck.ts:160
 msgctxt "command-option-description"
 msgid "Whether to display the deck sections as one stacked column. This is false (side-by-side) by default."
 msgstr ""
 
-#: src\commands\art.ts:32
+#: src\commands\art.ts:41
 msgctxt "command-option-description"
 msgid "Display the art for the card with this name."
 msgstr ""
 
-#: src\commands\art.ts:37
-#: src\commands\price.ts:65
 #: src\commands\rush-duel.ts:195
-#: src\commands\search.ts:40
+#: src\locale.ts:148
 msgctxt "command-option-description"
 msgid "Card name, fuzzy matching supported."
 msgstr ""
 
-#: src\commands\art.ts:42
+#: src\commands\art.ts:44
 msgctxt "command-option-description"
 msgid "Display the art for the card with this password."
 msgstr ""
 
-#: src\commands\art.ts:48
-#: src\commands\price.ts:76
-#: src\commands\search.ts:51
+#: src\locale.ts:167
 msgctxt "command-option-description"
 msgid "Card password, the eight-digit number printed on the bottom left corner."
 msgstr ""
 
-#: src\commands\art.ts:54
+#: src\commands\art.ts:47
 msgctxt "command-option-description"
 msgid "Display the art for the card with this official database ID."
 msgstr ""
 
-#: src\commands\art.ts:59
-#: src\commands\price.ts:87
 #: src\commands\rush-duel.ts:207
-#: src\commands\search.ts:62
+#: src\locale.ts:182
 msgctxt "command-option-description"
 msgid "Konami's official card database identifier."
 msgstr ""
 
-#: src\commands\search.ts:35
+#: src\commands\search.ts:40
 msgctxt "command-option-description"
 msgid "Find all information for the card with this name."
 msgstr ""
 
-#: src\commands\search.ts:45
+#: src\commands\search.ts:43
 msgctxt "command-option-description"
 msgid "Find all information for the card with this password."
 msgstr ""
 
-#: src\commands\search.ts:57
+#: src\commands\search.ts:46
 msgctxt "command-option-description"
 msgid "Find all information for the card with this official database ID."
 msgstr ""
@@ -1013,22 +1021,22 @@ msgctxt "command-option-description"
 msgid "The new default language to use in this channel or server."
 msgstr ""
 
-#: src\commands\price.ts:60
+#: src\commands\price.ts:69
 msgctxt "command-option-description"
 msgid "Display the price for the card with this name."
 msgstr ""
 
-#: src\commands\price.ts:70
+#: src\commands\price.ts:73
 msgctxt "command-option-description"
 msgid "Display the price for the card with this password."
 msgstr ""
 
-#: src\commands\price.ts:82
+#: src\commands\price.ts:76
 msgctxt "command-option-description"
 msgid "Display the price for the card with this official database ID."
 msgstr ""
 
-#: src\commands\price.ts:92
+#: src\commands\price.ts:66
 msgctxt "command-option-description"
 msgid "The vendor to fetch the price data from."
 msgstr ""
@@ -1058,7 +1066,7 @@ msgctxt "command-option-description"
 msgid "Display just the art for the Rush Duel card with this name."
 msgstr ""
 
-#: src\commands\art.ts:26
+#: src\commands\art.ts:37
 msgctxt "command-name"
 msgid "art"
 msgstr "卡圖"
@@ -1083,12 +1091,12 @@ msgctxt "command-name"
 msgid "help"
 msgstr ""
 
-#: src\commands\deck.ts:115
+#: src\commands\deck.ts:119
 msgctxt "command-name"
 msgid "deck"
 msgstr ""
 
-#: src\commands\search.ts:29
+#: src\commands\search.ts:36
 msgctxt "command-name"
 msgid "search"
 msgstr ""
@@ -1098,12 +1106,12 @@ msgctxt "command-name"
 msgid "locale"
 msgstr ""
 
-#: src\commands\random.ts:24
+#: src\commands\random.ts:30
 msgctxt "command-name"
 msgid "random"
 msgstr ""
 
-#: src\commands\price.ts:54
+#: src\commands\price.ts:60
 msgctxt "command-name"
 msgid "price"
 msgstr ""
@@ -1113,7 +1121,7 @@ msgctxt "command-name"
 msgid "rush-duel"
 msgstr ""
 
-#: src\commands\art.ts:27
+#: src\commands\art.ts:38
 msgctxt "command-description"
 msgid "Display the art for a card!"
 msgstr "顯示卡片圖。"
@@ -1138,12 +1146,12 @@ msgctxt "command-description"
 msgid "Get help with a Slash Command."
 msgstr ""
 
-#: src\commands\deck.ts:118
+#: src\commands\deck.ts:122
 msgctxt "command-description"
 msgid "Display a deck list from ydke:// or .ydk format, exported from a number of deck building programs."
 msgstr ""
 
-#: src\commands\search.ts:30
+#: src\commands\search.ts:37
 msgctxt "command-description"
 msgid "Find all information on a card!"
 msgstr ""
@@ -1153,12 +1161,12 @@ msgctxt "command-description"
 msgid "Check or set Bastion's locale for this channel or server."
 msgstr ""
 
-#: src\commands\random.ts:25
+#: src\commands\random.ts:31
 msgctxt "command-description"
 msgid "Get a random Yu-Gi-Oh! card."
 msgstr ""
 
-#: src\commands\price.ts:55
+#: src\commands\price.ts:61
 msgctxt "command-description"
 msgid "Display the price for a card!"
 msgstr ""


### PR DESCRIPTION
Three days ago, Yugipedia updated Speed Duel cards to display the correct limit regulation for the format, i.e. `Limited 1`, `Limited 2`, `Limited 3`. DawnbrandBots/yaml-yugi@e2eb79bc0e17364cf96852c8c2a64d63cdbad863

This caused the strong typing of our API type definitions to break, and the API started returning 500 for cards on the Speed Duel Limited List. Popular examples include:
- Allure of Darkness: <https://github.com/DawnbrandBots/yaml-yugi/blob/a76469b8d343eca3d5428623fbaf3ff80148ec4f/data/cards/01475311.yaml#L4>
- Book of Moon: <https://github.com/DawnbrandBots/yaml-yugi/blob/a76469b8d343eca3d5428623fbaf3ff80148ec4f/data/cards/14087893.yaml#L4>
- Cosmic Cyclone: <https://github.com/DawnbrandBots/yaml-yugi/blob/a76469b8d343eca3d5428623fbaf3ff80148ec4f/data/cards/08267140.yaml#L4>
- Cyber Angel Benten: <https://github.com/DawnbrandBots/yaml-yugi/blob/a76469b8d343eca3d5428623fbaf3ff80148ec4f/data/cards/77235086.yaml#L4>
- Cyber Dragon: <https://github.com/DawnbrandBots/yaml-yugi/blob/a76469b8d343eca3d5428623fbaf3ff80148ec4f/data/cards/70095154.yaml#L4>
- Jinzo: <https://github.com/DawnbrandBots/yaml-yugi/blob/a76469b8d343eca3d5428623fbaf3ff80148ec4f/data/cards/77585513.yaml#L5>
- Union Hangar: <https://github.com/DawnbrandBots/yaml-yugi/blob/a76469b8d343eca3d5428623fbaf3ff80148ec4f/data/cards/66399653.yaml#L4>
- Wall of Disruption: <https://github.com/DawnbrandBots/yaml-yugi/blob/a76469b8d343eca3d5428623fbaf3ff80148ec4f/data/cards/58169731.yaml#L4>

Speed Duel Limited Lists have been a thing for some time now:
- https://yugiohblog.konami.com/2023/04/april-2023-speed-duel-events-only-limited-list/
- https://yugiohblog.konami.com/2023/01/january-speed-duel-events-only-limited-list/
- https://yugiohblog.konami.com/2022/08/ycs-niagara-falls-speed-duel-public-events-limited-list/

Bastion will now display these limit regulations as-is, since there is no good way to convert to numbers and have `Limited 3` and `Unlimited` co-exist. Translations also work for these, but I only added ones for [Forbidden](https://yugipedia.com/wiki/Forbidden) from Yugipedia and was unable to confirm translations for the other labels.

This change would need to be ported to the [Reddit bot](https://github.com/DawnbrandBots/bastion-for-reddit), but the code will be simpler due to only supporting English.