### PR TITLE
/art, /rush-duel art: reduce calls to Yugipedia

### DIFF
--- a/src/art.ts
+++ b/src/art.ts
@@ -14,6 +14,7 @@ import {
 } from "discord.js";
 import { Got } from "got";
 import { t, useLocale } from "ttag";
+import { yugipediaFileRedirect } from "./card";
 import { CardSchema } from "./definitions";
 import { RushCardSchema } from "./definitions/rush";
 import { Locale } from "./locale";
@@ -64,7 +65,6 @@ export class ArtSwitcher {
 
 	constructor(
 		private readonly images: NonNullable<Static<typeof RushCardSchema | typeof CardSchema>["images"]>,
-		private readonly videoGameIllustration: string | null,
 		context: string
 	) {
 		this.labelButton.setLabel(this.label);
@@ -79,12 +79,10 @@ export class ArtSwitcher {
 	private get currentImage(): string {
 		const illustration = this.images[this.index].illustration;
 		if (illustration) {
-			return `https://yugipedia.com/wiki/Special:Redirect/file/${illustration}?utm_source=bastion`;
-		} else if (this.index === 0 && this.videoGameIllustration) {
-			return this.videoGameIllustration;
+			return yugipediaFileRedirect(illustration);
 		} else {
 			const image = this.images[this.index].image;
-			return `https://yugipedia.com/wiki/Special:Redirect/file/${image}?utm_source=bastion`;
+			return yugipediaFileRedirect(image);
 		}
 	}
 

--- a/src/card.ts
+++ b/src/card.ts
@@ -363,6 +363,10 @@ export function ygoprodeckCard(term: string | number): string {
 	return `https://ygoprodeck.com/card/?search=${encodeURIComponent(term)}&utm_source=bastion`;
 }
 
+/**
+ * @param name URL-encoded file name
+ * @returns Bastion-attributed MediaWiki redirect useful for embedding images
+ */
 export function yugipediaFileRedirect(name: string): string {
 	return `https://yugipedia.com/wiki/Special:Redirect/file/${name}?utm_source=bastion`;
 }

--- a/src/card.ts
+++ b/src/card.ts
@@ -363,10 +363,18 @@ export function ygoprodeckCard(term: string | number): string {
 	return `https://ygoprodeck.com/card/?search=${encodeURIComponent(term)}&utm_source=bastion`;
 }
 
-export function masterDuelIllustrationURL(card: Static<typeof CardSchema>): string {
+export function yugipediaFileRedirect(name: string): string {
+	return `https://yugipedia.com/wiki/Special:Redirect/file/${name}?utm_source=bastion`;
+}
+
+export function masterDuelIllustration(card: Static<typeof CardSchema>): string {
 	// Filter card name down to alphanumeric characters
 	const probableBasename = (card.name.en ?? "").replaceAll(/\W/g, "");
-	return `https://yugipedia.com/wiki/Special:Redirect/file/${probableBasename}-MADU-EN-VG-artwork.png?utm_source=bastion`;
+	return `${probableBasename}-MADU-EN-VG-artwork.png`;
+}
+
+export function masterDuelIllustrationURL(card: Static<typeof CardSchema>): string {
+	return yugipediaFileRedirect(masterDuelIllustration(card));
 }
 
 export function createCardEmbed(

--- a/src/commands/rush-duel.ts
+++ b/src/commands/rush-duel.ts
@@ -401,12 +401,13 @@ export class RushDuelCommand extends AutocompletableCommand {
 		}
 		await interaction.deferReply();
 		if (!card.images[0].illustration) {
-			const url = videoGameIllustration(card);
-			const hasVideoGameIllustration = await checkYugipediaRedirect(this.got, url, (...args) =>
-				this.#logger.warn(serialiseInteraction(interaction), ...args)
+			const hasVideoGameIllustration = await checkYugipediaRedirect(
+				this.got,
+				videoGameIllustrationURL(card),
+				(...args) => this.#logger.warn(serialiseInteraction(interaction), ...args)
 			);
 			if (hasVideoGameIllustration) {
-				card.images[0].illustration = url;
+				card.images[0].illustration = videoGameIllustration(card);
 			}
 		}
 		const switcher = new ArtSwitcher(card.images, "rush");

--- a/src/commands/rush-duel.ts
+++ b/src/commands/rush-duel.ts
@@ -15,7 +15,16 @@ import { inject, injectable } from "tsyringe";
 import { c, t, useLocale } from "ttag";
 import { AutocompletableCommand } from "../Command";
 import { ArtSwitcher, checkYugipediaRedirect } from "../art";
-import { AttributeIcon, Colour, Icon, RaceIcon, formatCardName, formatCardText, getRubylessCardName } from "../card";
+import {
+	AttributeIcon,
+	Colour,
+	Icon,
+	RaceIcon,
+	formatCardName,
+	formatCardText,
+	getRubylessCardName,
+	yugipediaFileRedirect
+} from "../card";
 import { RushCardSchema } from "../definitions/rush";
 import { UpdatingLimitRegulationVector } from "../limit-regulation";
 import {
@@ -31,11 +40,15 @@ import { addNotice, replyLatency, serialiseInteraction } from "../utils";
 
 const rc = c;
 
-function videoGameIllustrationURL(card: Static<typeof RushCardSchema>): string {
+function videoGameIllustration(card: Static<typeof RushCardSchema>): string {
 	// Filter card name down to alphanumeric characters
 	const probableBasename = (card.name.en ?? "").replaceAll(/\W/g, "");
 	// https://yugipedia.com/wiki/Category:Yu-Gi-Oh!_RUSH_DUEL:_Saikyo_Battle_Royale!!_Let%27s_Go!_Go_Rush!!_card_artworks
-	return `https://yugipedia.com/wiki/Special:Redirect/file/${probableBasename}-G002-JP-VG-artwork.png?utm_source=bastion`;
+	return `${probableBasename}-G002-JP-VG-artwork.png`;
+}
+
+function videoGameIllustrationURL(card: Static<typeof RushCardSchema>): string {
+	return yugipediaFileRedirect(videoGameIllustration(card));
 }
 
 function createRushCardEmbed(
@@ -387,11 +400,16 @@ export class RushDuelCommand extends AutocompletableCommand {
 			return replyLatency(reply, interaction);
 		}
 		await interaction.deferReply();
-		const url = videoGameIllustrationURL(card);
-		const hasVideoGameIllustration = await checkYugipediaRedirect(this.got, url, (...args) =>
-			this.#logger.warn(serialiseInteraction(interaction), ...args)
-		);
-		const switcher = new ArtSwitcher(card.images, hasVideoGameIllustration ? url : null, "rush");
+		if (!card.images[0].illustration) {
+			const url = videoGameIllustration(card);
+			const hasVideoGameIllustration = await checkYugipediaRedirect(this.got, url, (...args) =>
+				this.#logger.warn(serialiseInteraction(interaction), ...args)
+			);
+			if (hasVideoGameIllustration) {
+				card.images[0].illustration = url;
+			}
+		}
+		const switcher = new ArtSwitcher(card.images, "rush");
 		const end = Date.now();
 		await switcher.editReply(interaction, resultLanguage);
 		// When using deferReply, editedTimestamp is null, as if the reply was never edited, so provide a best estimate

--- a/test/unit/__snapshots__/art.spec.ts.snap
+++ b/test/unit/__snapshots__/art.spec.ts.snap
@@ -1,0 +1,130 @@
+// Jest Snapshot v1, https://goo.gl/fbAQLP
+
+exports[`ArtSwitcher shows first of two illustrations 1`] = `
+{
+  "components": [
+    {
+      "components": [
+        {
+          "custom_id": "label",
+          "disabled": true,
+          "emoji": undefined,
+          "label": "1 / 2",
+          "style": 1,
+          "type": 2,
+        },
+        {
+          "custom_id": "prev",
+          "disabled": true,
+          "emoji": {
+            "animated": false,
+            "id": undefined,
+            "name": "⬅",
+          },
+          "style": 2,
+          "type": 2,
+        },
+        {
+          "custom_id": "next",
+          "disabled": false,
+          "emoji": {
+            "animated": false,
+            "id": undefined,
+            "name": "➡",
+          },
+          "style": 2,
+          "type": 2,
+        },
+      ],
+      "type": 1,
+    },
+  ],
+  "content": "https://yugipedia.com/wiki/Special:Redirect/file/BlazingCartesiatheVirtuous-MADU-JP-VG-artwork.png?utm_source=bastion",
+}
+`;
+
+exports[`ArtSwitcher shows image if no illustrations 1`] = `
+{
+  "components": [
+    {
+      "components": [
+        {
+          "custom_id": "label",
+          "disabled": true,
+          "emoji": undefined,
+          "label": "1 / 1",
+          "style": 1,
+          "type": 2,
+        },
+        {
+          "custom_id": "prev",
+          "disabled": true,
+          "emoji": {
+            "animated": false,
+            "id": undefined,
+            "name": "⬅",
+          },
+          "style": 2,
+          "type": 2,
+        },
+        {
+          "custom_id": "next",
+          "disabled": true,
+          "emoji": {
+            "animated": false,
+            "id": undefined,
+            "name": "➡",
+          },
+          "style": 2,
+          "type": 2,
+        },
+      ],
+      "type": 1,
+    },
+  ],
+  "content": "https://yugipedia.com/wiki/Special:Redirect/file/Shuttleroid-PP11-JP-ScR.jpg?utm_source=bastion",
+}
+`;
+
+exports[`ArtSwitcher shows single illustration 1`] = `
+{
+  "components": [
+    {
+      "components": [
+        {
+          "custom_id": "label",
+          "disabled": true,
+          "emoji": undefined,
+          "label": "1 / 1",
+          "style": 1,
+          "type": 2,
+        },
+        {
+          "custom_id": "prev",
+          "disabled": true,
+          "emoji": {
+            "animated": false,
+            "id": undefined,
+            "name": "⬅",
+          },
+          "style": 2,
+          "type": 2,
+        },
+        {
+          "custom_id": "next",
+          "disabled": true,
+          "emoji": {
+            "animated": false,
+            "id": undefined,
+            "name": "➡",
+          },
+          "style": 2,
+          "type": 2,
+        },
+      ],
+      "type": 1,
+    },
+  ],
+  "content": "https://yugipedia.com/wiki/Special:Redirect/file/MekkKnightCrusadiaAvramax-MADU-EN-VG-artwork.png?utm_source=bastion",
+}
+`;

--- a/test/unit/art.spec.ts
+++ b/test/unit/art.spec.ts
@@ -1,0 +1,30 @@
+import { ChatInputCommandInteraction, DiscordjsError, DiscordjsErrorCodes } from "discord.js";
+import { ArtSwitcher } from "../../src/art";
+
+describe("ArtSwitcher", () => {
+	const awaitMessageComponent = jest.fn();
+	const editReply = jest.fn();
+	const interaction = { editReply } as unknown as ChatInputCommandInteraction;
+	beforeEach(() => {
+		awaitMessageComponent.mockReset();
+		editReply.mockReset().mockReturnValue({ awaitMessageComponent });
+	});
+	it("shows single illustration", async () => {
+		awaitMessageComponent.mockRejectedValue(new DiscordjsError(DiscordjsErrorCodes.InteractionCollectorError));
+		const switcher = new ArtSwitcher(
+			[
+				{
+					illustration: "https://example.net/illustration.png",
+					index: 1,
+					image: "https://example.net/image.png"
+				}
+			],
+			null,
+			"test"
+		);
+		await switcher.editReply(interaction, "en");
+		expect(editReply).toHaveBeenCalled();
+	});
+	it.todo("shows video game illustration if available");
+	it.todo("shows image if no illustrations");
+});

--- a/test/unit/art.spec.ts
+++ b/test/unit/art.spec.ts
@@ -1,4 +1,4 @@
-import { BaseMessageOptions, ChatInputCommandInteraction } from "discord.js";
+import { ChatInputCommandInteraction, DiscordjsError, DiscordjsErrorCodes } from "discord.js";
 import { ArtSwitcher } from "../../src/art";
 
 describe("ArtSwitcher", () => {
@@ -22,12 +22,7 @@ describe("ArtSwitcher", () => {
 		);
 		await switcher.editReply(interaction, "en");
 		expect(editReply).toHaveBeenCalledTimes(1);
-		expect(editReply).toHaveBeenCalledWith<[BaseMessageOptions]>(
-			expect.objectContaining({
-				content:
-					"https://yugipedia.com/wiki/Special:Redirect/file/MekkKnightCrusadiaAvramax-MADU-EN-VG-artwork.png?utm_source=bastion"
-			})
-		);
+		expect(editReply.mock.calls[0][0]).toMatchSnapshot();
 	});
 	it("shows image if no illustrations", async () => {
 		const switcher = new ArtSwitcher(
@@ -41,13 +36,27 @@ describe("ArtSwitcher", () => {
 		);
 		await switcher.editReply(interaction, "en");
 		expect(editReply).toHaveBeenCalledTimes(1);
-		expect(editReply).toHaveBeenCalledWith<[BaseMessageOptions]>(
-			expect.objectContaining({
-				content:
-					"https://yugipedia.com/wiki/Special:Redirect/file/Shuttleroid-PP11-JP-ScR.jpg?utm_source=bastion"
-			})
-		);
+		expect(editReply.mock.calls[0][0]).toMatchSnapshot();
 	});
-	// TODO: test multiple-image cases, using
-	// // awaitMessageComponent.mockRejectedValue(new DiscordjsError(DiscordjsErrorCodes.InteractionCollectorError));
+	const CARTESIA_IMAGES = [
+		{
+			illustration: "BlazingCartesiatheVirtuous-MADU-JP-VG-artwork.png",
+			index: 1,
+			image: "BlazingCartesiatheVirtuous-DABL-JP-SR.png"
+		},
+		{
+			illustration: "BlazingCartesiatheVirtuous-MADU-EN-VG-artwork.png",
+			index: "1.1",
+			image: "BlazingCartesiatheVirtuous-MP23-EN-PScR-1E.png"
+		}
+	];
+	it("shows first of two illustrations", async () => {
+		awaitMessageComponent.mockRejectedValue(new DiscordjsError(DiscordjsErrorCodes.InteractionCollectorError));
+		const interaction = { editReply, user: {} } as unknown as ChatInputCommandInteraction;
+		const switcher = new ArtSwitcher(CARTESIA_IMAGES, "test");
+		await switcher.editReply(interaction, "en");
+		expect(editReply).toHaveBeenCalledTimes(1);
+		expect(editReply.mock.calls[0][0]).toMatchSnapshot();
+	});
+	it.todo("shows second of two illustrations");
 });

--- a/test/unit/art.spec.ts
+++ b/test/unit/art.spec.ts
@@ -1,4 +1,4 @@
-import { ChatInputCommandInteraction, DiscordjsError, DiscordjsErrorCodes } from "discord.js";
+import { BaseMessageOptions, ChatInputCommandInteraction } from "discord.js";
 import { ArtSwitcher } from "../../src/art";
 
 describe("ArtSwitcher", () => {
@@ -10,21 +10,44 @@ describe("ArtSwitcher", () => {
 		editReply.mockReset().mockReturnValue({ awaitMessageComponent });
 	});
 	it("shows single illustration", async () => {
-		awaitMessageComponent.mockRejectedValue(new DiscordjsError(DiscordjsErrorCodes.InteractionCollectorError));
 		const switcher = new ArtSwitcher(
 			[
 				{
-					illustration: "https://example.net/illustration.png",
+					illustration: "MekkKnightCrusadiaAvramax-MADU-EN-VG-artwork.png",
 					index: 1,
-					image: "https://example.net/image.png"
+					image: "MekkKnightCrusadiaAvramax-RA01-EN-SR-1E.png"
 				}
 			],
-			null,
 			"test"
 		);
 		await switcher.editReply(interaction, "en");
-		expect(editReply).toHaveBeenCalled();
+		expect(editReply).toHaveBeenCalledTimes(1);
+		expect(editReply).toHaveBeenCalledWith<[BaseMessageOptions]>(
+			expect.objectContaining({
+				content:
+					"https://yugipedia.com/wiki/Special:Redirect/file/MekkKnightCrusadiaAvramax-MADU-EN-VG-artwork.png?utm_source=bastion"
+			})
+		);
 	});
-	it.todo("shows video game illustration if available");
-	it.todo("shows image if no illustrations");
+	it("shows image if no illustrations", async () => {
+		const switcher = new ArtSwitcher(
+			[
+				{
+					index: 1,
+					image: "Shuttleroid-PP11-JP-ScR.jpg"
+				}
+			],
+			"test"
+		);
+		await switcher.editReply(interaction, "en");
+		expect(editReply).toHaveBeenCalledTimes(1);
+		expect(editReply).toHaveBeenCalledWith<[BaseMessageOptions]>(
+			expect.objectContaining({
+				content:
+					"https://yugipedia.com/wiki/Special:Redirect/file/Shuttleroid-PP11-JP-ScR.jpg?utm_source=bastion"
+			})
+		);
+	});
+	// TODO: test multiple-image cases, using
+	// // awaitMessageComponent.mockRejectedValue(new DiscordjsError(DiscordjsErrorCodes.InteractionCollectorError));
 });

--- a/test/unit/card.spec.ts
+++ b/test/unit/card.spec.ts
@@ -1,0 +1,42 @@
+import { masterDuelIllustration, masterDuelIllustrationURL, yugipediaFileRedirect } from "../../src/card";
+
+describe("Helper functions", () => {
+	test("yugipediaFileRedirect", () => {
+		expect(yugipediaFileRedirect("BlazingCartesiatheVirtuous-MADU-JP-VG-artwork.png")).toEqual(
+			"https://yugipedia.com/wiki/Special:Redirect/file/BlazingCartesiatheVirtuous-MADU-JP-VG-artwork.png?utm_source=bastion"
+		);
+	});
+	test.each([
+		{
+			en: "Ghost Meets Girl - A Masterful Mayakashi Shiranui Saga",
+			expected: "GhostMeetsGirlAMasterfulMayakashiShiranuiSaga-MADU-EN-VG-artwork.png"
+		},
+		{
+			en: "Live☆Twin Ki-sikil",
+			expected: "LiveTwinKisikil-MADU-EN-VG-artwork.png"
+		},
+		{
+			en: "Evil★Twin Lil-la",
+			expected: "EvilTwinLilla-MADU-EN-VG-artwork.png"
+		},
+		{
+			en: "Number 81: Superdreadnought Rail Cannon Super Dora",
+			expected: "Number81SuperdreadnoughtRailCannonSuperDora-MADU-EN-VG-artwork.png"
+		},
+		{
+			en: "Danger!? Tsuchinoko",
+			expected: "DangerTsuchinoko-MADU-EN-VG-artwork.png"
+		}
+	])("masterDuelIllustration returns $expected for: $en", ({ en, expected }) => {
+		// eslint-disable-next-line @typescript-eslint/no-explicit-any
+		const mockCard = { name: { en } } as any;
+		expect(masterDuelIllustration(mockCard)).toEqual(expected);
+	});
+	test("masterDuelIllustrationURL", () => {
+		// eslint-disable-next-line @typescript-eslint/no-explicit-any
+		const mockCard = { name: { en: "Blue-Eyes White Dragon" } } as any;
+		expect(masterDuelIllustrationURL(mockCard)).toEqual(
+			"https://yugipedia.com/wiki/Special:Redirect/file/BlueEyesWhiteDragon-MADU-EN-VG-artwork.png?utm_source=bastion"
+		);
+	});
+});


### PR DESCRIPTION
/art no longer calls Yugipedia by assuming the Master Duel redirect exists if there is Master Duel rarity data.
/rush-duel art reduces calls to Yugipedia by skipping the redirect check when illustrations are already specified.
Rework some illustration URL construction logic to create a common yugipediaFileRedirect helper, with unit testing.
Add some unit tests for the ArtSwitcher.

Closes #443 