### PR TITLE
/query: create development/preview-only prototype

### DIFF
--- a/src/commands/index.ts
+++ b/src/commands/index.ts
@@ -8,6 +8,7 @@ import { LinkCommand } from "./link";
 import { LocaleCommand } from "./locale";
 import { PingCommand } from "./ping";
 import { PriceCommand } from "./price";
+import { QueryCommand } from "./query";
 import { RandomCommand } from "./random";
 import { RushDuelCommand } from "./rush-duel";
 import { SearchCommand } from "./search";
@@ -27,22 +28,24 @@ export const classes = [
 	RandomCommand,
 	HelpCommand,
 	PriceCommand,
-	RushDuelCommand
+	RushDuelCommand,
+	QueryCommand
 ];
 export {
+	ArtCommand,
 	DeckCommand,
-	PingCommand,
-	LinkCommand,
-	YugiCommand,
+	HelpCommand,
 	IdCommand,
+	LinkCommand,
+	LocaleCommand,
+	PingCommand,
+	PriceCommand,
+	QueryCommand,
+	RandomCommand,
+	RushDuelCommand,
 	SearchCommand,
 	YGOPRODECKCommand,
-	LocaleCommand,
-	ArtCommand,
-	RandomCommand,
-	HelpCommand,
-	PriceCommand,
-	RushDuelCommand
+	YugiCommand
 };
 
 // Register Slash Commands on CI

--- a/src/commands/index.ts
+++ b/src/commands/index.ts
@@ -15,7 +15,7 @@ import { SearchCommand } from "./search";
 import { YGOPRODECKCommand } from "./ygoprodeck";
 import { YugiCommand } from "./yugipedia";
 
-export const classes = [
+const productionCommandClasses = [
 	DeckCommand,
 	PingCommand,
 	LinkCommand,
@@ -28,9 +28,15 @@ export const classes = [
 	RandomCommand,
 	HelpCommand,
 	PriceCommand,
-	RushDuelCommand,
-	QueryCommand
+	RushDuelCommand
 ];
+const previewCommandClasses = [QueryCommand];
+
+export const classes = [
+	...productionCommandClasses,
+	...(process.env.BOT_NO_DIRECT_MESSAGE_SEARCH ? previewCommandClasses : [])
+];
+
 export {
 	ArtCommand,
 	DeckCommand,

--- a/src/commands/query.ts
+++ b/src/commands/query.ts
@@ -1,0 +1,63 @@
+import { SlashCommandBuilder } from "@discordjs/builders";
+import { Static } from "@sinclair/typebox";
+import { RESTPostAPIApplicationCommandsJSONBody } from "discord-api-types/v10";
+import { ChatInputCommandInteraction, SlashCommandStringOption } from "discord.js";
+import { Got } from "got";
+import { inject, injectable } from "tsyringe";
+import { c } from "ttag";
+import { Command } from "../Command";
+import { CardSchema } from "../definitions";
+import { LocaleProvider, buildLocalisedCommand } from "../locale";
+import { Logger, getLogger } from "../logger";
+import { Metrics } from "../metrics";
+
+@injectable()
+export class QueryCommand extends Command {
+	#logger = getLogger("command:query");
+
+	constructor(
+		metrics: Metrics,
+		@inject("LocaleProvider") private locales: LocaleProvider,
+		@inject("got") private got: Got
+	) {
+		super(metrics);
+		this.got = got.extend({
+			throwHttpErrors: true,
+			timeout: 10000
+		});
+	}
+
+	static override get meta(): RESTPostAPIApplicationCommandsJSONBody {
+		return buildLocalisedCommand(
+			new SlashCommandBuilder(),
+			() => c("command-name").t`query`,
+			() => c("command-description").t`Advanced search prototype`
+		)
+			.addStringOption(
+				buildLocalisedCommand(
+					new SlashCommandStringOption().setRequired(true),
+					() => c("command-option").t`lucene`,
+					() => c("command-option-description").t`Lucene query on YAML Yugi`
+				)
+			)
+			.toJSON();
+	}
+
+	protected override get logger(): Logger {
+		return this.#logger;
+	}
+
+	protected override async execute(interaction: ChatInputCommandInteraction): Promise<number> {
+		const query = interaction.options.getString("lucene", true);
+		await interaction.deferReply();
+		const response = await this.got(`${process.env.API_URL}/ocg-tcg/query?q=${encodeURIComponent(query)}`);
+		const cards: Static<typeof CardSchema>[] = JSON.parse(response.body);
+		let content = `Total: ${cards.length}\n`;
+		content += cards
+			.slice(0, 10)
+			.map(card => `1. ${card.name.en}`)
+			.join("\n");
+		await interaction.editReply({ content });
+		return -2;
+	}
+}


### PR DESCRIPTION
This is intended to succeed old Bastion [`.match` and `.search`](https://github.com/AlphaKretin/bastion-bot/wiki/Commands-for-users#finding-cards). [Lucene queries](https://www.elastic.co/guide/en/elasticsearch/reference/7.10/query-dsl-query-string-query.html#query-string-syntax) are more powerful than the ygo-data filter system and require no additional implementation effort.

[Simple query strings](https://www.elastic.co/guide/en/elasticsearch/reference/7.10/query-dsl-simple-query-string-query.html) are also possible for most search cases but are not implemented here as they cannot search on arbitrary fields. In context, only about 3% of `.match` and `.search` invocations applied additional filters on card properties rather than just searching text.