### PR TITLE
Display ruby text using Discord markdown for subtext

### DIFF
--- a/src/card.ts
+++ b/src/card.ts
@@ -297,7 +297,7 @@ export function formatCardName(card: Static<typeof CardSchema> | Static<typeof R
 	const name = card.name[lang]; // TypeScript cannot narrow typing on this without the variable
 	if ((lang === "ja" || lang === "ko") && name?.includes("<ruby>")) {
 		const [rubyless, rubyonly] = parseAndExpandRuby(name);
-		return `${rubyless}（${rubyonly}）`;
+		return `${rubyonly}\n${rubyless}`;
 	}
 	return name || `${card.name.en}`;
 }

--- a/src/card.ts
+++ b/src/card.ts
@@ -297,7 +297,7 @@ export function formatCardName(card: Static<typeof CardSchema> | Static<typeof R
 	const name = card.name[lang]; // TypeScript cannot narrow typing on this without the variable
 	if ((lang === "ja" || lang === "ko") && name?.includes("<ruby>")) {
 		const [rubyless, rubyonly] = parseAndExpandRuby(name);
-		return `${rubyonly}\n${rubyless}`;
+		return `${rubyless}（${rubyonly}）`;
 	}
 	return name || `${card.name.en}`;
 }
@@ -407,11 +407,6 @@ export function createCardEmbed(
 	const official = `https://www.db.yugioh-card.com/yugiohdb/card_search.action?ope=2&request_locale=${lang}&cid=${card.konami_id}`;
 	const rulings = `https://www.db.yugioh-card.com/yugiohdb/faq_search.action?ope=4&request_locale=ja&cid=${card.konami_id}`;
 
-	const embed = new EmbedBuilder()
-		.setTitle(formatCardName(card, lang))
-		.setURL(ygoprodeck)
-		.setThumbnail(thumbnail(card));
-
 	const links = {
 		name: t`🔗 Links`,
 		value: t`[Official Konami DB](${official}) | [OCG Rulings](${rulings}) | [Yugipedia](${yugipedia}) | [YGOPRODECK](${ygoprodeck})`
@@ -420,15 +415,19 @@ export function createCardEmbed(
 		links.value = t`[Yugipedia](${yugipedia}) | [YGOPRODECK](${ygoprodeck})`;
 	}
 
+	const embed = new EmbedBuilder().setURL(ygoprodeck).setThumbnail(thumbnail(card));
 	let description = "";
-	if (lang === "ja") {
-		if (card.name.ja_romaji) {
-			description = `**Rōmaji**: ${card.name.ja_romaji}\n`;
-		}
-	} else if (lang === "ko") {
-		if (card.name.ko_rr) {
-			description = `**RR**: ${card.name.ko_rr}\n`;
-		}
+
+	const name = card.name[lang]; // TypeScript cannot narrow typing on this without the variable
+	if ((lang === "ja" || lang === "ko") && name?.includes("<ruby>")) {
+		const [rubyless, rubyonly] = parseAndExpandRuby(name);
+		description += `-# ${rubyonly}\n**[${rubyless}](${ygoprodeck})**\n\n`;
+	} else {
+		embed.setTitle(name || `${card.name.en}`);
+	}
+
+	if (lang === "ja" && card.name.ja_romaji) {
+		description += `**Rōmaji**: ${card.name.ja_romaji}\n`;
 	}
 
 	const limitRegulations = [

--- a/src/card.ts
+++ b/src/card.ts
@@ -418,7 +418,7 @@ export function createCardEmbed(
 	const embed = new EmbedBuilder().setURL(ygoprodeck).setThumbnail(thumbnail(card));
 	let description = "";
 
-	const name = card.name[lang]; // TypeScript cannot narrow typing on this without the variable
+	const name = card.name[lang];
 	if ((lang === "ja" || lang === "ko") && name?.includes("<ruby>")) {
 		const [rubyless, rubyonly] = parseAndExpandRuby(name);
 		description += `-# ${rubyonly}\n**[${rubyless}](${ygoprodeck})**\n\n`;


### PR DESCRIPTION
Per https://support.discord.com/hc/en-us/articles/210298617-Markdown-Text-101-Chat-Formatting-Bold-Italic-Underline (and https://gist.github.com/matthewzring/9f7bbfd102003963f9be7dbcf7d40e51), adding `-# ` at the start of a line causes it to appear as subtext on Discord. The font size is smaller and the colour is muted. This is exclusively Discord-flavoured markdown and does not appear in other dialects.

We use this to render ruby text for Japanese and Korean when it's available. In these cases, the embed will not have a title. The description section instead starts with the constructed ruby text of the card name as a subtext, followed by the base text of the card name, bolded and hyperlinked as if it were still the embed title. Using a markdown header is not good here as we can't get rid of the top padding on the header between the two versions of the card name. In all other cases, the behaviour is unchanged and the card name will continue to be the embed title.

Also upon request, drop Korean RR from display, as it's not relevant to native speakers.

Integration tests accounting for this change in embed title to come afterward.