### PR TITLE
Fix replies being ignored

### DIFF
--- a/src/events/message-ping.ts
+++ b/src/events/message-ping.ts
@@ -33,10 +33,8 @@ export class PingMessageListener implements Listener<"messageCreate"> {
 		if (shouldIgnore(message)) {
 			return;
 		}
-		if (
-			message.client.user &&
-			message.mentions.has(message.client.user, { ignoreEveryone: true, ignoreRoles: true })
-		) {
+		// Only if directly pinged by name in message content (not by reply or group ping)
+		if (message.mentions.parsedUsers.has(message.client.user.id)) {
 			if (!this.eventLocks.has(message.id, PingMessageListener.name)) {
 				this.log("verbose", message, "skipNoLock");
 				return;

--- a/src/utils.ts
+++ b/src/utils.ts
@@ -153,8 +153,6 @@ export function splitText(outString: string, cap = 1024): string[] {
 
 export function shouldIgnore(message: Message): boolean {
 	return (
-		// Ignore replies to prevent overtriggering as they are treated as pings
-		!!message.reference ||
 		// Ignore system messages as we cannot reply to them
 		message.system ||
 		// Ignore bots to prevent infinite loops and other potentially malicious abuse, except from our Singing Lanius


### PR DESCRIPTION
Four months ago in #434 (1e121303f6229164f4f1fbbe43a3df4f0dbde316), a change was introduced that synchronized the ignore condition between the message ping and message search listeners. This added a new condition to ignore replies for message search. This behaviour is incorrect, unintuitive, and undocumented as all replies are ignored, not just direct replies, and there are no merits of ignoring even those for message search. This should fix most cases reported in #454, though there still remain uncommon cases of Discord not sending the message event. This also updates the logic in PingMessageListener so it can safely handle replies to other users containing a mention while ignoring reply mentions.