### PR TITLE
Refactor: implement CommandCache

### DIFF
--- a/src/bot.ts
+++ b/src/bot.ts
@@ -87,9 +87,6 @@ export class BotFactory {
 			logger.info("Registered messageCreate gateway event frequency early warning canary");
 		});
 
-		// Obtain the snowflakes for all our Slash Commands so they can be mentioned
-		bot.once("ready", async () => void (await bot.application?.commands.fetch()));
-
 		for (const listener of this.listeners) {
 			bot.on(listener.type, (...args) => listener.run(...args));
 		}

--- a/src/events/index.ts
+++ b/src/events/index.ts
@@ -9,3 +9,4 @@ export { InteractionListener } from "./interaction";
 export { MessageDeleteListener } from "./message-delete";
 export { PingMessageListener } from "./message-ping";
 export { SearchMessageListener } from "./message-search";
+export { CommandCacheReadyListener } from "./ready-commands";

--- a/src/events/ready-commands.ts
+++ b/src/events/ready-commands.ts
@@ -1,0 +1,38 @@
+import { ApplicationCommand, Client } from "discord.js";
+import { inject, injectable } from "tsyringe";
+import { Listener } from ".";
+import { getLogger } from "../logger";
+
+export type CommandCache = Map<string, ApplicationCommand>;
+
+@injectable()
+export class CommandCacheReadyListener implements Listener<"ready"> {
+	readonly type = "ready";
+
+	#logger = getLogger("events:message:ready-commands");
+
+	constructor(@inject("commandCache") private nameToCommand: CommandCache) {}
+
+	async run(client: Client<true>): Promise<void> {
+		// Obtain the snowflakes for all our Slash Commands so they can be mentioned
+		if (process.env.BOT_NO_DIRECT_MESSAGE_SEARCH) {
+			// Development/preview logic: grab server commands from the registered server
+			const commandCaches = await Promise.all(client.guilds.cache.map(server => server.commands.fetch()));
+			const commandCache = commandCaches.find(commandCache => commandCache.size);
+			this.#logger.info(`Found ${commandCache?.size} commands in server`);
+			for (const command of commandCache?.values() ?? []) {
+				this.nameToCommand.set(command.name, command);
+			}
+		} else {
+			// Production logic: grab global commands
+			const commandCache = await client.application.commands.fetch();
+			for (const command of commandCache.values()) {
+				this.nameToCommand.set(command.name, command);
+			}
+		}
+	}
+
+	get(commandName: string): ApplicationCommand | undefined {
+		return this.nameToCommand.get(commandName);
+	}
+}

--- a/src/index.ts
+++ b/src/index.ts
@@ -5,8 +5,15 @@ import { Command } from "./Command";
 import { BotFactory } from "./bot";
 import { classes, registerSlashCommands } from "./commands";
 import { EventLocker } from "./event-lock";
-import { InteractionListener, MessageDeleteListener, PingMessageListener, SearchMessageListener } from "./events";
+import {
+	CommandCacheReadyListener,
+	InteractionListener,
+	MessageDeleteListener,
+	PingMessageListener,
+	SearchMessageListener
+} from "./events";
 import { cardSearcherProvider } from "./events/message-search";
+import { CommandCache } from "./events/ready-commands";
 import createGotClient from "./got";
 import { limitRegulationMasterDuelProvider, limitRegulationRushProvider } from "./limit-regulation";
 import { LocaleProvider, SQLiteLocaleProvider, loadTranslations } from "./locale";
@@ -58,6 +65,7 @@ if (process.argv.length > 2 && process.argv[2] === "--deploy-slash") {
 
 	// TTL: 5 minutes, sweep every 5 minutes
 	container.registerInstance<RecentMessageCache>(RecentMessageCache, new RecentMessageCache(300000, 300000));
+	container.registerInstance<CommandCache>("commandCache", new Map());
 
 	container.register("limitRegulationRush", limitRegulationRushProvider);
 	container.register("limitRegulationMasterDuel", limitRegulationMasterDuelProvider);
@@ -70,6 +78,7 @@ if (process.argv.length > 2 && process.argv[2] === "--deploy-slash") {
 	container.register<PingMessageListener>("Listener", { useClass: PingMessageListener });
 	container.register<SearchMessageListener>("Listener", { useClass: SearchMessageListener });
 	container.register<MessageDeleteListener>("Listener", { useClass: MessageDeleteListener });
+	container.register<CommandCacheReadyListener>("Listener", { useClass: CommandCacheReadyListener });
 	//container.register<BotFactory>(BotFactory, { useClass: BotFactory });
 
 	const bot = container.resolve(BotFactory).createInstance();


### PR DESCRIPTION
Reuses logic between card searcher implementations, and allows command references to work in development and preview