### PR TITLE
Update locale logic

### DIFF
--- a/src/commands/locale-user.ts
+++ b/src/commands/locale-user.ts
@@ -67,10 +67,10 @@ export class LocaleUserCommand extends Command {
 		let content = "";
 		if (interaction.options.getSubcommand() === "get") {
 			const effectiveLocale = await this.#locales.get(interaction);
-			const override = await this.#locales.channel(interaction.channelId);
+			const override = await this.#locales.user(interaction.user.id);
 			useLocale(effectiveLocale);
 			if (override) {
-				content += t`Locale override for this direct message: ${override}`;
+				content += t`Locale override for your direct messages: ${override}`;
 				content += "\n";
 			}
 			content += t`Your Discord locale: ${interaction.locale}`;
@@ -78,13 +78,13 @@ export class LocaleUserCommand extends Command {
 			// subcommand set
 			const locale = interaction.options.getString("locale", true) as Locale | "default";
 			if (locale !== "default") {
-				await this.#locales.setForChannel(interaction.channelId, locale);
+				await this.#locales.setForUser(interaction.user.id, locale);
 				await this.useLocaleAfterWrite(interaction);
-				content = t`Locale for this direct message overridden with ${locale}. Your Discord setting is ${interaction.locale}.`;
+				content = t`Locale for your direct messages overridden with ${locale}. Your Discord setting is ${interaction.locale}.`;
 			} else {
-				await this.#locales.setForChannel(interaction.channelId, null);
+				await this.#locales.setForUser(interaction.user.id, null);
 				await this.useLocaleAfterWrite(interaction);
-				content = t`Locale for this direct message reset to Discord default. Your Discord setting is ${interaction.locale}.`;
+				content = t`Locale for your direct messages reset to Discord default. Your Discord setting is ${interaction.locale}.`;
 			}
 		}
 		const reply = await interaction.reply({ content, fetchReply: true });

--- a/src/commands/locale.ts
+++ b/src/commands/locale.ts
@@ -83,10 +83,10 @@ export class LocaleCommand extends Command {
 				}
 				content += t`Discord Community locale for this server: ${interaction.guildLocale}`;
 			} else {
-				const override = await this.#locales.channel(interaction.channelId);
+				const override = await this.#locales.user(interaction.user.id);
 				useLocale(effectiveLocale);
 				if (override) {
-					content += t`Locale override for this direct message: ${override}`;
+					content += t`Locale override for your direct messages: ${override}`;
 					content += "\n";
 				}
 				content += t`Your Discord locale: ${interaction.locale}`;
@@ -141,13 +141,13 @@ export class LocaleCommand extends Command {
 			} else {
 				// direct message, ignore scope
 				if (locale !== "default") {
-					await this.#locales.setForChannel(interaction.channelId, locale);
+					await this.#locales.setForUser(interaction.user.id, locale);
 					await this.useLocaleAfterWrite(interaction);
-					content = t`Locale for this direct message overridden with ${locale}. Your Discord setting is ${interaction.locale}.`;
+					content = t`Locale for your direct messages overridden with ${locale}. Your Discord setting is ${interaction.locale}.`;
 				} else {
-					await this.#locales.setForChannel(interaction.channelId, null);
+					await this.#locales.setForUser(interaction.user.id, null);
 					await this.useLocaleAfterWrite(interaction);
-					content = t`Locale for this direct message reset to Discord default. Your Discord setting is ${interaction.locale}.`;
+					content = t`Locale for your direct messages reset to Discord default. Your Discord setting is ${interaction.locale}.`;
 				}
 			}
 		}

--- a/src/locale.ts
+++ b/src/locale.ts
@@ -237,9 +237,10 @@ export abstract class LocaleProvider {
 				this.filter(interaction.guildLocale)
 			);
 		} else {
-			// In direct messages, it is safe to use the user's Discord-reported locale
-			// without breaching privacy. Further support configuring the locale in the DM.
-			return (await this.channel(interaction.channelId)) ?? this.filter(interaction.locale);
+			// In direct messages, including group chats, and the user-installed version being
+			// invoked from a server, use the user's locale reported by Discord, which may be
+			// further configured for this bot specificcaly.
+			return (await this.user(interaction.user.id)) ?? this.filter(interaction.locale);
 		}
 	}
 
@@ -253,8 +254,8 @@ export abstract class LocaleProvider {
 				this.filter(context.guild.preferredLocale)
 			);
 		} else {
-			// Cannot retrieve the user's locale from a direct message.
-			return (await this.channel(context.channelId)) ?? "en";
+			// User locale is only provided for interactions, not messages.
+			return (await this.user(context.author.id)) ?? "en";
 		}
 	}
 

--- a/test/unit/events/message-ping.spec.ts
+++ b/test/unit/events/message-ping.spec.ts
@@ -16,7 +16,6 @@ class MockLocaleProvider extends LocaleProvider {
 	async channel(id: string): Promise<Locale | null> {
 		return "en";
 	}
-
 	// eslint-disable-next-line @typescript-eslint/no-unused-vars
 	async user(id: string): Promise<Locale | null> {
 		return "en";
@@ -29,7 +28,6 @@ class MockLocaleProvider extends LocaleProvider {
 	setForChannel(id: string, set: Locale | null): Promise<void> {
 		throw new Error("Method not implemented.");
 	}
-
 	// eslint-disable-next-line @typescript-eslint/no-unused-vars
 	setForUser(id: string, set: Locale | null): Promise<void> {
 		throw new Error("Method not implemented.");

--- a/test/unit/events/message-ping.spec.ts
+++ b/test/unit/events/message-ping.spec.ts
@@ -16,6 +16,7 @@ class MockLocaleProvider extends LocaleProvider {
 	async channel(id: string): Promise<Locale | null> {
 		return "en";
 	}
+
 	// eslint-disable-next-line @typescript-eslint/no-unused-vars
 	async user(id: string): Promise<Locale | null> {
 		return "en";
@@ -28,6 +29,7 @@ class MockLocaleProvider extends LocaleProvider {
 	setForChannel(id: string, set: Locale | null): Promise<void> {
 		throw new Error("Method not implemented.");
 	}
+
 	// eslint-disable-next-line @typescript-eslint/no-unused-vars
 	setForUser(id: string, set: Locale | null): Promise<void> {
 		throw new Error("Method not implemented.");

--- a/test/unit/events/message-ping.spec.ts
+++ b/test/unit/events/message-ping.spec.ts
@@ -16,12 +16,22 @@ class MockLocaleProvider extends LocaleProvider {
 	async channel(id: string): Promise<Locale | null> {
 		return "en";
 	}
+
+	// eslint-disable-next-line @typescript-eslint/no-unused-vars
+	async user(id: string): Promise<Locale | null> {
+		return "en";
+	}
 	// eslint-disable-next-line @typescript-eslint/no-unused-vars
 	setForGuild(id: string, set: Locale | null): Promise<void> {
 		throw new Error("Method not implemented.");
 	}
 	// eslint-disable-next-line @typescript-eslint/no-unused-vars
 	setForChannel(id: string, set: Locale | null): Promise<void> {
+		throw new Error("Method not implemented.");
+	}
+
+	// eslint-disable-next-line @typescript-eslint/no-unused-vars
+	setForUser(id: string, set: Locale | null): Promise<void> {
 		throw new Error("Method not implemented.");
 	}
 }

--- a/translations/de.po
+++ b/translations/de.po
@@ -6,50 +6,50 @@ msgstr ""
 "MIME-Version: 1.0\n"
 "Content-Transfer-Encoding: 8bit\n"
 
-#: src\card.ts:416
-#: src\rush-duel.ts:39
+#: src\card.ts:412
+#: src\rush-duel.ts:48
 msgid "🔗 Links"
 msgstr ""
 
-#: src\card.ts:417
+#: src\card.ts:413
 #, javascript-format
 msgid "[Official Konami DB](${ official }) | [OCG Rulings](${ rulings }) | [Yugipedia](${ yugipedia }) | [YGOPRODECK](${ ygoprodeck })"
 msgstr ""
 
-#: src\card.ts:420
+#: src\card.ts:416
 #, javascript-format
 msgid "[Yugipedia](${ yugipedia }) | [YGOPRODECK](${ ygoprodeck })"
 msgstr ""
 
-#: src\card.ts:489
-#: src\rush-duel.ts:92
+#: src\card.ts:490
+#: src\rush-duel.ts:103
 #, javascript-format
 msgid "**Type**: ${ raceIcon } ${ localizedMonsterTypeLine }"
 msgstr "**Typ**: ${ raceIcon } ${ localizedMonsterTypeLine }"
 
-#: src\card.ts:491
-#: src\rush-duel.ts:94
+#: src\card.ts:492
+#: src\rush-duel.ts:105
 #, javascript-format
 msgid "**Attribute**: ${ attributeIcon } ${ localizedAttribute }"
 msgstr "**Eigenschaft**: ${ attributeIcon } ${ localizedAttribute }"
 
-#: src\card.ts:495
+#: src\card.ts:497
 #, javascript-format
 msgid "**Rank**: ${ rankIcon } ${ card.rank } **ATK**: ${ card.atk } **DEF**: ${ card.def }"
 msgstr "**Rang**: ${ rankIcon } ${ card.rank } **ATK**: ${ card.atk } **DEF**: ${ card.def }"
 
-#: src\card.ts:498
+#: src\card.ts:500
 #, javascript-format
 msgid "**Link Rating**: ${ card.link_arrows.length } **ATK**: ${ card.atk } **Link Arrows**: ${ arrows }"
 msgstr ""
 
-#: src\card.ts:500
-#: src\rush-duel.ts:96
+#: src\card.ts:503
+#: src\rush-duel.ts:107
 #, javascript-format
 msgid "**Level**: ${ levelIcon } ${ card.level } **ATK**: ${ card.atk } **DEF**: ${ card.def }"
 msgstr "**Stufe**: ${ levelIcon } ${ card.level } **ATK**: ${ card.atk } **DEF**: ${ card.def }"
 
-#: src\card.ts:507
+#: src\card.ts:511
 #, javascript-format
 msgid "**Pendulum Scale**: ${ formattedScale }"
 msgstr "**Pendelbereich**: ${ formattedScale }"
@@ -70,7 +70,7 @@ msgid "Password: ${ card.password } | Not yet released"
 msgstr ""
 
 #: src\card.ts:351
-#: src\rush-duel.ts:146
+#: src\rush-duel.ts:158
 msgid "Not yet released"
 msgstr ""
 
@@ -79,64 +79,64 @@ msgstr ""
 msgid "Placeholder ID: ${ card.fake_password }"
 msgstr ""
 
-#: src\utils.ts:41
+#: src\utils.ts:44
 msgid "🛠️ This command is in development."
 msgstr ""
 
-#: src\utils.ts:42
+#: src\utils.ts:45
 msgid "📨 Please send feedback to [our issue tracker](https://github.com/DawnbrandBots/bastion-bot) or the [support server](https://discord.gg/4aFuPyuE96)!"
 msgstr ""
 
-#: src\utils.ts:53
+#: src\utils.ts:56
 msgid "Please consider supporting us!"
 msgstr ""
 
-#: src\utils.ts:54
+#: src\utils.ts:57
 msgid "Help keep Bastion online!"
 msgstr ""
 
-#: src\utils.ts:55
+#: src\utils.ts:58
 msgid "Please help keep Bastion online!"
 msgstr ""
 
-#: src\utils.ts:56
+#: src\utils.ts:59
 msgid "Was Bastion helpful? Consider supporting us!"
 msgstr ""
 
-#: src\utils.ts:57
+#: src\utils.ts:60
 msgid "Was Bastion helpful? We need your support!"
 msgstr ""
 
-#: src\utils.ts:58
+#: src\utils.ts:61
 msgid "Did you find Bastion useful? Consider supporting us!"
 msgstr ""
 
-#: src\utils.ts:59
+#: src\utils.ts:62
 msgid "Did you find Bastion useful? Help keep it online!"
 msgstr ""
 
-#: src\utils.ts:60
+#: src\utils.ts:63
 msgid "Did you find Bastion useful? We need your support!"
 msgstr ""
 
-#: src\utils.ts:61
+#: src\utils.ts:64
 msgid "Enjoy Bastion? Help keep it online!"
 msgstr ""
 
-#: src\utils.ts:62
+#: src\utils.ts:65
 msgid "Enjoy Bastion? Consider supporting us!"
 msgstr ""
 
-#: src\utils.ts:63
+#: src\utils.ts:66
 msgid "Found what you were looking for? Consider supporting us!"
 msgstr ""
 
 #: src\commands\art.ts:63
-#: src\commands\price.ts:131
-#: src\commands\rush-duel.ts:172
-#: src\commands\rush-duel.ts:203
+#: src\commands\price.ts:132
+#: src\commands\rush-duel.ts:171
+#: src\commands\rush-duel.ts:202
 #: src\commands\search.ts:64
-#: src\events\message-search.ts:258
+#: src\events\message-search.ts:265
 #, javascript-format
 msgid "Could not find a card matching `${ input }`!"
 msgstr ""
@@ -147,51 +147,51 @@ msgstr ""
 msgid "Could not find art for `${ name }`!"
 msgstr ""
 
-#: src\commands\deck.ts:244
+#: src\commands\deck.ts:205
 #, javascript-format
 msgid "${ counts.Monster } Monster"
 msgid_plural "${ counts.Monster } Monsters"
 msgstr[0] ""
 msgstr[1] ""
 
-#: src\commands\deck.ts:247
+#: src\commands\deck.ts:208
 #, javascript-format
 msgid "${ counts.Spell } Spell"
 msgid_plural "${ counts.Spell } Spells"
 msgstr[0] ""
 msgstr[1] ""
 
-#: src\commands\deck.ts:250
+#: src\commands\deck.ts:211
 #, javascript-format
 msgid "${ counts.Trap } Trap"
 msgid_plural "${ counts.Trap } Traps"
 msgstr[0] ""
 msgstr[1] ""
 
-#: src\commands\deck.ts:278
+#: src\commands\deck.ts:239
 msgid "Your Deck"
 msgstr ""
 
-#: src\commands\deck.ts:283
+#: src\commands\deck.ts:244
 #, javascript-format
 msgid "Main Deck (${ deck.main.length } card — ${ countDetail })"
 msgid_plural "Main Deck (${ deck.main.length } cards — ${ countDetail })"
 msgstr[0] ""
 msgstr[1] ""
 
-#: src\commands\deck.ts:290
+#: src\commands\deck.ts:251
 msgid "Main Deck (continued)"
 msgstr ""
 
-#: src\commands\deck.ts:304
+#: src\commands\deck.ts:265
 msgid "Extra Deck (continued)"
 msgstr ""
 
-#: src\commands\deck.ts:318
+#: src\commands\deck.ts:279
 msgid "Side Deck (continued)"
 msgstr ""
 
-#: src\commands\deck.ts:407
+#: src\commands\deck.ts:347
 msgid "Error: Your deck is empty."
 msgstr ""
 
@@ -211,11 +211,7 @@ msgstr ""
 msgid "Discord Community locale for this server: ${ interaction.guildLocale }"
 msgstr ""
 
-#: src\commands\locale.ts:89
-#, javascript-format
-msgid "Locale override for this direct message: ${ override }"
-msgstr ""
-
+#: src\commands\locale-user.ts:76
 #: src\commands\locale.ts:92
 #, javascript-format
 msgid "Your Discord locale: ${ interaction.locale }"
@@ -253,24 +249,14 @@ msgstr ""
 msgid "Sorry, you must have the Manage Server permission to do this. If you think this is an error, contact your server admin or report a bug."
 msgstr ""
 
-#: src\commands\locale.ts:146
-#, javascript-format
-msgid "Locale for this direct message overridden with ${ locale }. Your Discord setting is ${ interaction.locale }."
-msgstr ""
-
-#: src\commands\locale.ts:150
-#, javascript-format
-msgid "Locale for this direct message reset to Discord default. Your Discord setting is ${ interaction.locale }."
-msgstr ""
-
-#: src\commands\ping.ts:36
-#: src\events\message-ping.ts:47
+#: src\commands\ping.ts:38
+#: src\events\message-ping.ts:45
 #, javascript-format
 msgid "Average WebSocket ping (new instance): ${ ping } ms"
 msgstr ""
 
-#: src\commands\ping.ts:40
-#: src\events\message-ping.ts:112
+#: src\commands\ping.ts:42
+#: src\events\message-ping.ts:110
 #, javascript-format
 msgid "Total latency: ${ latency } ms"
 msgstr ""
@@ -280,86 +266,69 @@ msgstr ""
 msgid "Could not find a Yugipedia page named `${ page }`."
 msgstr ""
 
-#: src\events\message-ping.ts:49
+#: src\events\message-ping.ts:47
 msgid "Free and open source _Yu-Gi-Oh!_ bot"
 msgstr ""
 
-#: src\events\message-ping.ts:72
+#: src\events\message-ping.ts:70
 #, javascript-format
 msgid "Revision: ${ process.env.BOT_REVISION }."
 msgstr ""
 
-#: src\commands\deck.ts:328
+#: src\commands\deck.ts:289
 msgid ".ydk files must have the .ydk extension!"
 msgstr ""
 
-#: src\commands\deck.ts:331
+#: src\commands\deck.ts:292
 msgid ".ydk files should not be larger than 1 KB!"
 msgstr ""
 
-#: src\commands\deck.ts:321
+#: src\commands\deck.ts:282
 msgid "ydke URL"
 msgstr ""
 
 #: src\card.ts:455
-#: src\rush-duel.ts:61
+#: src\rush-duel.ts:75
 #. Forbidden/Limited Lists or Limit Regulations in the OCG
 #, javascript-format
 msgid "**Limit**: ${ limitRegulationDisplay }"
 msgstr ""
 
-#: src\commands\price.ts:69
+#: src\commands\price.ts:70
 msgid "TCGPlayer"
 msgstr ""
 
-#: src\commands\price.ts:70
+#: src\commands\price.ts:71
 msgid "Cardmarket"
 msgstr ""
 
-#: src\commands\price.ts:147
+#: src\commands\price.ts:148
 msgid "No market price"
 msgstr ""
 
-#: src\commands\price.ts:155
+#: src\commands\price.ts:156
 #, javascript-format
 msgid "Prices for ${ card.name[resultLanguage] } - ${ vendorName }"
 msgstr ""
 
-#: src\commands\price.ts:169
+#: src\commands\price.ts:170
 #, javascript-format
 msgid "Could not find prices for `${ name }`!"
 msgstr ""
 
-#: src\commands\deck.ts:425
-#. prepare interaction button for FTP upload
+#: src\commands\deck.ts:363
 msgid "Upload to YGOPRODECK"
 msgstr ""
 
-#: src\commands\deck.ts:483
-#. disable original button
-#. prepare row to disable button on original message
-msgid "Upload Complete"
-msgstr ""
-
-#: src\commands\deck.ts:470
-msgid "Deck upload failed!"
-msgstr ""
-
-#: src\commands\deck.ts:491
-#. reply in affirmation
-#, javascript-format
-msgid "Deck successfully uploaded to <${ url }>!"
-msgstr ""
-
-#: src\events\message-search.ts:264
+#: src\events\message-search.ts:271
 msgid "💬 Translations missing?"
 msgstr ""
 
-#: src\events\message-search.ts:265
+#: src\events\message-search.ts:272
 msgid "Help translate Bastion at the links above."
 msgstr ""
 
-#: src\events\message-ping.ts:50
+#: src\events\message-ping.ts:48
 msgid ""
 "❓ Help documentation on [GitHub](https://github.com/DawnbrandBots/bastion-bot), or use `.commands` and `.help`.\n"
 "🟢 Licence: [GNU AGPL 3.0+](https://choosealicense.com/licenses/agpl-3.0/).\n"
@@ -375,38 +344,38 @@ msgid ""
 "💬 Translations missing? Help translate Bastion on [GitHub](https://github.com/DawnbrandBots/bastion-bot)."
 msgstr ""
 
-#: src\events\message-search.ts:256
-#: src\events\message-search.ts:294
+#: src\events\message-search.ts:263
+#: src\events\message-search.ts:302
 #, javascript-format
 msgid "Search type: ${ localisedType }"
 msgstr ""
 
-#: src\events\message-search.ts:236
+#: src\events\message-search.ts:242
 #, javascript-format
 msgid "Search language: **${ localisedInputLanguage }** (${ inputLanguage }). Check defaults with </locale get:${ id }> and configure with </locale set:${ id }>"
 msgstr ""
 
-#: src\events\message-ping.ts:95
+#: src\events\message-ping.ts:93
 msgid "⚠️ You pinged me, but I am missing permissions in the channel!"
 msgstr ""
 
-#: src\events\message-ping.ts:98
-#: src\events\message-search.ts:332
+#: src\events\message-ping.ts:96
+#: src\events\message-search.ts:340
 msgid "Please have a server administrator [fix this](https://github.com/DawnbrandBots/bastion-bot#discord-permissions)."
 msgstr ""
 
-#: src\events\message-search.ts:329
+#: src\events\message-search.ts:337
 msgid "⚠️ I am missing permissions in the channel!"
 msgstr ""
 
-#: src\commands\deck.ts:297
+#: src\commands\deck.ts:258
 #, javascript-format
 msgid "Extra Deck (${ deck.extra.length } card — ${ countDetail })"
 msgid_plural "Extra Deck (${ deck.extra.length } cards — ${ countDetail })"
 msgstr[0] ""
 msgstr[1] ""
 
-#: src\commands\deck.ts:311
+#: src\commands\deck.ts:272
 #, javascript-format
 msgid "Side Deck (${ deck.side.length } card — ${ countDetail })"
 msgid_plural "Side Deck (${ deck.side.length } cards — ${ countDetail })"
@@ -428,32 +397,31 @@ msgstr ""
 msgid "Something went wrong searching Yugipedia for `${ page }`."
 msgstr ""
 
-#: src\rush-duel.ts:40
+#: src\rush-duel.ts:49
 #, javascript-format
 msgid "[Official Konami DB](${ official }) | [Rulings (Japanese)](${ rulings }) | [Yugipedia](${ yugipedia }) | [RushCard](${ rushcard })"
 msgstr ""
 
-#: src\rush-duel.ts:43
+#: src\rush-duel.ts:52
 #, javascript-format
 msgid "[Yugipedia](${ yugipedia }) | [RushCard](${ rushcard })"
 msgstr ""
 
-#: src\rush-duel.ts:57
+#: src\rush-duel.ts:71
 msgid "__**LEGEND**__"
 msgstr ""
 
-#: src\rush-duel.ts:99
+#: src\rush-duel.ts:110
 #, javascript-format
 msgid "**MAXIMUM ATK**: ${ card.maximum_atk }"
 msgstr ""
 
-#: src\rush-duel.ts:146
+#: src\rush-duel.ts:158
 #, javascript-format
 msgid "Konami ID #${ card.konami_id }"
 msgstr ""
 
 #: src\art.ts:129
-#: src\commands\deck.ts:451
 msgid "Buttons can only be used by the user who called Bastion."
 msgstr ""
 
@@ -462,14 +430,32 @@ msgstr ""
 msgid "**Master Duel rarity**: ${ rarityIcon } ${ localizedRarity }"
 msgstr ""
 
-#: src\rush-duel.ts:205
+#: src\rush-duel.ts:217
 #, javascript-format
 msgid "Using ${ searchTrigger }, you can search for Rush Duel cards directly in messages without autocomplete"
 msgstr ""
 
-#: src\events\message-search.ts:296
+#: src\events\message-search.ts:304
 #, javascript-format
 msgid "Could not find a Rush Duel card matching `${ input }`!"
+msgstr ""
+
+#: src\commands\locale-user.ts:73
+#: src\commands\locale.ts:89
+#, javascript-format
+msgid "Locale override for your direct messages: ${ override }"
+msgstr ""
+
+#: src\commands\locale-user.ts:83
+#: src\commands\locale.ts:146
+#, javascript-format
+msgid "Locale for your direct messages overridden with ${ locale }. Your Discord setting is ${ interaction.locale }."
+msgstr ""
+
+#: src\commands\locale-user.ts:87
+#: src\commands\locale.ts:150
+#, javascript-format
+msgid "Locale for your direct messages reset to Discord default. Your Discord setting is ${ interaction.locale }."
 msgstr ""
 
 #: src\card.ts:40
@@ -836,65 +822,65 @@ msgctxt "master-duel-rarity"
 msgid "Ultra Rare (UR)"
 msgstr "Ultra Rare (UR)"
 
-#: src\card.ts:513
-#: src\card.ts:524
-#: src\rush-duel.ts:127
+#: src\card.ts:517
+#: src\card.ts:528
+#: src\rush-duel.ts:138
 msgctxt "card-embed"
 msgid "Card Text"
 msgstr "Kartentext"
 
-#: src\card.ts:518
+#: src\card.ts:522
 msgctxt "card-embed"
 msgid "Pendulum Effect"
 msgstr "Pendeleffekt"
 
-#: src\card.ts:539
+#: src\card.ts:545
 msgctxt "card-embed"
 msgid "Card Effect"
 msgstr ""
 
-#: src\rush-duel.ts:118
-#: src\rush-duel.ts:139
+#: src\rush-duel.ts:129
+#: src\rush-duel.ts:151
 msgctxt "card-embed"
 msgid "[REQUIREMENT]"
 msgstr "[BEDINGUNG]"
 
-#: src\rush-duel.ts:119
-#: src\rush-duel.ts:140
+#: src\rush-duel.ts:130
+#: src\rush-duel.ts:152
 msgctxt "card-embed"
 msgid "[EFFECT]"
 msgstr "[EFFEKT]"
 
-#: src\rush-duel.ts:121
+#: src\rush-duel.ts:132
 msgctxt "card-embed"
 msgid "[CONTINUOUS EFFECT]"
 msgstr "[DAUEREFFEKT]"
 
-#: src\rush-duel.ts:123
+#: src\rush-duel.ts:134
 msgctxt "card-embed"
 msgid "[MULTI-CHOICE EFFECT]"
 msgstr ""
 
-#: src\locale.ts:71
+#: src\locale.ts:74
 msgctxt "command-option"
 msgid "result-language"
 msgstr ""
 
-#: src\locale.ts:131
+#: src\locale.ts:140
 msgctxt "command-option"
 msgid "input-language"
 msgstr ""
 
-#: src\commands\rush-duel.ts:68
-#: src\commands\rush-duel.ts:80
-#: src\locale.ts:147
-#: src\locale.ts:165
-#: src\locale.ts:181
+#: src\commands\rush-duel.ts:67
+#: src\commands\rush-duel.ts:79
+#: src\locale.ts:156
+#: src\locale.ts:174
+#: src\locale.ts:190
 msgctxt "command-option"
 msgid "input"
 msgstr ""
 
-#: src\commands\help.ts:52
+#: src\commands\help.ts:55
 msgctxt "command-option"
 msgid "command"
 msgstr ""
@@ -909,54 +895,56 @@ msgctxt "command-option"
 msgid "page"
 msgstr ""
 
-#: src\commands\deck.ts:126
+#: src\commands\deck.ts:87
 msgctxt "command-option"
 msgid "url"
 msgstr ""
 
-#: src\commands\deck.ts:132
+#: src\commands\deck.ts:93
 msgctxt "command-option"
 msgid "file"
 msgstr ""
 
-#: src\commands\deck.ts:138
-#: src\commands\deck.ts:144
+#: src\commands\deck.ts:99
+#: src\commands\deck.ts:105
 msgctxt "command-option"
 msgid "deck"
 msgstr ""
 
-#: src\commands\deck.ts:150
+#: src\commands\deck.ts:111
 msgctxt "command-option"
 msgid "public"
 msgstr ""
 
-#: src\commands\deck.ts:157
+#: src\commands\deck.ts:118
 msgctxt "command-option"
 msgid "stacked"
 msgstr ""
 
-#: src\locale.ts:142
+#: src\locale.ts:151
 msgctxt "command-option"
 msgid "name"
 msgstr ""
 
-#: src\locale.ts:160
+#: src\locale.ts:169
 msgctxt "command-option"
 msgid "password"
 msgstr ""
 
-#: src\commands\rush-duel.ts:73
-#: src\events\message-search.ts:293
-#: src\locale.ts:176
+#: src\commands\rush-duel.ts:72
+#: src\events\message-search.ts:301
+#: src\locale.ts:185
 msgctxt "command-option"
 msgid "konami-id"
 msgstr ""
 
+#: src\commands\locale-user.ts:36
 #: src\commands\locale.ts:30
 msgctxt "command-option"
 msgid "get"
 msgstr ""
 
+#: src\commands\locale-user.ts:41
 #: src\commands\locale.ts:35
 msgctxt "command-option"
 msgid "set"
@@ -967,47 +955,69 @@ msgctxt "command-option"
 msgid "scope"
 msgstr ""
 
+#: src\commands\locale-user.ts:46
 #: src\commands\locale.ts:48
 msgctxt "command-option"
 msgid "locale"
 msgstr ""
 
-#: src\commands\price.ts:94
+#: src\commands\price.ts:95
 msgctxt "command-option"
 msgid "vendor"
 msgstr ""
 
-#: src\commands\rush-duel.ts:63
+#: src\commands\rush-duel.ts:62
 msgctxt "command-option"
 msgid "search"
 msgstr ""
 
-#: src\commands\rush-duel.ts:85
+#: src\commands\rush-duel.ts:84
 msgctxt "command-option"
 msgid "random"
 msgstr ""
 
-#: src\commands\rush-duel.ts:90
+#: src\commands\rush-duel.ts:89
 msgctxt "command-option"
 msgid "art"
 msgstr ""
 
-#: src\commands\query.ts:36
+#: src\commands\query.ts:35
 msgctxt "command-option"
 msgid "lucene"
 msgstr ""
 
-#: src\locale.ts:74
+#: src\commands\metagame.ts:209
+msgctxt "command-option"
+msgid "strategies"
+msgstr ""
+
+#: src\commands\metagame.ts:234
+#: src\commands\metagame.ts:274
+msgctxt "command-option"
+msgid "format"
+msgstr ""
+
+#: src\commands\metagame.ts:240
+msgctxt "command-option"
+msgid "cards"
+msgstr ""
+
+#: src\commands\metagame.ts:310
+msgctxt "command-option"
+msgid "date-range"
+msgstr ""
+
+#: src\locale.ts:77
 msgctxt "command-option-description"
 msgid "The output language for the card embed, overriding other settings."
 msgstr ""
 
-#: src\locale.ts:132
+#: src\locale.ts:141
 msgctxt "command-option-description"
 msgid "The language to search in, defaulting to the result language."
 msgstr ""
 
-#: src\commands\help.ts:55
+#: src\commands\help.ts:58
 msgctxt "command-option-description"
 msgid "The name of a specific Slash Command."
 msgstr ""
@@ -1017,32 +1027,32 @@ msgctxt "command-option-description"
 msgid "The name of the Yugipedia page you want to search for."
 msgstr ""
 
-#: src\commands\deck.ts:129
+#: src\commands\deck.ts:90
 msgctxt "command-option-description"
 msgid "View a deck by entering a ydke:// URL."
 msgstr ""
 
-#: src\commands\deck.ts:135
+#: src\commands\deck.ts:96
 msgctxt "command-option-description"
 msgid "View a deck by uploading a .ydk file."
 msgstr ""
 
-#: src\commands\deck.ts:141
+#: src\commands\deck.ts:102
 msgctxt "command-option-description"
 msgid "The ydke:// URL of the deck you want to view."
 msgstr ""
 
-#: src\commands\deck.ts:147
+#: src\commands\deck.ts:108
 msgctxt "command-option-description"
 msgid "The .ydk file of the deck you want to view."
 msgstr ""
 
-#: src\commands\deck.ts:153
+#: src\commands\deck.ts:114
 msgctxt "command-option-description"
 msgid "Whether to display the deck details publicly in chat. This is false by default."
 msgstr ""
 
-#: src\commands\deck.ts:160
+#: src\commands\deck.ts:121
 msgctxt "command-option-description"
 msgid "Whether to display the deck sections as one stacked column. This is false (side-by-side) by default."
 msgstr ""
@@ -1052,8 +1062,8 @@ msgctxt "command-option-description"
 msgid "Display the art for the card with this name."
 msgstr ""
 
-#: src\commands\rush-duel.ts:69
-#: src\locale.ts:148
+#: src\commands\rush-duel.ts:68
+#: src\locale.ts:157
 msgctxt "command-option-description"
 msgid "Card name, fuzzy matching supported."
 msgstr ""
@@ -1063,7 +1073,7 @@ msgctxt "command-option-description"
 msgid "Display the art for the card with this password."
 msgstr ""
 
-#: src\locale.ts:167
+#: src\locale.ts:176
 msgctxt "command-option-description"
 msgid "Card password, the eight-digit number printed on the bottom left corner."
 msgstr ""
@@ -1073,8 +1083,8 @@ msgctxt "command-option-description"
 msgid "Display the art for the card with this official database ID."
 msgstr ""
 
-#: src\commands\rush-duel.ts:81
-#: src\locale.ts:182
+#: src\commands\rush-duel.ts:80
+#: src\locale.ts:191
 msgctxt "command-option-description"
 msgid "Konami's official card database identifier."
 msgstr ""
@@ -1114,22 +1124,22 @@ msgctxt "command-option-description"
 msgid "The new default language to use in this channel or server."
 msgstr ""
 
-#: src\commands\price.ts:98
+#: src\commands\price.ts:99
 msgctxt "command-option-description"
 msgid "Display the price for the card with this name."
 msgstr ""
 
-#: src\commands\price.ts:102
+#: src\commands\price.ts:103
 msgctxt "command-option-description"
 msgid "Display the price for the card with this password."
 msgstr ""
 
-#: src\commands\price.ts:105
+#: src\commands\price.ts:106
 msgctxt "command-option-description"
 msgid "Display the price for the card with this official database ID."
 msgstr ""
 
-#: src\commands\price.ts:95
+#: src\commands\price.ts:96
 msgctxt "command-option-description"
 msgid "The vendor to fetch the price data from."
 msgstr ""
@@ -1139,29 +1149,70 @@ msgctxt "command-option-description"
 msgid "The English name of the card you're looking for."
 msgstr ""
 
-#: src\commands\rush-duel.ts:64
+#: src\commands\rush-duel.ts:63
 msgctxt "command-option-description"
 msgid "Find all information for the Rush Duel card with this name."
 msgstr ""
 
-#: src\commands\rush-duel.ts:75
+#: src\commands\rush-duel.ts:74
 msgctxt "command-option-description"
 msgid "Find all information for the Rush Duel card with this official database ID."
 msgstr ""
 
-#: src\commands\rush-duel.ts:86
+#: src\commands\rush-duel.ts:85
 msgctxt "command-option-description"
 msgid "Get a random Rush Duel card."
 msgstr ""
 
-#: src\commands\rush-duel.ts:91
+#: src\commands\rush-duel.ts:90
 msgctxt "command-option-description"
 msgid "Display just the art for the Rush Duel card with this name."
 msgstr ""
 
-#: src\commands\query.ts:37
+#: src\commands\query.ts:36
 msgctxt "command-option-description"
 msgid "Lucene query on YAML Yugi"
+msgstr ""
+
+#: src\commands\locale-user.ts:37
+msgctxt "command-option-description"
+msgid "Check your user-installed Bastion's locale."
+msgstr ""
+
+#: src\commands\locale-user.ts:42
+msgctxt "command-option-description"
+msgid "Configure your user-installed Bastion's locale."
+msgstr ""
+
+#: src\commands\locale-user.ts:47
+msgctxt "command-option-description"
+msgid "The new default language to use for user-installed Bastion."
+msgstr ""
+
+#: src\commands\metagame.ts:212
+msgctxt "command-option-description"
+msgid "Show the top competitive strategies in tournaments and the Master Duel ranked ladder."
+msgstr ""
+
+#: src\commands\metagame.ts:214
+msgctxt "command-option-description"
+msgid "Show the top competitive strategies in tournaments."
+msgstr ""
+
+#: src\commands\metagame.ts:235
+#: src\commands\metagame.ts:275
+msgctxt "command-option-description"
+msgid "Game region."
+msgstr ""
+
+#: src\commands\metagame.ts:242
+msgctxt "command-option-description"
+msgid "Show the most popular cards in tournaments and the Master Duel ranked ladder."
+msgstr ""
+
+#: src\commands\metagame.ts:312
+msgctxt "command-option-description"
+msgid "Limit card usage statistics to this date range. Has no effect for Master Duel."
 msgstr ""
 
 #: src\commands\art.ts:36
@@ -1169,12 +1220,12 @@ msgctxt "command-name"
 msgid "art"
 msgstr ""
 
-#: src\commands\help.ts:49
+#: src\commands\help.ts:52
 msgctxt "command-name"
 msgid "help"
 msgstr ""
 
-#: src\commands\ping.ts:23
+#: src\commands\ping.ts:25
 msgctxt "command-name"
 msgid "ping"
 msgstr ""
@@ -1189,7 +1240,7 @@ msgctxt "command-name"
 msgid "yugipedia"
 msgstr ""
 
-#: src\commands\deck.ts:119
+#: src\commands\deck.ts:80
 msgctxt "command-name"
 msgid "deck"
 msgstr ""
@@ -1204,24 +1255,34 @@ msgctxt "command-name"
 msgid "locale"
 msgstr ""
 
-#: src\commands\random.ts:44
+#: src\commands\random.ts:43
 msgctxt "command-name"
 msgid "random"
 msgstr ""
 
-#: src\commands\price.ts:89
+#: src\commands\price.ts:90
 msgctxt "command-name"
 msgid "price"
 msgstr ""
 
-#: src\commands\rush-duel.ts:58
+#: src\commands\rush-duel.ts:57
 msgctxt "command-name"
 msgid "rush-duel"
 msgstr ""
 
-#: src\commands\query.ts:30
+#: src\commands\query.ts:29
 msgctxt "command-name"
 msgid "query"
+msgstr ""
+
+#: src\commands\locale-user.ts:31
+msgctxt "command-name"
+msgid "locale-user"
+msgstr ""
+
+#: src\commands\metagame.ts:204
+msgctxt "command-name"
+msgid "metagame"
 msgstr ""
 
 #: src\commands\art.ts:37
@@ -1229,12 +1290,12 @@ msgctxt "command-description"
 msgid "Display the art for a card!"
 msgstr ""
 
-#: src\commands\help.ts:50
+#: src\commands\help.ts:53
 msgctxt "command-description"
 msgid "Get help with a Slash Command."
 msgstr ""
 
-#: src\commands\ping.ts:24
+#: src\commands\ping.ts:26
 msgctxt "command-description"
 msgid "Test latency to the new bot instance."
 msgstr ""
@@ -1249,7 +1310,7 @@ msgctxt "command-description"
 msgid "Search the Yugipedia wiki for a page and link to it."
 msgstr ""
 
-#: src\commands\deck.ts:122
+#: src\commands\deck.ts:83
 msgctxt "command-description"
 msgid "Display a deck list from ydke:// or .ydk format, exported from a number of deck building programs."
 msgstr ""
@@ -1264,24 +1325,34 @@ msgctxt "command-description"
 msgid "Check or set Bastion's locale for this channel or server."
 msgstr ""
 
-#: src\commands\random.ts:45
+#: src\commands\random.ts:44
 msgctxt "command-description"
 msgid "Get a random Yu-Gi-Oh! card."
 msgstr ""
 
-#: src\commands\price.ts:90
+#: src\commands\price.ts:91
 msgctxt "command-description"
 msgid "Display the price for a card!"
 msgstr ""
 
-#: src\commands\rush-duel.ts:59
+#: src\commands\rush-duel.ts:58
 msgctxt "command-description"
 msgid "Find information on Rush Duel cards."
 msgstr ""
 
-#: src\commands\query.ts:31
+#: src\commands\query.ts:30
 msgctxt "command-description"
 msgid "Advanced search prototype"
+msgstr ""
+
+#: src\commands\locale-user.ts:32
+msgctxt "command-description"
+msgid "Check or set user-installed Bastion's locale."
+msgstr ""
+
+#: src\commands\metagame.ts:205
+msgctxt "command-description"
+msgid "Show statistics on the current competitive state of play."
 msgstr ""
 
 #: src\commands\locale.ts:43
@@ -1294,7 +1365,71 @@ msgctxt "command-option-choice"
 msgid "server"
 msgstr ""
 
+#: src\commands\locale-user.ts:49
 #: src\commands\locale.ts:51
 msgctxt "command-option-choice"
 msgid "Discord default"
+msgstr ""
+
+#: src\commands\metagame.ts:219
+#: src\commands\metagame.ts:251
+msgctxt "command-option-choice"
+msgid "TCG"
+msgstr ""
+
+#: src\commands\metagame.ts:220
+#: src\commands\metagame.ts:255
+msgctxt "command-option-choice"
+msgid "OCG"
+msgstr ""
+
+#: src\commands\metagame.ts:221
+#: src\commands\metagame.ts:259
+msgctxt "command-option-choice"
+msgid "OCG (Asian-English)"
+msgstr ""
+
+#: src\commands\metagame.ts:228
+msgctxt "command-option-choice"
+msgid "Master Duel Diamond+ tier list"
+msgstr ""
+
+#: src\commands\metagame.ts:261
+msgctxt "command-option-choice"
+msgid "Master Duel ranked ladder"
+msgstr ""
+
+#: src\commands\metagame.ts:283
+msgctxt "command-option-choice"
+msgid "Current format"
+msgstr ""
+
+#: src\commands\metagame.ts:287
+msgctxt "command-option-choice"
+msgid "Since last Forbidden/Limited List"
+msgstr ""
+
+#: src\commands\metagame.ts:291
+msgctxt "command-option-choice"
+msgid "Last 7 days"
+msgstr ""
+
+#: src\commands\metagame.ts:295
+msgctxt "command-option-choice"
+msgid "Last 14 days"
+msgstr ""
+
+#: src\commands\metagame.ts:299
+msgctxt "command-option-choice"
+msgid "Last 30 days"
+msgstr ""
+
+#: src\commands\metagame.ts:303
+msgctxt "command-option-choice"
+msgid "Last three months"
+msgstr ""
+
+#: src\commands\metagame.ts:307
+msgctxt "command-option-choice"
+msgid "Last six months"
 msgstr ""

--- a/translations/de.po
+++ b/translations/de.po
@@ -6,50 +6,33 @@ msgstr ""
 "MIME-Version: 1.0\n"
 "Content-Transfer-Encoding: 8bit\n"
 
-#: src\card.ts:416
-#: src\rush-duel.ts:39
+#: src\card.ts:412
+#: src\rush-duel.ts:48
 msgid "🔗 Links"
 msgstr ""
 
-#: src\card.ts:417
+#: src\card.ts:413
 #, javascript-format
 msgid "[Official Konami DB](${ official }) | [OCG Rulings](${ rulings }) | [Yugipedia](${ yugipedia }) | [YGOPRODECK](${ ygoprodeck })"
 msgstr ""
 
-#: src\card.ts:420
+#: src\card.ts:416
 #, javascript-format
 msgid "[Yugipedia](${ yugipedia }) | [YGOPRODECK](${ ygoprodeck })"
 msgstr ""
 
-#: src\card.ts:489
-#: src\rush-duel.ts:92
+#: src\card.ts:490
+#: src\rush-duel.ts:103
 #, javascript-format
 msgid "**Type**: ${ raceIcon } ${ localizedMonsterTypeLine }"
 msgstr "**Typ**: ${ raceIcon } ${ localizedMonsterTypeLine }"
 
-#: src\card.ts:491
-#: src\rush-duel.ts:94
-#, javascript-format
-msgid "**Attribute**: ${ AttributeIcon[card.attribute] } ${ localizedAttribute }"
-msgstr "**Eigenschaft**: ${ AttributeIcon[card.attribute] } ${ localizedAttribute }"
-
-#: src\card.ts:495
-#, javascript-format
-msgid "**Rank**: ${ Icon.Rank } ${ card.rank } **ATK**: ${ card.atk } **DEF**: ${ card.def }"
-msgstr "**Rang**: ${ Icon.Rank } ${ card.rank } **ATK**: ${ card.atk } **DEF**: ${ card.def }"
-
-#: src\card.ts:498
+#: src\card.ts:500
 #, javascript-format
 msgid "**Link Rating**: ${ card.link_arrows.length } **ATK**: ${ card.atk } **Link Arrows**: ${ arrows }"
 msgstr ""
 
-#: src\card.ts:500
-#: src\rush-duel.ts:96
-#, javascript-format
-msgid "**Level**: ${ Icon.Level } ${ card.level } **ATK**: ${ card.atk } **DEF**: ${ card.def }"
-msgstr "**Stufe**: ${ Icon.Level } ${ card.level } **ATK**: ${ card.atk } **DEF**: ${ card.def }"
-
-#: src\card.ts:507
+#: src\card.ts:511
 #, javascript-format
 msgid "**Pendulum Scale**: ${ formattedScale }"
 msgstr "**Pendelbereich**: ${ formattedScale }"
@@ -70,7 +53,7 @@ msgid "Password: ${ card.password } | Not yet released"
 msgstr ""
 
 #: src\card.ts:351
-#: src\rush-duel.ts:146
+#: src\rush-duel.ts:158
 msgid "Not yet released"
 msgstr ""
 
@@ -79,64 +62,64 @@ msgstr ""
 msgid "Placeholder ID: ${ card.fake_password }"
 msgstr ""
 
-#: src\utils.ts:41
+#: src\utils.ts:44
 msgid "🛠️ This command is in development."
 msgstr ""
 
-#: src\utils.ts:42
+#: src\utils.ts:45
 msgid "📨 Please send feedback to [our issue tracker](https://github.com/DawnbrandBots/bastion-bot) or the [support server](https://discord.gg/4aFuPyuE96)!"
 msgstr ""
 
-#: src\utils.ts:53
+#: src\utils.ts:56
 msgid "Please consider supporting us!"
 msgstr ""
 
-#: src\utils.ts:54
+#: src\utils.ts:57
 msgid "Help keep Bastion online!"
 msgstr ""
 
-#: src\utils.ts:55
+#: src\utils.ts:58
 msgid "Please help keep Bastion online!"
 msgstr ""
 
-#: src\utils.ts:56
+#: src\utils.ts:59
 msgid "Was Bastion helpful? Consider supporting us!"
 msgstr ""
 
-#: src\utils.ts:57
+#: src\utils.ts:60
 msgid "Was Bastion helpful? We need your support!"
 msgstr ""
 
-#: src\utils.ts:58
+#: src\utils.ts:61
 msgid "Did you find Bastion useful? Consider supporting us!"
 msgstr ""
 
-#: src\utils.ts:59
+#: src\utils.ts:62
 msgid "Did you find Bastion useful? Help keep it online!"
 msgstr ""
 
-#: src\utils.ts:60
+#: src\utils.ts:63
 msgid "Did you find Bastion useful? We need your support!"
 msgstr ""
 
-#: src\utils.ts:61
+#: src\utils.ts:64
 msgid "Enjoy Bastion? Help keep it online!"
 msgstr ""
 
-#: src\utils.ts:62
+#: src\utils.ts:65
 msgid "Enjoy Bastion? Consider supporting us!"
 msgstr ""
 
-#: src\utils.ts:63
+#: src\utils.ts:66
 msgid "Found what you were looking for? Consider supporting us!"
 msgstr ""
 
 #: src\commands\art.ts:63
-#: src\commands\price.ts:131
-#: src\commands\rush-duel.ts:172
-#: src\commands\rush-duel.ts:203
+#: src\commands\price.ts:132
+#: src\commands\rush-duel.ts:171
+#: src\commands\rush-duel.ts:202
 #: src\commands\search.ts:64
-#: src\events\message-search.ts:258
+#: src\events\message-search.ts:265
 #, javascript-format
 msgid "Could not find a card matching `${ input }`!"
 msgstr ""
@@ -147,51 +130,51 @@ msgstr ""
 msgid "Could not find art for `${ name }`!"
 msgstr ""
 
-#: src\commands\deck.ts:244
+#: src\commands\deck.ts:205
 #, javascript-format
 msgid "${ counts.Monster } Monster"
 msgid_plural "${ counts.Monster } Monsters"
 msgstr[0] ""
 msgstr[1] ""
 
-#: src\commands\deck.ts:247
+#: src\commands\deck.ts:208
 #, javascript-format
 msgid "${ counts.Spell } Spell"
 msgid_plural "${ counts.Spell } Spells"
 msgstr[0] ""
 msgstr[1] ""
 
-#: src\commands\deck.ts:250
+#: src\commands\deck.ts:211
 #, javascript-format
 msgid "${ counts.Trap } Trap"
 msgid_plural "${ counts.Trap } Traps"
 msgstr[0] ""
 msgstr[1] ""
 
-#: src\commands\deck.ts:278
+#: src\commands\deck.ts:239
 msgid "Your Deck"
 msgstr ""
 
-#: src\commands\deck.ts:283
+#: src\commands\deck.ts:244
 #, javascript-format
 msgid "Main Deck (${ deck.main.length } card — ${ countDetail })"
 msgid_plural "Main Deck (${ deck.main.length } cards — ${ countDetail })"
 msgstr[0] ""
 msgstr[1] ""
 
-#: src\commands\deck.ts:290
+#: src\commands\deck.ts:251
 msgid "Main Deck (continued)"
 msgstr ""
 
-#: src\commands\deck.ts:304
+#: src\commands\deck.ts:265
 msgid "Extra Deck (continued)"
 msgstr ""
 
-#: src\commands\deck.ts:318
+#: src\commands\deck.ts:279
 msgid "Side Deck (continued)"
 msgstr ""
 
-#: src\commands\deck.ts:407
+#: src\commands\deck.ts:347
 msgid "Error: Your deck is empty."
 msgstr ""
 
@@ -211,11 +194,7 @@ msgstr ""
 msgid "Discord Community locale for this server: ${ interaction.guildLocale }"
 msgstr ""
 
-#: src\commands\locale.ts:89
-#, javascript-format
-msgid "Locale override for this direct message: ${ override }"
-msgstr ""
-
+#: src\commands\locale-user.ts:76
 #: src\commands\locale.ts:92
 #, javascript-format
 msgid "Your Discord locale: ${ interaction.locale }"
@@ -253,24 +232,14 @@ msgstr ""
 msgid "Sorry, you must have the Manage Server permission to do this. If you think this is an error, contact your server admin or report a bug."
 msgstr ""
 
-#: src\commands\locale.ts:146
-#, javascript-format
-msgid "Locale for this direct message overridden with ${ locale }. Your Discord setting is ${ interaction.locale }."
-msgstr ""
-
-#: src\commands\locale.ts:150
-#, javascript-format
-msgid "Locale for this direct message reset to Discord default. Your Discord setting is ${ interaction.locale }."
-msgstr ""
-
-#: src\commands\ping.ts:36
-#: src\events\message-ping.ts:47
+#: src\commands\ping.ts:38
+#: src\events\message-ping.ts:45
 #, javascript-format
 msgid "Average WebSocket ping (new instance): ${ ping } ms"
 msgstr ""
 
-#: src\commands\ping.ts:40
-#: src\events\message-ping.ts:112
+#: src\commands\ping.ts:42
+#: src\events\message-ping.ts:110
 #, javascript-format
 msgid "Total latency: ${ latency } ms"
 msgstr ""
@@ -280,86 +249,69 @@ msgstr ""
 msgid "Could not find a Yugipedia page named `${ page }`."
 msgstr ""
 
-#: src\events\message-ping.ts:49
+#: src\events\message-ping.ts:47
 msgid "Free and open source _Yu-Gi-Oh!_ bot"
 msgstr ""
 
-#: src\events\message-ping.ts:72
+#: src\events\message-ping.ts:70
 #, javascript-format
 msgid "Revision: ${ process.env.BOT_REVISION }."
 msgstr ""
 
-#: src\commands\deck.ts:328
+#: src\commands\deck.ts:289
 msgid ".ydk files must have the .ydk extension!"
 msgstr ""
 
-#: src\commands\deck.ts:331
+#: src\commands\deck.ts:292
 msgid ".ydk files should not be larger than 1 KB!"
 msgstr ""
 
-#: src\commands\deck.ts:321
+#: src\commands\deck.ts:282
 msgid "ydke URL"
 msgstr ""
 
 #: src\card.ts:455
-#: src\rush-duel.ts:61
+#: src\rush-duel.ts:75
 #. Forbidden/Limited Lists or Limit Regulations in the OCG
 #, javascript-format
 msgid "**Limit**: ${ limitRegulationDisplay }"
 msgstr ""
 
-#: src\commands\price.ts:69
+#: src\commands\price.ts:70
 msgid "TCGPlayer"
 msgstr ""
 
-#: src\commands\price.ts:70
+#: src\commands\price.ts:71
 msgid "Cardmarket"
 msgstr ""
 
-#: src\commands\price.ts:147
+#: src\commands\price.ts:148
 msgid "No market price"
 msgstr ""
 
-#: src\commands\price.ts:155
+#: src\commands\price.ts:156
 #, javascript-format
 msgid "Prices for ${ card.name[resultLanguage] } - ${ vendorName }"
 msgstr ""
 
-#: src\commands\price.ts:169
+#: src\commands\price.ts:170
 #, javascript-format
 msgid "Could not find prices for `${ name }`!"
 msgstr ""
 
-#: src\commands\deck.ts:425
-#. prepare interaction button for FTP upload
+#: src\commands\deck.ts:363
 msgid "Upload to YGOPRODECK"
 msgstr ""
 
-#: src\commands\deck.ts:483
-#. disable original button
-#. prepare row to disable button on original message
-msgid "Upload Complete"
-msgstr ""
-
-#: src\commands\deck.ts:470
-msgid "Deck upload failed!"
-msgstr ""
-
-#: src\commands\deck.ts:491
-#. reply in affirmation
-#, javascript-format
-msgid "Deck successfully uploaded to <${ url }>!"
-msgstr ""
-
-#: src\events\message-search.ts:264
+#: src\events\message-search.ts:271
 msgid "💬 Translations missing?"
 msgstr ""
 
-#: src\events\message-search.ts:265
+#: src\events\message-search.ts:272
 msgid "Help translate Bastion at the links above."
 msgstr ""
 
-#: src\events\message-ping.ts:50
+#: src\events\message-ping.ts:48
 msgid ""
 "❓ Help documentation on [GitHub](https://github.com/DawnbrandBots/bastion-bot), or use `.commands` and `.help`.\n"
 "🟢 Licence: [GNU AGPL 3.0+](https://choosealicense.com/licenses/agpl-3.0/).\n"
@@ -375,38 +327,38 @@ msgid ""
 "💬 Translations missing? Help translate Bastion on [GitHub](https://github.com/DawnbrandBots/bastion-bot)."
 msgstr ""
 
-#: src\events\message-search.ts:256
-#: src\events\message-search.ts:294
+#: src\events\message-search.ts:263
+#: src\events\message-search.ts:302
 #, javascript-format
 msgid "Search type: ${ localisedType }"
 msgstr ""
 
-#: src\events\message-search.ts:236
+#: src\events\message-search.ts:242
 #, javascript-format
 msgid "Search language: **${ localisedInputLanguage }** (${ inputLanguage }). Check defaults with </locale get:${ id }> and configure with </locale set:${ id }>"
 msgstr ""
 
-#: src\events\message-ping.ts:95
+#: src\events\message-ping.ts:93
 msgid "⚠️ You pinged me, but I am missing permissions in the channel!"
 msgstr ""
 
-#: src\events\message-ping.ts:98
-#: src\events\message-search.ts:332
+#: src\events\message-ping.ts:96
+#: src\events\message-search.ts:340
 msgid "Please have a server administrator [fix this](https://github.com/DawnbrandBots/bastion-bot#discord-permissions)."
 msgstr ""
 
-#: src\events\message-search.ts:329
+#: src\events\message-search.ts:337
 msgid "⚠️ I am missing permissions in the channel!"
 msgstr ""
 
-#: src\commands\deck.ts:297
+#: src\commands\deck.ts:258
 #, javascript-format
 msgid "Extra Deck (${ deck.extra.length } card — ${ countDetail })"
 msgid_plural "Extra Deck (${ deck.extra.length } cards — ${ countDetail })"
 msgstr[0] ""
 msgstr[1] ""
 
-#: src\commands\deck.ts:311
+#: src\commands\deck.ts:272
 #, javascript-format
 msgid "Side Deck (${ deck.side.length } card — ${ countDetail })"
 msgid_plural "Side Deck (${ deck.side.length } cards — ${ countDetail })"
@@ -428,48 +380,82 @@ msgstr ""
 msgid "Something went wrong searching Yugipedia for `${ page }`."
 msgstr ""
 
-#: src\rush-duel.ts:40
+#: src\rush-duel.ts:49
 #, javascript-format
 msgid "[Official Konami DB](${ official }) | [Rulings (Japanese)](${ rulings }) | [Yugipedia](${ yugipedia }) | [RushCard](${ rushcard })"
 msgstr ""
 
-#: src\rush-duel.ts:43
+#: src\rush-duel.ts:52
 #, javascript-format
 msgid "[Yugipedia](${ yugipedia }) | [RushCard](${ rushcard })"
 msgstr ""
 
-#: src\rush-duel.ts:57
+#: src\rush-duel.ts:71
 msgid "__**LEGEND**__"
 msgstr ""
 
-#: src\rush-duel.ts:99
+#: src\rush-duel.ts:110
 #, javascript-format
 msgid "**MAXIMUM ATK**: ${ card.maximum_atk }"
 msgstr ""
 
-#: src\rush-duel.ts:146
+#: src\rush-duel.ts:158
 #, javascript-format
 msgid "Konami ID #${ card.konami_id }"
 msgstr ""
 
 #: src\art.ts:129
-#: src\commands\deck.ts:451
 msgid "Buttons can only be used by the user who called Bastion."
 msgstr ""
 
-#: src\card.ts:462
-#, javascript-format
-msgid "**Master Duel rarity**: ${ rarity_icon } ${ localized_rarity }"
-msgstr ""
-
-#: src\rush-duel.ts:205
+#: src\rush-duel.ts:217
 #, javascript-format
 msgid "Using ${ searchTrigger }, you can search for Rush Duel cards directly in messages without autocomplete"
 msgstr ""
 
-#: src\events\message-search.ts:296
+#: src\events\message-search.ts:304
 #, javascript-format
 msgid "Could not find a Rush Duel card matching `${ input }`!"
+msgstr ""
+
+#: src\card.ts:462
+#, javascript-format
+msgid "**Master Duel rarity**: ${ rarityIcon } ${ localizedRarity }"
+msgstr ""
+
+#: src\card.ts:492
+#: src\rush-duel.ts:105
+#, javascript-format
+msgid "**Attribute**: ${ attributeIcon } ${ localizedAttribute }"
+msgstr ""
+
+#: src\card.ts:497
+#, javascript-format
+msgid "**Rank**: ${ rankIcon } ${ card.rank } **ATK**: ${ card.atk } **DEF**: ${ card.def }"
+msgstr ""
+
+#: src\card.ts:503
+#: src\rush-duel.ts:107
+#, javascript-format
+msgid "**Level**: ${ levelIcon } ${ card.level } **ATK**: ${ card.atk } **DEF**: ${ card.def }"
+msgstr ""
+
+#: src\commands\locale-user.ts:73
+#: src\commands\locale.ts:89
+#, javascript-format
+msgid "Locale override for your direct messages: ${ override }"
+msgstr ""
+
+#: src\commands\locale-user.ts:83
+#: src\commands\locale.ts:146
+#, javascript-format
+msgid "Locale for your direct messages overridden with ${ locale }. Your Discord setting is ${ interaction.locale }."
+msgstr ""
+
+#: src\commands\locale-user.ts:87
+#: src\commands\locale.ts:150
+#, javascript-format
+msgid "Locale for your direct messages reset to Discord default. Your Discord setting is ${ interaction.locale }."
 msgstr ""
 
 #: src\card.ts:40
@@ -836,65 +822,65 @@ msgctxt "master-duel-rarity"
 msgid "Ultra Rare (UR)"
 msgstr "Ultra Rare (UR)"
 
-#: src\card.ts:513
-#: src\card.ts:524
-#: src\rush-duel.ts:127
+#: src\card.ts:517
+#: src\card.ts:528
+#: src\rush-duel.ts:138
 msgctxt "card-embed"
 msgid "Card Text"
 msgstr "Kartentext"
 
-#: src\card.ts:518
+#: src\card.ts:522
 msgctxt "card-embed"
 msgid "Pendulum Effect"
 msgstr "Pendeleffekt"
 
-#: src\card.ts:539
+#: src\card.ts:545
 msgctxt "card-embed"
 msgid "Card Effect"
 msgstr ""
 
-#: src\rush-duel.ts:118
-#: src\rush-duel.ts:139
+#: src\rush-duel.ts:129
+#: src\rush-duel.ts:151
 msgctxt "card-embed"
 msgid "[REQUIREMENT]"
 msgstr "[BEDINGUNG]"
 
-#: src\rush-duel.ts:119
-#: src\rush-duel.ts:140
+#: src\rush-duel.ts:130
+#: src\rush-duel.ts:152
 msgctxt "card-embed"
 msgid "[EFFECT]"
 msgstr "[EFFEKT]"
 
-#: src\rush-duel.ts:121
+#: src\rush-duel.ts:132
 msgctxt "card-embed"
 msgid "[CONTINUOUS EFFECT]"
 msgstr "[DAUEREFFEKT]"
 
-#: src\rush-duel.ts:123
+#: src\rush-duel.ts:134
 msgctxt "card-embed"
 msgid "[MULTI-CHOICE EFFECT]"
 msgstr ""
 
-#: src\locale.ts:71
+#: src\locale.ts:74
 msgctxt "command-option"
 msgid "result-language"
 msgstr ""
 
-#: src\locale.ts:131
+#: src\locale.ts:140
 msgctxt "command-option"
 msgid "input-language"
 msgstr ""
 
-#: src\commands\rush-duel.ts:68
-#: src\commands\rush-duel.ts:80
-#: src\locale.ts:147
-#: src\locale.ts:165
-#: src\locale.ts:181
+#: src\commands\rush-duel.ts:67
+#: src\commands\rush-duel.ts:79
+#: src\locale.ts:156
+#: src\locale.ts:174
+#: src\locale.ts:190
 msgctxt "command-option"
 msgid "input"
 msgstr ""
 
-#: src\commands\help.ts:52
+#: src\commands\help.ts:55
 msgctxt "command-option"
 msgid "command"
 msgstr ""
@@ -909,54 +895,56 @@ msgctxt "command-option"
 msgid "page"
 msgstr ""
 
-#: src\commands\deck.ts:126
+#: src\commands\deck.ts:87
 msgctxt "command-option"
 msgid "url"
 msgstr ""
 
-#: src\commands\deck.ts:132
+#: src\commands\deck.ts:93
 msgctxt "command-option"
 msgid "file"
 msgstr ""
 
-#: src\commands\deck.ts:138
-#: src\commands\deck.ts:144
+#: src\commands\deck.ts:99
+#: src\commands\deck.ts:105
 msgctxt "command-option"
 msgid "deck"
 msgstr ""
 
-#: src\commands\deck.ts:150
+#: src\commands\deck.ts:111
 msgctxt "command-option"
 msgid "public"
 msgstr ""
 
-#: src\commands\deck.ts:157
+#: src\commands\deck.ts:118
 msgctxt "command-option"
 msgid "stacked"
 msgstr ""
 
-#: src\locale.ts:142
+#: src\locale.ts:151
 msgctxt "command-option"
 msgid "name"
 msgstr ""
 
-#: src\locale.ts:160
+#: src\locale.ts:169
 msgctxt "command-option"
 msgid "password"
 msgstr ""
 
-#: src\commands\rush-duel.ts:73
-#: src\events\message-search.ts:293
-#: src\locale.ts:176
+#: src\commands\rush-duel.ts:72
+#: src\events\message-search.ts:301
+#: src\locale.ts:185
 msgctxt "command-option"
 msgid "konami-id"
 msgstr ""
 
+#: src\commands\locale-user.ts:36
 #: src\commands\locale.ts:30
 msgctxt "command-option"
 msgid "get"
 msgstr ""
 
+#: src\commands\locale-user.ts:41
 #: src\commands\locale.ts:35
 msgctxt "command-option"
 msgid "set"
@@ -967,47 +955,69 @@ msgctxt "command-option"
 msgid "scope"
 msgstr ""
 
+#: src\commands\locale-user.ts:46
 #: src\commands\locale.ts:48
 msgctxt "command-option"
 msgid "locale"
 msgstr ""
 
-#: src\commands\price.ts:94
+#: src\commands\price.ts:95
 msgctxt "command-option"
 msgid "vendor"
 msgstr ""
 
-#: src\commands\rush-duel.ts:63
+#: src\commands\rush-duel.ts:62
 msgctxt "command-option"
 msgid "search"
 msgstr ""
 
-#: src\commands\rush-duel.ts:85
+#: src\commands\rush-duel.ts:84
 msgctxt "command-option"
 msgid "random"
 msgstr ""
 
-#: src\commands\rush-duel.ts:90
+#: src\commands\rush-duel.ts:89
 msgctxt "command-option"
 msgid "art"
 msgstr ""
 
-#: src\commands\query.ts:36
+#: src\commands\query.ts:35
 msgctxt "command-option"
 msgid "lucene"
 msgstr ""
 
-#: src\locale.ts:74
+#: src\commands\metagame.ts:209
+msgctxt "command-option"
+msgid "strategies"
+msgstr ""
+
+#: src\commands\metagame.ts:234
+#: src\commands\metagame.ts:274
+msgctxt "command-option"
+msgid "format"
+msgstr ""
+
+#: src\commands\metagame.ts:240
+msgctxt "command-option"
+msgid "cards"
+msgstr ""
+
+#: src\commands\metagame.ts:310
+msgctxt "command-option"
+msgid "date-range"
+msgstr ""
+
+#: src\locale.ts:77
 msgctxt "command-option-description"
 msgid "The output language for the card embed, overriding other settings."
 msgstr ""
 
-#: src\locale.ts:132
+#: src\locale.ts:141
 msgctxt "command-option-description"
 msgid "The language to search in, defaulting to the result language."
 msgstr ""
 
-#: src\commands\help.ts:55
+#: src\commands\help.ts:58
 msgctxt "command-option-description"
 msgid "The name of a specific Slash Command."
 msgstr ""
@@ -1017,32 +1027,32 @@ msgctxt "command-option-description"
 msgid "The name of the Yugipedia page you want to search for."
 msgstr ""
 
-#: src\commands\deck.ts:129
+#: src\commands\deck.ts:90
 msgctxt "command-option-description"
 msgid "View a deck by entering a ydke:// URL."
 msgstr ""
 
-#: src\commands\deck.ts:135
+#: src\commands\deck.ts:96
 msgctxt "command-option-description"
 msgid "View a deck by uploading a .ydk file."
 msgstr ""
 
-#: src\commands\deck.ts:141
+#: src\commands\deck.ts:102
 msgctxt "command-option-description"
 msgid "The ydke:// URL of the deck you want to view."
 msgstr ""
 
-#: src\commands\deck.ts:147
+#: src\commands\deck.ts:108
 msgctxt "command-option-description"
 msgid "The .ydk file of the deck you want to view."
 msgstr ""
 
-#: src\commands\deck.ts:153
+#: src\commands\deck.ts:114
 msgctxt "command-option-description"
 msgid "Whether to display the deck details publicly in chat. This is false by default."
 msgstr ""
 
-#: src\commands\deck.ts:160
+#: src\commands\deck.ts:121
 msgctxt "command-option-description"
 msgid "Whether to display the deck sections as one stacked column. This is false (side-by-side) by default."
 msgstr ""
@@ -1052,8 +1062,8 @@ msgctxt "command-option-description"
 msgid "Display the art for the card with this name."
 msgstr ""
 
-#: src\commands\rush-duel.ts:69
-#: src\locale.ts:148
+#: src\commands\rush-duel.ts:68
+#: src\locale.ts:157
 msgctxt "command-option-description"
 msgid "Card name, fuzzy matching supported."
 msgstr ""
@@ -1063,7 +1073,7 @@ msgctxt "command-option-description"
 msgid "Display the art for the card with this password."
 msgstr ""
 
-#: src\locale.ts:167
+#: src\locale.ts:176
 msgctxt "command-option-description"
 msgid "Card password, the eight-digit number printed on the bottom left corner."
 msgstr ""
@@ -1073,8 +1083,8 @@ msgctxt "command-option-description"
 msgid "Display the art for the card with this official database ID."
 msgstr ""
 
-#: src\commands\rush-duel.ts:81
-#: src\locale.ts:182
+#: src\commands\rush-duel.ts:80
+#: src\locale.ts:191
 msgctxt "command-option-description"
 msgid "Konami's official card database identifier."
 msgstr ""
@@ -1114,22 +1124,22 @@ msgctxt "command-option-description"
 msgid "The new default language to use in this channel or server."
 msgstr ""
 
-#: src\commands\price.ts:98
+#: src\commands\price.ts:99
 msgctxt "command-option-description"
 msgid "Display the price for the card with this name."
 msgstr ""
 
-#: src\commands\price.ts:102
+#: src\commands\price.ts:103
 msgctxt "command-option-description"
 msgid "Display the price for the card with this password."
 msgstr ""
 
-#: src\commands\price.ts:105
+#: src\commands\price.ts:106
 msgctxt "command-option-description"
 msgid "Display the price for the card with this official database ID."
 msgstr ""
 
-#: src\commands\price.ts:95
+#: src\commands\price.ts:96
 msgctxt "command-option-description"
 msgid "The vendor to fetch the price data from."
 msgstr ""
@@ -1139,29 +1149,70 @@ msgctxt "command-option-description"
 msgid "The English name of the card you're looking for."
 msgstr ""
 
-#: src\commands\rush-duel.ts:64
+#: src\commands\rush-duel.ts:63
 msgctxt "command-option-description"
 msgid "Find all information for the Rush Duel card with this name."
 msgstr ""
 
-#: src\commands\rush-duel.ts:75
+#: src\commands\rush-duel.ts:74
 msgctxt "command-option-description"
 msgid "Find all information for the Rush Duel card with this official database ID."
 msgstr ""
 
-#: src\commands\rush-duel.ts:86
+#: src\commands\rush-duel.ts:85
 msgctxt "command-option-description"
 msgid "Get a random Rush Duel card."
 msgstr ""
 
-#: src\commands\rush-duel.ts:91
+#: src\commands\rush-duel.ts:90
 msgctxt "command-option-description"
 msgid "Display just the art for the Rush Duel card with this name."
 msgstr ""
 
-#: src\commands\query.ts:37
+#: src\commands\query.ts:36
 msgctxt "command-option-description"
 msgid "Lucene query on YAML Yugi"
+msgstr ""
+
+#: src\commands\locale-user.ts:37
+msgctxt "command-option-description"
+msgid "Check your user-installed Bastion's locale."
+msgstr ""
+
+#: src\commands\locale-user.ts:42
+msgctxt "command-option-description"
+msgid "Configure your user-installed Bastion's locale."
+msgstr ""
+
+#: src\commands\locale-user.ts:47
+msgctxt "command-option-description"
+msgid "The new default language to use for user-installed Bastion."
+msgstr ""
+
+#: src\commands\metagame.ts:212
+msgctxt "command-option-description"
+msgid "Show the top competitive strategies in tournaments and the Master Duel ranked ladder."
+msgstr ""
+
+#: src\commands\metagame.ts:214
+msgctxt "command-option-description"
+msgid "Show the top competitive strategies in tournaments."
+msgstr ""
+
+#: src\commands\metagame.ts:235
+#: src\commands\metagame.ts:275
+msgctxt "command-option-description"
+msgid "Game region."
+msgstr ""
+
+#: src\commands\metagame.ts:242
+msgctxt "command-option-description"
+msgid "Show the most popular cards in tournaments and the Master Duel ranked ladder."
+msgstr ""
+
+#: src\commands\metagame.ts:312
+msgctxt "command-option-description"
+msgid "Limit card usage statistics to this date range. Has no effect for Master Duel."
 msgstr ""
 
 #: src\commands\art.ts:36
@@ -1169,12 +1220,12 @@ msgctxt "command-name"
 msgid "art"
 msgstr ""
 
-#: src\commands\help.ts:49
+#: src\commands\help.ts:52
 msgctxt "command-name"
 msgid "help"
 msgstr ""
 
-#: src\commands\ping.ts:23
+#: src\commands\ping.ts:25
 msgctxt "command-name"
 msgid "ping"
 msgstr ""
@@ -1189,7 +1240,7 @@ msgctxt "command-name"
 msgid "yugipedia"
 msgstr ""
 
-#: src\commands\deck.ts:119
+#: src\commands\deck.ts:80
 msgctxt "command-name"
 msgid "deck"
 msgstr ""
@@ -1204,24 +1255,34 @@ msgctxt "command-name"
 msgid "locale"
 msgstr ""
 
-#: src\commands\random.ts:44
+#: src\commands\random.ts:43
 msgctxt "command-name"
 msgid "random"
 msgstr ""
 
-#: src\commands\price.ts:89
+#: src\commands\price.ts:90
 msgctxt "command-name"
 msgid "price"
 msgstr ""
 
-#: src\commands\rush-duel.ts:58
+#: src\commands\rush-duel.ts:57
 msgctxt "command-name"
 msgid "rush-duel"
 msgstr ""
 
-#: src\commands\query.ts:30
+#: src\commands\query.ts:29
 msgctxt "command-name"
 msgid "query"
+msgstr ""
+
+#: src\commands\locale-user.ts:31
+msgctxt "command-name"
+msgid "locale-user"
+msgstr ""
+
+#: src\commands\metagame.ts:204
+msgctxt "command-name"
+msgid "metagame"
 msgstr ""
 
 #: src\commands\art.ts:37
@@ -1229,12 +1290,12 @@ msgctxt "command-description"
 msgid "Display the art for a card!"
 msgstr ""
 
-#: src\commands\help.ts:50
+#: src\commands\help.ts:53
 msgctxt "command-description"
 msgid "Get help with a Slash Command."
 msgstr ""
 
-#: src\commands\ping.ts:24
+#: src\commands\ping.ts:26
 msgctxt "command-description"
 msgid "Test latency to the new bot instance."
 msgstr ""
@@ -1249,7 +1310,7 @@ msgctxt "command-description"
 msgid "Search the Yugipedia wiki for a page and link to it."
 msgstr ""
 
-#: src\commands\deck.ts:122
+#: src\commands\deck.ts:83
 msgctxt "command-description"
 msgid "Display a deck list from ydke:// or .ydk format, exported from a number of deck building programs."
 msgstr ""
@@ -1264,24 +1325,34 @@ msgctxt "command-description"
 msgid "Check or set Bastion's locale for this channel or server."
 msgstr ""
 
-#: src\commands\random.ts:45
+#: src\commands\random.ts:44
 msgctxt "command-description"
 msgid "Get a random Yu-Gi-Oh! card."
 msgstr ""
 
-#: src\commands\price.ts:90
+#: src\commands\price.ts:91
 msgctxt "command-description"
 msgid "Display the price for a card!"
 msgstr ""
 
-#: src\commands\rush-duel.ts:59
+#: src\commands\rush-duel.ts:58
 msgctxt "command-description"
 msgid "Find information on Rush Duel cards."
 msgstr ""
 
-#: src\commands\query.ts:31
+#: src\commands\query.ts:30
 msgctxt "command-description"
 msgid "Advanced search prototype"
+msgstr ""
+
+#: src\commands\locale-user.ts:32
+msgctxt "command-description"
+msgid "Check or set user-installed Bastion's locale."
+msgstr ""
+
+#: src\commands\metagame.ts:205
+msgctxt "command-description"
+msgid "Show statistics on the current competitive state of play."
 msgstr ""
 
 #: src\commands\locale.ts:43
@@ -1294,7 +1365,71 @@ msgctxt "command-option-choice"
 msgid "server"
 msgstr ""
 
+#: src\commands\locale-user.ts:49
 #: src\commands\locale.ts:51
 msgctxt "command-option-choice"
 msgid "Discord default"
+msgstr ""
+
+#: src\commands\metagame.ts:219
+#: src\commands\metagame.ts:251
+msgctxt "command-option-choice"
+msgid "TCG"
+msgstr ""
+
+#: src\commands\metagame.ts:220
+#: src\commands\metagame.ts:255
+msgctxt "command-option-choice"
+msgid "OCG"
+msgstr ""
+
+#: src\commands\metagame.ts:221
+#: src\commands\metagame.ts:259
+msgctxt "command-option-choice"
+msgid "OCG (Asian-English)"
+msgstr ""
+
+#: src\commands\metagame.ts:228
+msgctxt "command-option-choice"
+msgid "Master Duel Diamond+ tier list"
+msgstr ""
+
+#: src\commands\metagame.ts:261
+msgctxt "command-option-choice"
+msgid "Master Duel ranked ladder"
+msgstr ""
+
+#: src\commands\metagame.ts:283
+msgctxt "command-option-choice"
+msgid "Current format"
+msgstr ""
+
+#: src\commands\metagame.ts:287
+msgctxt "command-option-choice"
+msgid "Since last Forbidden/Limited List"
+msgstr ""
+
+#: src\commands\metagame.ts:291
+msgctxt "command-option-choice"
+msgid "Last 7 days"
+msgstr ""
+
+#: src\commands\metagame.ts:295
+msgctxt "command-option-choice"
+msgid "Last 14 days"
+msgstr ""
+
+#: src\commands\metagame.ts:299
+msgctxt "command-option-choice"
+msgid "Last 30 days"
+msgstr ""
+
+#: src\commands\metagame.ts:303
+msgctxt "command-option-choice"
+msgid "Last three months"
+msgstr ""
+
+#: src\commands\metagame.ts:307
+msgctxt "command-option-choice"
+msgid "Last six months"
 msgstr ""

--- a/translations/de.po
+++ b/translations/de.po
@@ -6,33 +6,50 @@ msgstr ""
 "MIME-Version: 1.0\n"
 "Content-Transfer-Encoding: 8bit\n"
 
-#: src\card.ts:412
-#: src\rush-duel.ts:48
+#: src\card.ts:416
+#: src\rush-duel.ts:39
 msgid "🔗 Links"
 msgstr ""
 
-#: src\card.ts:413
+#: src\card.ts:417
 #, javascript-format
 msgid "[Official Konami DB](${ official }) | [OCG Rulings](${ rulings }) | [Yugipedia](${ yugipedia }) | [YGOPRODECK](${ ygoprodeck })"
 msgstr ""
 
-#: src\card.ts:416
+#: src\card.ts:420
 #, javascript-format
 msgid "[Yugipedia](${ yugipedia }) | [YGOPRODECK](${ ygoprodeck })"
 msgstr ""
 
-#: src\card.ts:490
-#: src\rush-duel.ts:103
+#: src\card.ts:489
+#: src\rush-duel.ts:92
 #, javascript-format
 msgid "**Type**: ${ raceIcon } ${ localizedMonsterTypeLine }"
 msgstr "**Typ**: ${ raceIcon } ${ localizedMonsterTypeLine }"
 
-#: src\card.ts:500
+#: src\card.ts:491
+#: src\rush-duel.ts:94
+#, javascript-format
+msgid "**Attribute**: ${ AttributeIcon[card.attribute] } ${ localizedAttribute }"
+msgstr "**Eigenschaft**: ${ AttributeIcon[card.attribute] } ${ localizedAttribute }"
+
+#: src\card.ts:495
+#, javascript-format
+msgid "**Rank**: ${ Icon.Rank } ${ card.rank } **ATK**: ${ card.atk } **DEF**: ${ card.def }"
+msgstr "**Rang**: ${ Icon.Rank } ${ card.rank } **ATK**: ${ card.atk } **DEF**: ${ card.def }"
+
+#: src\card.ts:498
 #, javascript-format
 msgid "**Link Rating**: ${ card.link_arrows.length } **ATK**: ${ card.atk } **Link Arrows**: ${ arrows }"
 msgstr ""
 
-#: src\card.ts:511
+#: src\card.ts:500
+#: src\rush-duel.ts:96
+#, javascript-format
+msgid "**Level**: ${ Icon.Level } ${ card.level } **ATK**: ${ card.atk } **DEF**: ${ card.def }"
+msgstr "**Stufe**: ${ Icon.Level } ${ card.level } **ATK**: ${ card.atk } **DEF**: ${ card.def }"
+
+#: src\card.ts:507
 #, javascript-format
 msgid "**Pendulum Scale**: ${ formattedScale }"
 msgstr "**Pendelbereich**: ${ formattedScale }"
@@ -53,7 +70,7 @@ msgid "Password: ${ card.password } | Not yet released"
 msgstr ""
 
 #: src\card.ts:351
-#: src\rush-duel.ts:158
+#: src\rush-duel.ts:146
 msgid "Not yet released"
 msgstr ""
 
@@ -62,64 +79,64 @@ msgstr ""
 msgid "Placeholder ID: ${ card.fake_password }"
 msgstr ""
 
-#: src\utils.ts:44
+#: src\utils.ts:41
 msgid "🛠️ This command is in development."
 msgstr ""
 
-#: src\utils.ts:45
+#: src\utils.ts:42
 msgid "📨 Please send feedback to [our issue tracker](https://github.com/DawnbrandBots/bastion-bot) or the [support server](https://discord.gg/4aFuPyuE96)!"
 msgstr ""
 
-#: src\utils.ts:56
+#: src\utils.ts:53
 msgid "Please consider supporting us!"
 msgstr ""
 
-#: src\utils.ts:57
+#: src\utils.ts:54
 msgid "Help keep Bastion online!"
 msgstr ""
 
-#: src\utils.ts:58
+#: src\utils.ts:55
 msgid "Please help keep Bastion online!"
 msgstr ""
 
-#: src\utils.ts:59
+#: src\utils.ts:56
 msgid "Was Bastion helpful? Consider supporting us!"
 msgstr ""
 
-#: src\utils.ts:60
+#: src\utils.ts:57
 msgid "Was Bastion helpful? We need your support!"
 msgstr ""
 
-#: src\utils.ts:61
+#: src\utils.ts:58
 msgid "Did you find Bastion useful? Consider supporting us!"
 msgstr ""
 
-#: src\utils.ts:62
+#: src\utils.ts:59
 msgid "Did you find Bastion useful? Help keep it online!"
 msgstr ""
 
-#: src\utils.ts:63
+#: src\utils.ts:60
 msgid "Did you find Bastion useful? We need your support!"
 msgstr ""
 
-#: src\utils.ts:64
+#: src\utils.ts:61
 msgid "Enjoy Bastion? Help keep it online!"
 msgstr ""
 
-#: src\utils.ts:65
+#: src\utils.ts:62
 msgid "Enjoy Bastion? Consider supporting us!"
 msgstr ""
 
-#: src\utils.ts:66
+#: src\utils.ts:63
 msgid "Found what you were looking for? Consider supporting us!"
 msgstr ""
 
 #: src\commands\art.ts:63
-#: src\commands\price.ts:132
-#: src\commands\rush-duel.ts:171
-#: src\commands\rush-duel.ts:202
+#: src\commands\price.ts:131
+#: src\commands\rush-duel.ts:172
+#: src\commands\rush-duel.ts:203
 #: src\commands\search.ts:64
-#: src\events\message-search.ts:265
+#: src\events\message-search.ts:258
 #, javascript-format
 msgid "Could not find a card matching `${ input }`!"
 msgstr ""
@@ -130,51 +147,51 @@ msgstr ""
 msgid "Could not find art for `${ name }`!"
 msgstr ""
 
-#: src\commands\deck.ts:205
+#: src\commands\deck.ts:244
 #, javascript-format
 msgid "${ counts.Monster } Monster"
 msgid_plural "${ counts.Monster } Monsters"
 msgstr[0] ""
 msgstr[1] ""
 
-#: src\commands\deck.ts:208
+#: src\commands\deck.ts:247
 #, javascript-format
 msgid "${ counts.Spell } Spell"
 msgid_plural "${ counts.Spell } Spells"
 msgstr[0] ""
 msgstr[1] ""
 
-#: src\commands\deck.ts:211
+#: src\commands\deck.ts:250
 #, javascript-format
 msgid "${ counts.Trap } Trap"
 msgid_plural "${ counts.Trap } Traps"
 msgstr[0] ""
 msgstr[1] ""
 
-#: src\commands\deck.ts:239
+#: src\commands\deck.ts:278
 msgid "Your Deck"
 msgstr ""
 
-#: src\commands\deck.ts:244
+#: src\commands\deck.ts:283
 #, javascript-format
 msgid "Main Deck (${ deck.main.length } card — ${ countDetail })"
 msgid_plural "Main Deck (${ deck.main.length } cards — ${ countDetail })"
 msgstr[0] ""
 msgstr[1] ""
 
-#: src\commands\deck.ts:251
+#: src\commands\deck.ts:290
 msgid "Main Deck (continued)"
 msgstr ""
 
-#: src\commands\deck.ts:265
+#: src\commands\deck.ts:304
 msgid "Extra Deck (continued)"
 msgstr ""
 
-#: src\commands\deck.ts:279
+#: src\commands\deck.ts:318
 msgid "Side Deck (continued)"
 msgstr ""
 
-#: src\commands\deck.ts:347
+#: src\commands\deck.ts:407
 msgid "Error: Your deck is empty."
 msgstr ""
 
@@ -194,7 +211,11 @@ msgstr ""
 msgid "Discord Community locale for this server: ${ interaction.guildLocale }"
 msgstr ""
 
-#: src\commands\locale-user.ts:76
+#: src\commands\locale.ts:89
+#, javascript-format
+msgid "Locale override for this direct message: ${ override }"
+msgstr ""
+
 #: src\commands\locale.ts:92
 #, javascript-format
 msgid "Your Discord locale: ${ interaction.locale }"
@@ -232,14 +253,24 @@ msgstr ""
 msgid "Sorry, you must have the Manage Server permission to do this. If you think this is an error, contact your server admin or report a bug."
 msgstr ""
 
-#: src\commands\ping.ts:38
-#: src\events\message-ping.ts:45
+#: src\commands\locale.ts:146
+#, javascript-format
+msgid "Locale for this direct message overridden with ${ locale }. Your Discord setting is ${ interaction.locale }."
+msgstr ""
+
+#: src\commands\locale.ts:150
+#, javascript-format
+msgid "Locale for this direct message reset to Discord default. Your Discord setting is ${ interaction.locale }."
+msgstr ""
+
+#: src\commands\ping.ts:36
+#: src\events\message-ping.ts:47
 #, javascript-format
 msgid "Average WebSocket ping (new instance): ${ ping } ms"
 msgstr ""
 
-#: src\commands\ping.ts:42
-#: src\events\message-ping.ts:110
+#: src\commands\ping.ts:40
+#: src\events\message-ping.ts:112
 #, javascript-format
 msgid "Total latency: ${ latency } ms"
 msgstr ""
@@ -249,69 +280,86 @@ msgstr ""
 msgid "Could not find a Yugipedia page named `${ page }`."
 msgstr ""
 
-#: src\events\message-ping.ts:47
+#: src\events\message-ping.ts:49
 msgid "Free and open source _Yu-Gi-Oh!_ bot"
 msgstr ""
 
-#: src\events\message-ping.ts:70
+#: src\events\message-ping.ts:72
 #, javascript-format
 msgid "Revision: ${ process.env.BOT_REVISION }."
 msgstr ""
 
-#: src\commands\deck.ts:289
+#: src\commands\deck.ts:328
 msgid ".ydk files must have the .ydk extension!"
 msgstr ""
 
-#: src\commands\deck.ts:292
+#: src\commands\deck.ts:331
 msgid ".ydk files should not be larger than 1 KB!"
 msgstr ""
 
-#: src\commands\deck.ts:282
+#: src\commands\deck.ts:321
 msgid "ydke URL"
 msgstr ""
 
 #: src\card.ts:455
-#: src\rush-duel.ts:75
+#: src\rush-duel.ts:61
 #. Forbidden/Limited Lists or Limit Regulations in the OCG
 #, javascript-format
 msgid "**Limit**: ${ limitRegulationDisplay }"
 msgstr ""
 
-#: src\commands\price.ts:70
+#: src\commands\price.ts:69
 msgid "TCGPlayer"
 msgstr ""
 
-#: src\commands\price.ts:71
+#: src\commands\price.ts:70
 msgid "Cardmarket"
 msgstr ""
 
-#: src\commands\price.ts:148
+#: src\commands\price.ts:147
 msgid "No market price"
 msgstr ""
 
-#: src\commands\price.ts:156
+#: src\commands\price.ts:155
 #, javascript-format
 msgid "Prices for ${ card.name[resultLanguage] } - ${ vendorName }"
 msgstr ""
 
-#: src\commands\price.ts:170
+#: src\commands\price.ts:169
 #, javascript-format
 msgid "Could not find prices for `${ name }`!"
 msgstr ""
 
-#: src\commands\deck.ts:363
+#: src\commands\deck.ts:425
+#. prepare interaction button for FTP upload
 msgid "Upload to YGOPRODECK"
 msgstr ""
 
-#: src\events\message-search.ts:271
+#: src\commands\deck.ts:483
+#. disable original button
+#. prepare row to disable button on original message
+msgid "Upload Complete"
+msgstr ""
+
+#: src\commands\deck.ts:470
+msgid "Deck upload failed!"
+msgstr ""
+
+#: src\commands\deck.ts:491
+#. reply in affirmation
+#, javascript-format
+msgid "Deck successfully uploaded to <${ url }>!"
+msgstr ""
+
+#: src\events\message-search.ts:264
 msgid "💬 Translations missing?"
 msgstr ""
 
-#: src\events\message-search.ts:272
+#: src\events\message-search.ts:265
 msgid "Help translate Bastion at the links above."
 msgstr ""
 
-#: src\events\message-ping.ts:48
+#: src\events\message-ping.ts:50
 msgid ""
 "❓ Help documentation on [GitHub](https://github.com/DawnbrandBots/bastion-bot), or use `.commands` and `.help`.\n"
 "🟢 Licence: [GNU AGPL 3.0+](https://choosealicense.com/licenses/agpl-3.0/).\n"
@@ -327,38 +375,38 @@ msgid ""
 "💬 Translations missing? Help translate Bastion on [GitHub](https://github.com/DawnbrandBots/bastion-bot)."
 msgstr ""
 
-#: src\events\message-search.ts:263
-#: src\events\message-search.ts:302
+#: src\events\message-search.ts:256
+#: src\events\message-search.ts:294
 #, javascript-format
 msgid "Search type: ${ localisedType }"
 msgstr ""
 
-#: src\events\message-search.ts:242
+#: src\events\message-search.ts:236
 #, javascript-format
 msgid "Search language: **${ localisedInputLanguage }** (${ inputLanguage }). Check defaults with </locale get:${ id }> and configure with </locale set:${ id }>"
 msgstr ""
 
-#: src\events\message-ping.ts:93
+#: src\events\message-ping.ts:95
 msgid "⚠️ You pinged me, but I am missing permissions in the channel!"
 msgstr ""
 
-#: src\events\message-ping.ts:96
-#: src\events\message-search.ts:340
+#: src\events\message-ping.ts:98
+#: src\events\message-search.ts:332
 msgid "Please have a server administrator [fix this](https://github.com/DawnbrandBots/bastion-bot#discord-permissions)."
 msgstr ""
 
-#: src\events\message-search.ts:337
+#: src\events\message-search.ts:329
 msgid "⚠️ I am missing permissions in the channel!"
 msgstr ""
 
-#: src\commands\deck.ts:258
+#: src\commands\deck.ts:297
 #, javascript-format
 msgid "Extra Deck (${ deck.extra.length } card — ${ countDetail })"
 msgid_plural "Extra Deck (${ deck.extra.length } cards — ${ countDetail })"
 msgstr[0] ""
 msgstr[1] ""
 
-#: src\commands\deck.ts:272
+#: src\commands\deck.ts:311
 #, javascript-format
 msgid "Side Deck (${ deck.side.length } card — ${ countDetail })"
 msgid_plural "Side Deck (${ deck.side.length } cards — ${ countDetail })"
@@ -380,82 +428,48 @@ msgstr ""
 msgid "Something went wrong searching Yugipedia for `${ page }`."
 msgstr ""
 
-#: src\rush-duel.ts:49
+#: src\rush-duel.ts:40
 #, javascript-format
 msgid "[Official Konami DB](${ official }) | [Rulings (Japanese)](${ rulings }) | [Yugipedia](${ yugipedia }) | [RushCard](${ rushcard })"
 msgstr ""
 
-#: src\rush-duel.ts:52
+#: src\rush-duel.ts:43
 #, javascript-format
 msgid "[Yugipedia](${ yugipedia }) | [RushCard](${ rushcard })"
 msgstr ""
 
-#: src\rush-duel.ts:71
+#: src\rush-duel.ts:57
 msgid "__**LEGEND**__"
 msgstr ""
 
-#: src\rush-duel.ts:110
+#: src\rush-duel.ts:99
 #, javascript-format
 msgid "**MAXIMUM ATK**: ${ card.maximum_atk }"
 msgstr ""
 
-#: src\rush-duel.ts:158
+#: src\rush-duel.ts:146
 #, javascript-format
 msgid "Konami ID #${ card.konami_id }"
 msgstr ""
 
 #: src\art.ts:129
+#: src\commands\deck.ts:451
 msgid "Buttons can only be used by the user who called Bastion."
-msgstr ""
-
-#: src\rush-duel.ts:217
-#, javascript-format
-msgid "Using ${ searchTrigger }, you can search for Rush Duel cards directly in messages without autocomplete"
-msgstr ""
-
-#: src\events\message-search.ts:304
-#, javascript-format
-msgid "Could not find a Rush Duel card matching `${ input }`!"
 msgstr ""
 
 #: src\card.ts:462
 #, javascript-format
-msgid "**Master Duel rarity**: ${ rarityIcon } ${ localizedRarity }"
+msgid "**Master Duel rarity**: ${ rarity_icon } ${ localized_rarity }"
 msgstr ""
 
-#: src\card.ts:492
-#: src\rush-duel.ts:105
+#: src\rush-duel.ts:205
 #, javascript-format
-msgid "**Attribute**: ${ attributeIcon } ${ localizedAttribute }"
+msgid "Using ${ searchTrigger }, you can search for Rush Duel cards directly in messages without autocomplete"
 msgstr ""
 
-#: src\card.ts:497
+#: src\events\message-search.ts:296
 #, javascript-format
-msgid "**Rank**: ${ rankIcon } ${ card.rank } **ATK**: ${ card.atk } **DEF**: ${ card.def }"
-msgstr ""
-
-#: src\card.ts:503
-#: src\rush-duel.ts:107
-#, javascript-format
-msgid "**Level**: ${ levelIcon } ${ card.level } **ATK**: ${ card.atk } **DEF**: ${ card.def }"
-msgstr ""
-
-#: src\commands\locale-user.ts:73
-#: src\commands\locale.ts:89
-#, javascript-format
-msgid "Locale override for your direct messages: ${ override }"
-msgstr ""
-
-#: src\commands\locale-user.ts:83
-#: src\commands\locale.ts:146
-#, javascript-format
-msgid "Locale for your direct messages overridden with ${ locale }. Your Discord setting is ${ interaction.locale }."
-msgstr ""
-
-#: src\commands\locale-user.ts:87
-#: src\commands\locale.ts:150
-#, javascript-format
-msgid "Locale for your direct messages reset to Discord default. Your Discord setting is ${ interaction.locale }."
+msgid "Could not find a Rush Duel card matching `${ input }`!"
 msgstr ""
 
 #: src\card.ts:40
@@ -822,65 +836,65 @@ msgctxt "master-duel-rarity"
 msgid "Ultra Rare (UR)"
 msgstr "Ultra Rare (UR)"
 
-#: src\card.ts:517
-#: src\card.ts:528
-#: src\rush-duel.ts:138
+#: src\card.ts:513
+#: src\card.ts:524
+#: src\rush-duel.ts:127
 msgctxt "card-embed"
 msgid "Card Text"
 msgstr "Kartentext"
 
-#: src\card.ts:522
+#: src\card.ts:518
 msgctxt "card-embed"
 msgid "Pendulum Effect"
 msgstr "Pendeleffekt"
 
-#: src\card.ts:545
+#: src\card.ts:539
 msgctxt "card-embed"
 msgid "Card Effect"
 msgstr ""
 
-#: src\rush-duel.ts:129
-#: src\rush-duel.ts:151
+#: src\rush-duel.ts:118
+#: src\rush-duel.ts:139
 msgctxt "card-embed"
 msgid "[REQUIREMENT]"
 msgstr "[BEDINGUNG]"
 
-#: src\rush-duel.ts:130
-#: src\rush-duel.ts:152
+#: src\rush-duel.ts:119
+#: src\rush-duel.ts:140
 msgctxt "card-embed"
 msgid "[EFFECT]"
 msgstr "[EFFEKT]"
 
-#: src\rush-duel.ts:132
+#: src\rush-duel.ts:121
 msgctxt "card-embed"
 msgid "[CONTINUOUS EFFECT]"
 msgstr "[DAUEREFFEKT]"
 
-#: src\rush-duel.ts:134
+#: src\rush-duel.ts:123
 msgctxt "card-embed"
 msgid "[MULTI-CHOICE EFFECT]"
 msgstr ""
 
-#: src\locale.ts:74
+#: src\locale.ts:71
 msgctxt "command-option"
 msgid "result-language"
 msgstr ""
 
-#: src\locale.ts:140
+#: src\locale.ts:131
 msgctxt "command-option"
 msgid "input-language"
 msgstr ""
 
-#: src\commands\rush-duel.ts:67
-#: src\commands\rush-duel.ts:79
-#: src\locale.ts:156
-#: src\locale.ts:174
-#: src\locale.ts:190
+#: src\commands\rush-duel.ts:68
+#: src\commands\rush-duel.ts:80
+#: src\locale.ts:147
+#: src\locale.ts:165
+#: src\locale.ts:181
 msgctxt "command-option"
 msgid "input"
 msgstr ""
 
-#: src\commands\help.ts:55
+#: src\commands\help.ts:52
 msgctxt "command-option"
 msgid "command"
 msgstr ""
@@ -895,56 +909,54 @@ msgctxt "command-option"
 msgid "page"
 msgstr ""
 
-#: src\commands\deck.ts:87
+#: src\commands\deck.ts:126
 msgctxt "command-option"
 msgid "url"
 msgstr ""
 
-#: src\commands\deck.ts:93
+#: src\commands\deck.ts:132
 msgctxt "command-option"
 msgid "file"
 msgstr ""
 
-#: src\commands\deck.ts:99
-#: src\commands\deck.ts:105
+#: src\commands\deck.ts:138
+#: src\commands\deck.ts:144
 msgctxt "command-option"
 msgid "deck"
 msgstr ""
 
-#: src\commands\deck.ts:111
+#: src\commands\deck.ts:150
 msgctxt "command-option"
 msgid "public"
 msgstr ""
 
-#: src\commands\deck.ts:118
+#: src\commands\deck.ts:157
 msgctxt "command-option"
 msgid "stacked"
 msgstr ""
 
-#: src\locale.ts:151
+#: src\locale.ts:142
 msgctxt "command-option"
 msgid "name"
 msgstr ""
 
-#: src\locale.ts:169
+#: src\locale.ts:160
 msgctxt "command-option"
 msgid "password"
 msgstr ""
 
-#: src\commands\rush-duel.ts:72
-#: src\events\message-search.ts:301
-#: src\locale.ts:185
+#: src\commands\rush-duel.ts:73
+#: src\events\message-search.ts:293
+#: src\locale.ts:176
 msgctxt "command-option"
 msgid "konami-id"
 msgstr ""
 
-#: src\commands\locale-user.ts:36
 #: src\commands\locale.ts:30
 msgctxt "command-option"
 msgid "get"
 msgstr ""
 
-#: src\commands\locale-user.ts:41
 #: src\commands\locale.ts:35
 msgctxt "command-option"
 msgid "set"
@@ -955,69 +967,47 @@ msgctxt "command-option"
 msgid "scope"
 msgstr ""
 
-#: src\commands\locale-user.ts:46
 #: src\commands\locale.ts:48
 msgctxt "command-option"
 msgid "locale"
 msgstr ""
 
-#: src\commands\price.ts:95
+#: src\commands\price.ts:94
 msgctxt "command-option"
 msgid "vendor"
 msgstr ""
 
-#: src\commands\rush-duel.ts:62
+#: src\commands\rush-duel.ts:63
 msgctxt "command-option"
 msgid "search"
 msgstr ""
 
-#: src\commands\rush-duel.ts:84
+#: src\commands\rush-duel.ts:85
 msgctxt "command-option"
 msgid "random"
 msgstr ""
 
-#: src\commands\rush-duel.ts:89
+#: src\commands\rush-duel.ts:90
 msgctxt "command-option"
 msgid "art"
 msgstr ""
 
-#: src\commands\query.ts:35
+#: src\commands\query.ts:36
 msgctxt "command-option"
 msgid "lucene"
 msgstr ""
 
-#: src\commands\metagame.ts:209
-msgctxt "command-option"
-msgid "strategies"
-msgstr ""
-
-#: src\commands\metagame.ts:234
-#: src\commands\metagame.ts:274
-msgctxt "command-option"
-msgid "format"
-msgstr ""
-
-#: src\commands\metagame.ts:240
-msgctxt "command-option"
-msgid "cards"
-msgstr ""
-
-#: src\commands\metagame.ts:310
-msgctxt "command-option"
-msgid "date-range"
-msgstr ""
-
-#: src\locale.ts:77
+#: src\locale.ts:74
 msgctxt "command-option-description"
 msgid "The output language for the card embed, overriding other settings."
 msgstr ""
 
-#: src\locale.ts:141
+#: src\locale.ts:132
 msgctxt "command-option-description"
 msgid "The language to search in, defaulting to the result language."
 msgstr ""
 
-#: src\commands\help.ts:58
+#: src\commands\help.ts:55
 msgctxt "command-option-description"
 msgid "The name of a specific Slash Command."
 msgstr ""
@@ -1027,32 +1017,32 @@ msgctxt "command-option-description"
 msgid "The name of the Yugipedia page you want to search for."
 msgstr ""
 
-#: src\commands\deck.ts:90
+#: src\commands\deck.ts:129
 msgctxt "command-option-description"
 msgid "View a deck by entering a ydke:// URL."
 msgstr ""
 
-#: src\commands\deck.ts:96
+#: src\commands\deck.ts:135
 msgctxt "command-option-description"
 msgid "View a deck by uploading a .ydk file."
 msgstr ""
 
-#: src\commands\deck.ts:102
+#: src\commands\deck.ts:141
 msgctxt "command-option-description"
 msgid "The ydke:// URL of the deck you want to view."
 msgstr ""
 
-#: src\commands\deck.ts:108
+#: src\commands\deck.ts:147
 msgctxt "command-option-description"
 msgid "The .ydk file of the deck you want to view."
 msgstr ""
 
-#: src\commands\deck.ts:114
+#: src\commands\deck.ts:153
 msgctxt "command-option-description"
 msgid "Whether to display the deck details publicly in chat. This is false by default."
 msgstr ""
 
-#: src\commands\deck.ts:121
+#: src\commands\deck.ts:160
 msgctxt "command-option-description"
 msgid "Whether to display the deck sections as one stacked column. This is false (side-by-side) by default."
 msgstr ""
@@ -1062,8 +1052,8 @@ msgctxt "command-option-description"
 msgid "Display the art for the card with this name."
 msgstr ""
 
-#: src\commands\rush-duel.ts:68
-#: src\locale.ts:157
+#: src\commands\rush-duel.ts:69
+#: src\locale.ts:148
 msgctxt "command-option-description"
 msgid "Card name, fuzzy matching supported."
 msgstr ""
@@ -1073,7 +1063,7 @@ msgctxt "command-option-description"
 msgid "Display the art for the card with this password."
 msgstr ""
 
-#: src\locale.ts:176
+#: src\locale.ts:167
 msgctxt "command-option-description"
 msgid "Card password, the eight-digit number printed on the bottom left corner."
 msgstr ""
@@ -1083,8 +1073,8 @@ msgctxt "command-option-description"
 msgid "Display the art for the card with this official database ID."
 msgstr ""
 
-#: src\commands\rush-duel.ts:80
-#: src\locale.ts:191
+#: src\commands\rush-duel.ts:81
+#: src\locale.ts:182
 msgctxt "command-option-description"
 msgid "Konami's official card database identifier."
 msgstr ""
@@ -1124,22 +1114,22 @@ msgctxt "command-option-description"
 msgid "The new default language to use in this channel or server."
 msgstr ""
 
-#: src\commands\price.ts:99
+#: src\commands\price.ts:98
 msgctxt "command-option-description"
 msgid "Display the price for the card with this name."
 msgstr ""
 
-#: src\commands\price.ts:103
+#: src\commands\price.ts:102
 msgctxt "command-option-description"
 msgid "Display the price for the card with this password."
 msgstr ""
 
-#: src\commands\price.ts:106
+#: src\commands\price.ts:105
 msgctxt "command-option-description"
 msgid "Display the price for the card with this official database ID."
 msgstr ""
 
-#: src\commands\price.ts:96
+#: src\commands\price.ts:95
 msgctxt "command-option-description"
 msgid "The vendor to fetch the price data from."
 msgstr ""
@@ -1149,70 +1139,29 @@ msgctxt "command-option-description"
 msgid "The English name of the card you're looking for."
 msgstr ""
 
-#: src\commands\rush-duel.ts:63
+#: src\commands\rush-duel.ts:64
 msgctxt "command-option-description"
 msgid "Find all information for the Rush Duel card with this name."
 msgstr ""
 
-#: src\commands\rush-duel.ts:74
+#: src\commands\rush-duel.ts:75
 msgctxt "command-option-description"
 msgid "Find all information for the Rush Duel card with this official database ID."
 msgstr ""
 
-#: src\commands\rush-duel.ts:85
+#: src\commands\rush-duel.ts:86
 msgctxt "command-option-description"
 msgid "Get a random Rush Duel card."
 msgstr ""
 
-#: src\commands\rush-duel.ts:90
+#: src\commands\rush-duel.ts:91
 msgctxt "command-option-description"
 msgid "Display just the art for the Rush Duel card with this name."
 msgstr ""
 
-#: src\commands\query.ts:36
+#: src\commands\query.ts:37
 msgctxt "command-option-description"
 msgid "Lucene query on YAML Yugi"
-msgstr ""
-
-#: src\commands\locale-user.ts:37
-msgctxt "command-option-description"
-msgid "Check your user-installed Bastion's locale."
-msgstr ""
-
-#: src\commands\locale-user.ts:42
-msgctxt "command-option-description"
-msgid "Configure your user-installed Bastion's locale."
-msgstr ""
-
-#: src\commands\locale-user.ts:47
-msgctxt "command-option-description"
-msgid "The new default language to use for user-installed Bastion."
-msgstr ""
-
-#: src\commands\metagame.ts:212
-msgctxt "command-option-description"
-msgid "Show the top competitive strategies in tournaments and the Master Duel ranked ladder."
-msgstr ""
-
-#: src\commands\metagame.ts:214
-msgctxt "command-option-description"
-msgid "Show the top competitive strategies in tournaments."
-msgstr ""
-
-#: src\commands\metagame.ts:235
-#: src\commands\metagame.ts:275
-msgctxt "command-option-description"
-msgid "Game region."
-msgstr ""
-
-#: src\commands\metagame.ts:242
-msgctxt "command-option-description"
-msgid "Show the most popular cards in tournaments and the Master Duel ranked ladder."
-msgstr ""
-
-#: src\commands\metagame.ts:312
-msgctxt "command-option-description"
-msgid "Limit card usage statistics to this date range. Has no effect for Master Duel."
 msgstr ""
 
 #: src\commands\art.ts:36
@@ -1220,12 +1169,12 @@ msgctxt "command-name"
 msgid "art"
 msgstr ""
 
-#: src\commands\help.ts:52
+#: src\commands\help.ts:49
 msgctxt "command-name"
 msgid "help"
 msgstr ""
 
-#: src\commands\ping.ts:25
+#: src\commands\ping.ts:23
 msgctxt "command-name"
 msgid "ping"
 msgstr ""
@@ -1240,7 +1189,7 @@ msgctxt "command-name"
 msgid "yugipedia"
 msgstr ""
 
-#: src\commands\deck.ts:80
+#: src\commands\deck.ts:119
 msgctxt "command-name"
 msgid "deck"
 msgstr ""
@@ -1255,34 +1204,24 @@ msgctxt "command-name"
 msgid "locale"
 msgstr ""
 
-#: src\commands\random.ts:43
+#: src\commands\random.ts:44
 msgctxt "command-name"
 msgid "random"
 msgstr ""
 
-#: src\commands\price.ts:90
+#: src\commands\price.ts:89
 msgctxt "command-name"
 msgid "price"
 msgstr ""
 
-#: src\commands\rush-duel.ts:57
+#: src\commands\rush-duel.ts:58
 msgctxt "command-name"
 msgid "rush-duel"
 msgstr ""
 
-#: src\commands\query.ts:29
+#: src\commands\query.ts:30
 msgctxt "command-name"
 msgid "query"
-msgstr ""
-
-#: src\commands\locale-user.ts:31
-msgctxt "command-name"
-msgid "locale-user"
-msgstr ""
-
-#: src\commands\metagame.ts:204
-msgctxt "command-name"
-msgid "metagame"
 msgstr ""
 
 #: src\commands\art.ts:37
@@ -1290,12 +1229,12 @@ msgctxt "command-description"
 msgid "Display the art for a card!"
 msgstr ""
 
-#: src\commands\help.ts:53
+#: src\commands\help.ts:50
 msgctxt "command-description"
 msgid "Get help with a Slash Command."
 msgstr ""
 
-#: src\commands\ping.ts:26
+#: src\commands\ping.ts:24
 msgctxt "command-description"
 msgid "Test latency to the new bot instance."
 msgstr ""
@@ -1310,7 +1249,7 @@ msgctxt "command-description"
 msgid "Search the Yugipedia wiki for a page and link to it."
 msgstr ""
 
-#: src\commands\deck.ts:83
+#: src\commands\deck.ts:122
 msgctxt "command-description"
 msgid "Display a deck list from ydke:// or .ydk format, exported from a number of deck building programs."
 msgstr ""
@@ -1325,34 +1264,24 @@ msgctxt "command-description"
 msgid "Check or set Bastion's locale for this channel or server."
 msgstr ""
 
-#: src\commands\random.ts:44
+#: src\commands\random.ts:45
 msgctxt "command-description"
 msgid "Get a random Yu-Gi-Oh! card."
 msgstr ""
 
-#: src\commands\price.ts:91
+#: src\commands\price.ts:90
 msgctxt "command-description"
 msgid "Display the price for a card!"
 msgstr ""
 
-#: src\commands\rush-duel.ts:58
+#: src\commands\rush-duel.ts:59
 msgctxt "command-description"
 msgid "Find information on Rush Duel cards."
 msgstr ""
 
-#: src\commands\query.ts:30
+#: src\commands\query.ts:31
 msgctxt "command-description"
 msgid "Advanced search prototype"
-msgstr ""
-
-#: src\commands\locale-user.ts:32
-msgctxt "command-description"
-msgid "Check or set user-installed Bastion's locale."
-msgstr ""
-
-#: src\commands\metagame.ts:205
-msgctxt "command-description"
-msgid "Show statistics on the current competitive state of play."
 msgstr ""
 
 #: src\commands\locale.ts:43
@@ -1365,71 +1294,7 @@ msgctxt "command-option-choice"
 msgid "server"
 msgstr ""
 
-#: src\commands\locale-user.ts:49
 #: src\commands\locale.ts:51
 msgctxt "command-option-choice"
 msgid "Discord default"
-msgstr ""
-
-#: src\commands\metagame.ts:219
-#: src\commands\metagame.ts:251
-msgctxt "command-option-choice"
-msgid "TCG"
-msgstr ""
-
-#: src\commands\metagame.ts:220
-#: src\commands\metagame.ts:255
-msgctxt "command-option-choice"
-msgid "OCG"
-msgstr ""
-
-#: src\commands\metagame.ts:221
-#: src\commands\metagame.ts:259
-msgctxt "command-option-choice"
-msgid "OCG (Asian-English)"
-msgstr ""
-
-#: src\commands\metagame.ts:228
-msgctxt "command-option-choice"
-msgid "Master Duel Diamond+ tier list"
-msgstr ""
-
-#: src\commands\metagame.ts:261
-msgctxt "command-option-choice"
-msgid "Master Duel ranked ladder"
-msgstr ""
-
-#: src\commands\metagame.ts:283
-msgctxt "command-option-choice"
-msgid "Current format"
-msgstr ""
-
-#: src\commands\metagame.ts:287
-msgctxt "command-option-choice"
-msgid "Since last Forbidden/Limited List"
-msgstr ""
-
-#: src\commands\metagame.ts:291
-msgctxt "command-option-choice"
-msgid "Last 7 days"
-msgstr ""
-
-#: src\commands\metagame.ts:295
-msgctxt "command-option-choice"
-msgid "Last 14 days"
-msgstr ""
-
-#: src\commands\metagame.ts:299
-msgctxt "command-option-choice"
-msgid "Last 30 days"
-msgstr ""
-
-#: src\commands\metagame.ts:303
-msgctxt "command-option-choice"
-msgid "Last three months"
-msgstr ""
-
-#: src\commands\metagame.ts:307
-msgctxt "command-option-choice"
-msgid "Last six months"
 msgstr ""

--- a/translations/de.po
+++ b/translations/de.po
@@ -30,13 +30,13 @@ msgstr "**Typ**: ${ raceIcon } ${ localizedMonsterTypeLine }"
 #: src\card.ts:491
 #: src\rush-duel.ts:94
 #, javascript-format
-msgid "**Attribute**: ${ AttributeIcon[card.attribute] } ${ localizedAttribute }"
-msgstr "**Eigenschaft**: ${ AttributeIcon[card.attribute] } ${ localizedAttribute }"
+msgid "**Attribute**: ${ attributeIcon } ${ localizedAttribute }"
+msgstr "**Eigenschaft**: ${ attributeIcon } ${ localizedAttribute }"
 
 #: src\card.ts:495
 #, javascript-format
-msgid "**Rank**: ${ Icon.Rank } ${ card.rank } **ATK**: ${ card.atk } **DEF**: ${ card.def }"
-msgstr "**Rang**: ${ Icon.Rank } ${ card.rank } **ATK**: ${ card.atk } **DEF**: ${ card.def }"
+msgid "**Rank**: ${ rankIcon } ${ card.rank } **ATK**: ${ card.atk } **DEF**: ${ card.def }"
+msgstr "**Rang**: ${ rankIcon } ${ card.rank } **ATK**: ${ card.atk } **DEF**: ${ card.def }"
 
 #: src\card.ts:498
 #, javascript-format
@@ -46,8 +46,8 @@ msgstr ""
 #: src\card.ts:500
 #: src\rush-duel.ts:96
 #, javascript-format
-msgid "**Level**: ${ Icon.Level } ${ card.level } **ATK**: ${ card.atk } **DEF**: ${ card.def }"
-msgstr "**Stufe**: ${ Icon.Level } ${ card.level } **ATK**: ${ card.atk } **DEF**: ${ card.def }"
+msgid "**Level**: ${ levelIcon } ${ card.level } **ATK**: ${ card.atk } **DEF**: ${ card.def }"
+msgstr "**Stufe**: ${ levelIcon } ${ card.level } **ATK**: ${ card.atk } **DEF**: ${ card.def }"
 
 #: src\card.ts:507
 #, javascript-format
@@ -459,7 +459,7 @@ msgstr ""
 
 #: src\card.ts:462
 #, javascript-format
-msgid "**Master Duel rarity**: ${ rarity_icon } ${ localized_rarity }"
+msgid "**Master Duel rarity**: ${ rarityIcon } ${ localizedRarity }"
 msgstr ""
 
 #: src\rush-duel.ts:205

--- a/translations/es.po
+++ b/translations/es.po
@@ -6,50 +6,50 @@ msgstr ""
 "MIME-Version: 1.0\n"
 "Content-Transfer-Encoding: 8bit\n"
 
-#: src\card.ts:416
-#: src\rush-duel.ts:39
+#: src\card.ts:412
+#: src\rush-duel.ts:48
 msgid "🔗 Links"
 msgstr ""
 
-#: src\card.ts:417
+#: src\card.ts:413
 #, javascript-format
 msgid "[Official Konami DB](${ official }) | [OCG Rulings](${ rulings }) | [Yugipedia](${ yugipedia }) | [YGOPRODECK](${ ygoprodeck })"
 msgstr ""
 
-#: src\card.ts:420
+#: src\card.ts:416
 #, javascript-format
 msgid "[Yugipedia](${ yugipedia }) | [YGOPRODECK](${ ygoprodeck })"
 msgstr ""
 
-#: src\card.ts:489
-#: src\rush-duel.ts:92
+#: src\card.ts:490
+#: src\rush-duel.ts:103
 #, javascript-format
 msgid "**Type**: ${ raceIcon } ${ localizedMonsterTypeLine }"
 msgstr "**Tipo**: ${ raceIcon } ${ localizedMonsterTypeLine }"
 
-#: src\card.ts:491
-#: src\rush-duel.ts:94
+#: src\card.ts:492
+#: src\rush-duel.ts:105
 #, javascript-format
 msgid "**Attribute**: ${ attributeIcon } ${ localizedAttribute }"
 msgstr "**Atributo**: ${ attributeIcon } ${ localizedAttribute }"
 
-#: src\card.ts:495
+#: src\card.ts:497
 #, javascript-format
 msgid "**Rank**: ${ rankIcon } ${ card.rank } **ATK**: ${ card.atk } **DEF**: ${ card.def }"
 msgstr "**Rango**: ${ rankIcon } ${ card.rank } **ATK**: ${ card.atk } **DEF**: ${ card.def }"
 
-#: src\card.ts:498
+#: src\card.ts:500
 #, javascript-format
 msgid "**Link Rating**: ${ card.link_arrows.length } **ATK**: ${ card.atk } **Link Arrows**: ${ arrows }"
 msgstr ""
 
-#: src\card.ts:500
-#: src\rush-duel.ts:96
+#: src\card.ts:503
+#: src\rush-duel.ts:107
 #, javascript-format
 msgid "**Level**: ${ levelIcon } ${ card.level } **ATK**: ${ card.atk } **DEF**: ${ card.def }"
 msgstr "**Nivel**: ${ levelIcon } ${ card.level } **ATK**: ${ card.atk } **DEF**: ${ card.def }"
 
-#: src\card.ts:507
+#: src\card.ts:511
 #, javascript-format
 msgid "**Pendulum Scale**: ${ formattedScale }"
 msgstr "**Escala de Péndulo**: ${ formattedScale }"
@@ -70,7 +70,7 @@ msgid "Password: ${ card.password } | Not yet released"
 msgstr ""
 
 #: src\card.ts:351
-#: src\rush-duel.ts:146
+#: src\rush-duel.ts:158
 msgid "Not yet released"
 msgstr ""
 
@@ -79,64 +79,64 @@ msgstr ""
 msgid "Placeholder ID: ${ card.fake_password }"
 msgstr ""
 
-#: src\utils.ts:41
+#: src\utils.ts:44
 msgid "🛠️ This command is in development."
 msgstr ""
 
-#: src\utils.ts:42
+#: src\utils.ts:45
 msgid "📨 Please send feedback to [our issue tracker](https://github.com/DawnbrandBots/bastion-bot) or the [support server](https://discord.gg/4aFuPyuE96)!"
 msgstr ""
 
-#: src\utils.ts:53
+#: src\utils.ts:56
 msgid "Please consider supporting us!"
 msgstr ""
 
-#: src\utils.ts:54
+#: src\utils.ts:57
 msgid "Help keep Bastion online!"
 msgstr ""
 
-#: src\utils.ts:55
+#: src\utils.ts:58
 msgid "Please help keep Bastion online!"
 msgstr ""
 
-#: src\utils.ts:56
+#: src\utils.ts:59
 msgid "Was Bastion helpful? Consider supporting us!"
 msgstr ""
 
-#: src\utils.ts:57
+#: src\utils.ts:60
 msgid "Was Bastion helpful? We need your support!"
 msgstr ""
 
-#: src\utils.ts:58
+#: src\utils.ts:61
 msgid "Did you find Bastion useful? Consider supporting us!"
 msgstr ""
 
-#: src\utils.ts:59
+#: src\utils.ts:62
 msgid "Did you find Bastion useful? Help keep it online!"
 msgstr ""
 
-#: src\utils.ts:60
+#: src\utils.ts:63
 msgid "Did you find Bastion useful? We need your support!"
 msgstr ""
 
-#: src\utils.ts:61
+#: src\utils.ts:64
 msgid "Enjoy Bastion? Help keep it online!"
 msgstr ""
 
-#: src\utils.ts:62
+#: src\utils.ts:65
 msgid "Enjoy Bastion? Consider supporting us!"
 msgstr ""
 
-#: src\utils.ts:63
+#: src\utils.ts:66
 msgid "Found what you were looking for? Consider supporting us!"
 msgstr ""
 
 #: src\commands\art.ts:63
-#: src\commands\price.ts:131
-#: src\commands\rush-duel.ts:172
-#: src\commands\rush-duel.ts:203
+#: src\commands\price.ts:132
+#: src\commands\rush-duel.ts:171
+#: src\commands\rush-duel.ts:202
 #: src\commands\search.ts:64
-#: src\events\message-search.ts:258
+#: src\events\message-search.ts:265
 #, javascript-format
 msgid "Could not find a card matching `${ input }`!"
 msgstr ""
@@ -147,51 +147,51 @@ msgstr ""
 msgid "Could not find art for `${ name }`!"
 msgstr ""
 
-#: src\commands\deck.ts:244
+#: src\commands\deck.ts:205
 #, javascript-format
 msgid "${ counts.Monster } Monster"
 msgid_plural "${ counts.Monster } Monsters"
 msgstr[0] ""
 msgstr[1] ""
 
-#: src\commands\deck.ts:247
+#: src\commands\deck.ts:208
 #, javascript-format
 msgid "${ counts.Spell } Spell"
 msgid_plural "${ counts.Spell } Spells"
 msgstr[0] ""
 msgstr[1] ""
 
-#: src\commands\deck.ts:250
+#: src\commands\deck.ts:211
 #, javascript-format
 msgid "${ counts.Trap } Trap"
 msgid_plural "${ counts.Trap } Traps"
 msgstr[0] ""
 msgstr[1] ""
 
-#: src\commands\deck.ts:278
+#: src\commands\deck.ts:239
 msgid "Your Deck"
 msgstr ""
 
-#: src\commands\deck.ts:283
+#: src\commands\deck.ts:244
 #, javascript-format
 msgid "Main Deck (${ deck.main.length } card — ${ countDetail })"
 msgid_plural "Main Deck (${ deck.main.length } cards — ${ countDetail })"
 msgstr[0] ""
 msgstr[1] ""
 
-#: src\commands\deck.ts:290
+#: src\commands\deck.ts:251
 msgid "Main Deck (continued)"
 msgstr ""
 
-#: src\commands\deck.ts:304
+#: src\commands\deck.ts:265
 msgid "Extra Deck (continued)"
 msgstr ""
 
-#: src\commands\deck.ts:318
+#: src\commands\deck.ts:279
 msgid "Side Deck (continued)"
 msgstr ""
 
-#: src\commands\deck.ts:407
+#: src\commands\deck.ts:347
 msgid "Error: Your deck is empty."
 msgstr ""
 
@@ -211,11 +211,7 @@ msgstr ""
 msgid "Discord Community locale for this server: ${ interaction.guildLocale }"
 msgstr ""
 
-#: src\commands\locale.ts:89
-#, javascript-format
-msgid "Locale override for this direct message: ${ override }"
-msgstr ""
-
+#: src\commands\locale-user.ts:76
 #: src\commands\locale.ts:92
 #, javascript-format
 msgid "Your Discord locale: ${ interaction.locale }"
@@ -253,24 +249,14 @@ msgstr ""
 msgid "Sorry, you must have the Manage Server permission to do this. If you think this is an error, contact your server admin or report a bug."
 msgstr ""
 
-#: src\commands\locale.ts:146
-#, javascript-format
-msgid "Locale for this direct message overridden with ${ locale }. Your Discord setting is ${ interaction.locale }."
-msgstr ""
-
-#: src\commands\locale.ts:150
-#, javascript-format
-msgid "Locale for this direct message reset to Discord default. Your Discord setting is ${ interaction.locale }."
-msgstr ""
-
-#: src\commands\ping.ts:36
-#: src\events\message-ping.ts:47
+#: src\commands\ping.ts:38
+#: src\events\message-ping.ts:45
 #, javascript-format
 msgid "Average WebSocket ping (new instance): ${ ping } ms"
 msgstr ""
 
-#: src\commands\ping.ts:40
-#: src\events\message-ping.ts:112
+#: src\commands\ping.ts:42
+#: src\events\message-ping.ts:110
 #, javascript-format
 msgid "Total latency: ${ latency } ms"
 msgstr ""
@@ -280,86 +266,69 @@ msgstr ""
 msgid "Could not find a Yugipedia page named `${ page }`."
 msgstr ""
 
-#: src\events\message-ping.ts:49
+#: src\events\message-ping.ts:47
 msgid "Free and open source _Yu-Gi-Oh!_ bot"
 msgstr ""
 
-#: src\events\message-ping.ts:72
+#: src\events\message-ping.ts:70
 #, javascript-format
 msgid "Revision: ${ process.env.BOT_REVISION }."
 msgstr ""
 
-#: src\commands\deck.ts:328
+#: src\commands\deck.ts:289
 msgid ".ydk files must have the .ydk extension!"
 msgstr ""
 
-#: src\commands\deck.ts:331
+#: src\commands\deck.ts:292
 msgid ".ydk files should not be larger than 1 KB!"
 msgstr ""
 
-#: src\commands\deck.ts:321
+#: src\commands\deck.ts:282
 msgid "ydke URL"
 msgstr ""
 
 #: src\card.ts:455
-#: src\rush-duel.ts:61
+#: src\rush-duel.ts:75
 #. Forbidden/Limited Lists or Limit Regulations in the OCG
 #, javascript-format
 msgid "**Limit**: ${ limitRegulationDisplay }"
 msgstr ""
 
-#: src\commands\price.ts:69
+#: src\commands\price.ts:70
 msgid "TCGPlayer"
 msgstr ""
 
-#: src\commands\price.ts:70
+#: src\commands\price.ts:71
 msgid "Cardmarket"
 msgstr ""
 
-#: src\commands\price.ts:147
+#: src\commands\price.ts:148
 msgid "No market price"
 msgstr ""
 
-#: src\commands\price.ts:155
+#: src\commands\price.ts:156
 #, javascript-format
 msgid "Prices for ${ card.name[resultLanguage] } - ${ vendorName }"
 msgstr ""
 
-#: src\commands\price.ts:169
+#: src\commands\price.ts:170
 #, javascript-format
 msgid "Could not find prices for `${ name }`!"
 msgstr ""
 
-#: src\commands\deck.ts:425
-#. prepare interaction button for FTP upload
+#: src\commands\deck.ts:363
 msgid "Upload to YGOPRODECK"
 msgstr ""
 
-#: src\commands\deck.ts:483
-#. disable original button
-#. prepare row to disable button on original message
-msgid "Upload Complete"
-msgstr ""
-
-#: src\commands\deck.ts:470
-msgid "Deck upload failed!"
-msgstr ""
-
-#: src\commands\deck.ts:491
-#. reply in affirmation
-#, javascript-format
-msgid "Deck successfully uploaded to <${ url }>!"
-msgstr ""
-
-#: src\events\message-search.ts:264
+#: src\events\message-search.ts:271
 msgid "💬 Translations missing?"
 msgstr ""
 
-#: src\events\message-search.ts:265
+#: src\events\message-search.ts:272
 msgid "Help translate Bastion at the links above."
 msgstr ""
 
-#: src\events\message-ping.ts:50
+#: src\events\message-ping.ts:48
 msgid ""
 "❓ Help documentation on [GitHub](https://github.com/DawnbrandBots/bastion-bot), or use `.commands` and `.help`.\n"
 "🟢 Licence: [GNU AGPL 3.0+](https://choosealicense.com/licenses/agpl-3.0/).\n"
@@ -375,38 +344,38 @@ msgid ""
 "💬 Translations missing? Help translate Bastion on [GitHub](https://github.com/DawnbrandBots/bastion-bot)."
 msgstr ""
 
-#: src\events\message-search.ts:256
-#: src\events\message-search.ts:294
+#: src\events\message-search.ts:263
+#: src\events\message-search.ts:302
 #, javascript-format
 msgid "Search type: ${ localisedType }"
 msgstr ""
 
-#: src\events\message-search.ts:236
+#: src\events\message-search.ts:242
 #, javascript-format
 msgid "Search language: **${ localisedInputLanguage }** (${ inputLanguage }). Check defaults with </locale get:${ id }> and configure with </locale set:${ id }>"
 msgstr ""
 
-#: src\events\message-ping.ts:95
+#: src\events\message-ping.ts:93
 msgid "⚠️ You pinged me, but I am missing permissions in the channel!"
 msgstr ""
 
-#: src\events\message-ping.ts:98
-#: src\events\message-search.ts:332
+#: src\events\message-ping.ts:96
+#: src\events\message-search.ts:340
 msgid "Please have a server administrator [fix this](https://github.com/DawnbrandBots/bastion-bot#discord-permissions)."
 msgstr ""
 
-#: src\events\message-search.ts:329
+#: src\events\message-search.ts:337
 msgid "⚠️ I am missing permissions in the channel!"
 msgstr ""
 
-#: src\commands\deck.ts:297
+#: src\commands\deck.ts:258
 #, javascript-format
 msgid "Extra Deck (${ deck.extra.length } card — ${ countDetail })"
 msgid_plural "Extra Deck (${ deck.extra.length } cards — ${ countDetail })"
 msgstr[0] ""
 msgstr[1] ""
 
-#: src\commands\deck.ts:311
+#: src\commands\deck.ts:272
 #, javascript-format
 msgid "Side Deck (${ deck.side.length } card — ${ countDetail })"
 msgid_plural "Side Deck (${ deck.side.length } cards — ${ countDetail })"
@@ -428,32 +397,31 @@ msgstr ""
 msgid "Something went wrong searching Yugipedia for `${ page }`."
 msgstr ""
 
-#: src\rush-duel.ts:40
+#: src\rush-duel.ts:49
 #, javascript-format
 msgid "[Official Konami DB](${ official }) | [Rulings (Japanese)](${ rulings }) | [Yugipedia](${ yugipedia }) | [RushCard](${ rushcard })"
 msgstr ""
 
-#: src\rush-duel.ts:43
+#: src\rush-duel.ts:52
 #, javascript-format
 msgid "[Yugipedia](${ yugipedia }) | [RushCard](${ rushcard })"
 msgstr ""
 
-#: src\rush-duel.ts:57
+#: src\rush-duel.ts:71
 msgid "__**LEGEND**__"
 msgstr ""
 
-#: src\rush-duel.ts:99
+#: src\rush-duel.ts:110
 #, javascript-format
 msgid "**MAXIMUM ATK**: ${ card.maximum_atk }"
 msgstr ""
 
-#: src\rush-duel.ts:146
+#: src\rush-duel.ts:158
 #, javascript-format
 msgid "Konami ID #${ card.konami_id }"
 msgstr ""
 
 #: src\art.ts:129
-#: src\commands\deck.ts:451
 msgid "Buttons can only be used by the user who called Bastion."
 msgstr ""
 
@@ -462,14 +430,32 @@ msgstr ""
 msgid "**Master Duel rarity**: ${ rarityIcon } ${ localizedRarity }"
 msgstr ""
 
-#: src\rush-duel.ts:205
+#: src\rush-duel.ts:217
 #, javascript-format
 msgid "Using ${ searchTrigger }, you can search for Rush Duel cards directly in messages without autocomplete"
 msgstr ""
 
-#: src\events\message-search.ts:296
+#: src\events\message-search.ts:304
 #, javascript-format
 msgid "Could not find a Rush Duel card matching `${ input }`!"
+msgstr ""
+
+#: src\commands\locale-user.ts:73
+#: src\commands\locale.ts:89
+#, javascript-format
+msgid "Locale override for your direct messages: ${ override }"
+msgstr ""
+
+#: src\commands\locale-user.ts:83
+#: src\commands\locale.ts:146
+#, javascript-format
+msgid "Locale for your direct messages overridden with ${ locale }. Your Discord setting is ${ interaction.locale }."
+msgstr ""
+
+#: src\commands\locale-user.ts:87
+#: src\commands\locale.ts:150
+#, javascript-format
+msgid "Locale for your direct messages reset to Discord default. Your Discord setting is ${ interaction.locale }."
 msgstr ""
 
 #: src\card.ts:40
@@ -836,65 +822,65 @@ msgctxt "master-duel-rarity"
 msgid "Ultra Rare (UR)"
 msgstr "Ultra Raro (UR)"
 
-#: src\card.ts:513
-#: src\card.ts:524
-#: src\rush-duel.ts:127
+#: src\card.ts:517
+#: src\card.ts:528
+#: src\rush-duel.ts:138
 msgctxt "card-embed"
 msgid "Card Text"
 msgstr "Texto de carta"
 
-#: src\card.ts:518
+#: src\card.ts:522
 msgctxt "card-embed"
 msgid "Pendulum Effect"
 msgstr "Efecto de Péndulo"
 
-#: src\card.ts:539
+#: src\card.ts:545
 msgctxt "card-embed"
 msgid "Card Effect"
 msgstr ""
 
-#: src\rush-duel.ts:118
-#: src\rush-duel.ts:139
+#: src\rush-duel.ts:129
+#: src\rush-duel.ts:151
 msgctxt "card-embed"
 msgid "[REQUIREMENT]"
 msgstr "[REQUISITO]"
 
-#: src\rush-duel.ts:119
-#: src\rush-duel.ts:140
+#: src\rush-duel.ts:130
+#: src\rush-duel.ts:152
 msgctxt "card-embed"
 msgid "[EFFECT]"
 msgstr "[EFECTO]"
 
-#: src\rush-duel.ts:121
+#: src\rush-duel.ts:132
 msgctxt "card-embed"
 msgid "[CONTINUOUS EFFECT]"
 msgstr "[EFECTO CONTINUO]"
 
-#: src\rush-duel.ts:123
+#: src\rush-duel.ts:134
 msgctxt "card-embed"
 msgid "[MULTI-CHOICE EFFECT]"
 msgstr ""
 
-#: src\locale.ts:71
+#: src\locale.ts:74
 msgctxt "command-option"
 msgid "result-language"
 msgstr ""
 
-#: src\locale.ts:131
+#: src\locale.ts:140
 msgctxt "command-option"
 msgid "input-language"
 msgstr ""
 
-#: src\commands\rush-duel.ts:68
-#: src\commands\rush-duel.ts:80
-#: src\locale.ts:147
-#: src\locale.ts:165
-#: src\locale.ts:181
+#: src\commands\rush-duel.ts:67
+#: src\commands\rush-duel.ts:79
+#: src\locale.ts:156
+#: src\locale.ts:174
+#: src\locale.ts:190
 msgctxt "command-option"
 msgid "input"
 msgstr ""
 
-#: src\commands\help.ts:52
+#: src\commands\help.ts:55
 msgctxt "command-option"
 msgid "command"
 msgstr ""
@@ -909,54 +895,56 @@ msgctxt "command-option"
 msgid "page"
 msgstr ""
 
-#: src\commands\deck.ts:126
+#: src\commands\deck.ts:87
 msgctxt "command-option"
 msgid "url"
 msgstr ""
 
-#: src\commands\deck.ts:132
+#: src\commands\deck.ts:93
 msgctxt "command-option"
 msgid "file"
 msgstr ""
 
-#: src\commands\deck.ts:138
-#: src\commands\deck.ts:144
+#: src\commands\deck.ts:99
+#: src\commands\deck.ts:105
 msgctxt "command-option"
 msgid "deck"
 msgstr ""
 
-#: src\commands\deck.ts:150
+#: src\commands\deck.ts:111
 msgctxt "command-option"
 msgid "public"
 msgstr ""
 
-#: src\commands\deck.ts:157
+#: src\commands\deck.ts:118
 msgctxt "command-option"
 msgid "stacked"
 msgstr ""
 
-#: src\locale.ts:142
+#: src\locale.ts:151
 msgctxt "command-option"
 msgid "name"
 msgstr ""
 
-#: src\locale.ts:160
+#: src\locale.ts:169
 msgctxt "command-option"
 msgid "password"
 msgstr ""
 
-#: src\commands\rush-duel.ts:73
-#: src\events\message-search.ts:293
-#: src\locale.ts:176
+#: src\commands\rush-duel.ts:72
+#: src\events\message-search.ts:301
+#: src\locale.ts:185
 msgctxt "command-option"
 msgid "konami-id"
 msgstr ""
 
+#: src\commands\locale-user.ts:36
 #: src\commands\locale.ts:30
 msgctxt "command-option"
 msgid "get"
 msgstr ""
 
+#: src\commands\locale-user.ts:41
 #: src\commands\locale.ts:35
 msgctxt "command-option"
 msgid "set"
@@ -967,47 +955,69 @@ msgctxt "command-option"
 msgid "scope"
 msgstr ""
 
+#: src\commands\locale-user.ts:46
 #: src\commands\locale.ts:48
 msgctxt "command-option"
 msgid "locale"
 msgstr ""
 
-#: src\commands\price.ts:94
+#: src\commands\price.ts:95
 msgctxt "command-option"
 msgid "vendor"
 msgstr ""
 
-#: src\commands\rush-duel.ts:63
+#: src\commands\rush-duel.ts:62
 msgctxt "command-option"
 msgid "search"
 msgstr ""
 
-#: src\commands\rush-duel.ts:85
+#: src\commands\rush-duel.ts:84
 msgctxt "command-option"
 msgid "random"
 msgstr ""
 
-#: src\commands\rush-duel.ts:90
+#: src\commands\rush-duel.ts:89
 msgctxt "command-option"
 msgid "art"
 msgstr ""
 
-#: src\commands\query.ts:36
+#: src\commands\query.ts:35
 msgctxt "command-option"
 msgid "lucene"
 msgstr ""
 
-#: src\locale.ts:74
+#: src\commands\metagame.ts:209
+msgctxt "command-option"
+msgid "strategies"
+msgstr ""
+
+#: src\commands\metagame.ts:234
+#: src\commands\metagame.ts:274
+msgctxt "command-option"
+msgid "format"
+msgstr ""
+
+#: src\commands\metagame.ts:240
+msgctxt "command-option"
+msgid "cards"
+msgstr ""
+
+#: src\commands\metagame.ts:310
+msgctxt "command-option"
+msgid "date-range"
+msgstr ""
+
+#: src\locale.ts:77
 msgctxt "command-option-description"
 msgid "The output language for the card embed, overriding other settings."
 msgstr ""
 
-#: src\locale.ts:132
+#: src\locale.ts:141
 msgctxt "command-option-description"
 msgid "The language to search in, defaulting to the result language."
 msgstr ""
 
-#: src\commands\help.ts:55
+#: src\commands\help.ts:58
 msgctxt "command-option-description"
 msgid "The name of a specific Slash Command."
 msgstr ""
@@ -1017,32 +1027,32 @@ msgctxt "command-option-description"
 msgid "The name of the Yugipedia page you want to search for."
 msgstr ""
 
-#: src\commands\deck.ts:129
+#: src\commands\deck.ts:90
 msgctxt "command-option-description"
 msgid "View a deck by entering a ydke:// URL."
 msgstr ""
 
-#: src\commands\deck.ts:135
+#: src\commands\deck.ts:96
 msgctxt "command-option-description"
 msgid "View a deck by uploading a .ydk file."
 msgstr ""
 
-#: src\commands\deck.ts:141
+#: src\commands\deck.ts:102
 msgctxt "command-option-description"
 msgid "The ydke:// URL of the deck you want to view."
 msgstr ""
 
-#: src\commands\deck.ts:147
+#: src\commands\deck.ts:108
 msgctxt "command-option-description"
 msgid "The .ydk file of the deck you want to view."
 msgstr ""
 
-#: src\commands\deck.ts:153
+#: src\commands\deck.ts:114
 msgctxt "command-option-description"
 msgid "Whether to display the deck details publicly in chat. This is false by default."
 msgstr ""
 
-#: src\commands\deck.ts:160
+#: src\commands\deck.ts:121
 msgctxt "command-option-description"
 msgid "Whether to display the deck sections as one stacked column. This is false (side-by-side) by default."
 msgstr ""
@@ -1052,8 +1062,8 @@ msgctxt "command-option-description"
 msgid "Display the art for the card with this name."
 msgstr ""
 
-#: src\commands\rush-duel.ts:69
-#: src\locale.ts:148
+#: src\commands\rush-duel.ts:68
+#: src\locale.ts:157
 msgctxt "command-option-description"
 msgid "Card name, fuzzy matching supported."
 msgstr ""
@@ -1063,7 +1073,7 @@ msgctxt "command-option-description"
 msgid "Display the art for the card with this password."
 msgstr ""
 
-#: src\locale.ts:167
+#: src\locale.ts:176
 msgctxt "command-option-description"
 msgid "Card password, the eight-digit number printed on the bottom left corner."
 msgstr ""
@@ -1073,8 +1083,8 @@ msgctxt "command-option-description"
 msgid "Display the art for the card with this official database ID."
 msgstr ""
 
-#: src\commands\rush-duel.ts:81
-#: src\locale.ts:182
+#: src\commands\rush-duel.ts:80
+#: src\locale.ts:191
 msgctxt "command-option-description"
 msgid "Konami's official card database identifier."
 msgstr ""
@@ -1114,22 +1124,22 @@ msgctxt "command-option-description"
 msgid "The new default language to use in this channel or server."
 msgstr ""
 
-#: src\commands\price.ts:98
+#: src\commands\price.ts:99
 msgctxt "command-option-description"
 msgid "Display the price for the card with this name."
 msgstr ""
 
-#: src\commands\price.ts:102
+#: src\commands\price.ts:103
 msgctxt "command-option-description"
 msgid "Display the price for the card with this password."
 msgstr ""
 
-#: src\commands\price.ts:105
+#: src\commands\price.ts:106
 msgctxt "command-option-description"
 msgid "Display the price for the card with this official database ID."
 msgstr ""
 
-#: src\commands\price.ts:95
+#: src\commands\price.ts:96
 msgctxt "command-option-description"
 msgid "The vendor to fetch the price data from."
 msgstr ""
@@ -1139,29 +1149,70 @@ msgctxt "command-option-description"
 msgid "The English name of the card you're looking for."
 msgstr ""
 
-#: src\commands\rush-duel.ts:64
+#: src\commands\rush-duel.ts:63
 msgctxt "command-option-description"
 msgid "Find all information for the Rush Duel card with this name."
 msgstr ""
 
-#: src\commands\rush-duel.ts:75
+#: src\commands\rush-duel.ts:74
 msgctxt "command-option-description"
 msgid "Find all information for the Rush Duel card with this official database ID."
 msgstr ""
 
-#: src\commands\rush-duel.ts:86
+#: src\commands\rush-duel.ts:85
 msgctxt "command-option-description"
 msgid "Get a random Rush Duel card."
 msgstr ""
 
-#: src\commands\rush-duel.ts:91
+#: src\commands\rush-duel.ts:90
 msgctxt "command-option-description"
 msgid "Display just the art for the Rush Duel card with this name."
 msgstr ""
 
-#: src\commands\query.ts:37
+#: src\commands\query.ts:36
 msgctxt "command-option-description"
 msgid "Lucene query on YAML Yugi"
+msgstr ""
+
+#: src\commands\locale-user.ts:37
+msgctxt "command-option-description"
+msgid "Check your user-installed Bastion's locale."
+msgstr ""
+
+#: src\commands\locale-user.ts:42
+msgctxt "command-option-description"
+msgid "Configure your user-installed Bastion's locale."
+msgstr ""
+
+#: src\commands\locale-user.ts:47
+msgctxt "command-option-description"
+msgid "The new default language to use for user-installed Bastion."
+msgstr ""
+
+#: src\commands\metagame.ts:212
+msgctxt "command-option-description"
+msgid "Show the top competitive strategies in tournaments and the Master Duel ranked ladder."
+msgstr ""
+
+#: src\commands\metagame.ts:214
+msgctxt "command-option-description"
+msgid "Show the top competitive strategies in tournaments."
+msgstr ""
+
+#: src\commands\metagame.ts:235
+#: src\commands\metagame.ts:275
+msgctxt "command-option-description"
+msgid "Game region."
+msgstr ""
+
+#: src\commands\metagame.ts:242
+msgctxt "command-option-description"
+msgid "Show the most popular cards in tournaments and the Master Duel ranked ladder."
+msgstr ""
+
+#: src\commands\metagame.ts:312
+msgctxt "command-option-description"
+msgid "Limit card usage statistics to this date range. Has no effect for Master Duel."
 msgstr ""
 
 #: src\commands\art.ts:36
@@ -1169,12 +1220,12 @@ msgctxt "command-name"
 msgid "art"
 msgstr ""
 
-#: src\commands\help.ts:49
+#: src\commands\help.ts:52
 msgctxt "command-name"
 msgid "help"
 msgstr ""
 
-#: src\commands\ping.ts:23
+#: src\commands\ping.ts:25
 msgctxt "command-name"
 msgid "ping"
 msgstr ""
@@ -1189,7 +1240,7 @@ msgctxt "command-name"
 msgid "yugipedia"
 msgstr ""
 
-#: src\commands\deck.ts:119
+#: src\commands\deck.ts:80
 msgctxt "command-name"
 msgid "deck"
 msgstr ""
@@ -1204,24 +1255,34 @@ msgctxt "command-name"
 msgid "locale"
 msgstr ""
 
-#: src\commands\random.ts:44
+#: src\commands\random.ts:43
 msgctxt "command-name"
 msgid "random"
 msgstr ""
 
-#: src\commands\price.ts:89
+#: src\commands\price.ts:90
 msgctxt "command-name"
 msgid "price"
 msgstr ""
 
-#: src\commands\rush-duel.ts:58
+#: src\commands\rush-duel.ts:57
 msgctxt "command-name"
 msgid "rush-duel"
 msgstr ""
 
-#: src\commands\query.ts:30
+#: src\commands\query.ts:29
 msgctxt "command-name"
 msgid "query"
+msgstr ""
+
+#: src\commands\locale-user.ts:31
+msgctxt "command-name"
+msgid "locale-user"
+msgstr ""
+
+#: src\commands\metagame.ts:204
+msgctxt "command-name"
+msgid "metagame"
 msgstr ""
 
 #: src\commands\art.ts:37
@@ -1229,12 +1290,12 @@ msgctxt "command-description"
 msgid "Display the art for a card!"
 msgstr ""
 
-#: src\commands\help.ts:50
+#: src\commands\help.ts:53
 msgctxt "command-description"
 msgid "Get help with a Slash Command."
 msgstr ""
 
-#: src\commands\ping.ts:24
+#: src\commands\ping.ts:26
 msgctxt "command-description"
 msgid "Test latency to the new bot instance."
 msgstr ""
@@ -1249,7 +1310,7 @@ msgctxt "command-description"
 msgid "Search the Yugipedia wiki for a page and link to it."
 msgstr ""
 
-#: src\commands\deck.ts:122
+#: src\commands\deck.ts:83
 msgctxt "command-description"
 msgid "Display a deck list from ydke:// or .ydk format, exported from a number of deck building programs."
 msgstr ""
@@ -1264,24 +1325,34 @@ msgctxt "command-description"
 msgid "Check or set Bastion's locale for this channel or server."
 msgstr ""
 
-#: src\commands\random.ts:45
+#: src\commands\random.ts:44
 msgctxt "command-description"
 msgid "Get a random Yu-Gi-Oh! card."
 msgstr ""
 
-#: src\commands\price.ts:90
+#: src\commands\price.ts:91
 msgctxt "command-description"
 msgid "Display the price for a card!"
 msgstr ""
 
-#: src\commands\rush-duel.ts:59
+#: src\commands\rush-duel.ts:58
 msgctxt "command-description"
 msgid "Find information on Rush Duel cards."
 msgstr ""
 
-#: src\commands\query.ts:31
+#: src\commands\query.ts:30
 msgctxt "command-description"
 msgid "Advanced search prototype"
+msgstr ""
+
+#: src\commands\locale-user.ts:32
+msgctxt "command-description"
+msgid "Check or set user-installed Bastion's locale."
+msgstr ""
+
+#: src\commands\metagame.ts:205
+msgctxt "command-description"
+msgid "Show statistics on the current competitive state of play."
 msgstr ""
 
 #: src\commands\locale.ts:43
@@ -1294,7 +1365,71 @@ msgctxt "command-option-choice"
 msgid "server"
 msgstr ""
 
+#: src\commands\locale-user.ts:49
 #: src\commands\locale.ts:51
 msgctxt "command-option-choice"
 msgid "Discord default"
+msgstr ""
+
+#: src\commands\metagame.ts:219
+#: src\commands\metagame.ts:251
+msgctxt "command-option-choice"
+msgid "TCG"
+msgstr ""
+
+#: src\commands\metagame.ts:220
+#: src\commands\metagame.ts:255
+msgctxt "command-option-choice"
+msgid "OCG"
+msgstr ""
+
+#: src\commands\metagame.ts:221
+#: src\commands\metagame.ts:259
+msgctxt "command-option-choice"
+msgid "OCG (Asian-English)"
+msgstr ""
+
+#: src\commands\metagame.ts:228
+msgctxt "command-option-choice"
+msgid "Master Duel Diamond+ tier list"
+msgstr ""
+
+#: src\commands\metagame.ts:261
+msgctxt "command-option-choice"
+msgid "Master Duel ranked ladder"
+msgstr ""
+
+#: src\commands\metagame.ts:283
+msgctxt "command-option-choice"
+msgid "Current format"
+msgstr ""
+
+#: src\commands\metagame.ts:287
+msgctxt "command-option-choice"
+msgid "Since last Forbidden/Limited List"
+msgstr ""
+
+#: src\commands\metagame.ts:291
+msgctxt "command-option-choice"
+msgid "Last 7 days"
+msgstr ""
+
+#: src\commands\metagame.ts:295
+msgctxt "command-option-choice"
+msgid "Last 14 days"
+msgstr ""
+
+#: src\commands\metagame.ts:299
+msgctxt "command-option-choice"
+msgid "Last 30 days"
+msgstr ""
+
+#: src\commands\metagame.ts:303
+msgctxt "command-option-choice"
+msgid "Last three months"
+msgstr ""
+
+#: src\commands\metagame.ts:307
+msgctxt "command-option-choice"
+msgid "Last six months"
 msgstr ""

--- a/translations/es.po
+++ b/translations/es.po
@@ -30,13 +30,13 @@ msgstr "**Tipo**: ${ raceIcon } ${ localizedMonsterTypeLine }"
 #: src\card.ts:491
 #: src\rush-duel.ts:94
 #, javascript-format
-msgid "**Attribute**: ${ AttributeIcon[card.attribute] } ${ localizedAttribute }"
-msgstr "**Atributo**: ${ AttributeIcon[card.attribute] } ${ localizedAttribute }"
+msgid "**Attribute**: ${ attributeIcon } ${ localizedAttribute }"
+msgstr "**Atributo**: ${ attributeIcon } ${ localizedAttribute }"
 
 #: src\card.ts:495
 #, javascript-format
-msgid "**Rank**: ${ Icon.Rank } ${ card.rank } **ATK**: ${ card.atk } **DEF**: ${ card.def }"
-msgstr "**Rango**: ${ Icon.Rank } ${ card.rank } **ATK**: ${ card.atk } **DEF**: ${ card.def }"
+msgid "**Rank**: ${ rankIcon } ${ card.rank } **ATK**: ${ card.atk } **DEF**: ${ card.def }"
+msgstr "**Rango**: ${ rankIcon } ${ card.rank } **ATK**: ${ card.atk } **DEF**: ${ card.def }"
 
 #: src\card.ts:498
 #, javascript-format
@@ -46,8 +46,8 @@ msgstr ""
 #: src\card.ts:500
 #: src\rush-duel.ts:96
 #, javascript-format
-msgid "**Level**: ${ Icon.Level } ${ card.level } **ATK**: ${ card.atk } **DEF**: ${ card.def }"
-msgstr "**Nivel**: ${ Icon.Level } ${ card.level } **ATK**: ${ card.atk } **DEF**: ${ card.def }"
+msgid "**Level**: ${ levelIcon } ${ card.level } **ATK**: ${ card.atk } **DEF**: ${ card.def }"
+msgstr "**Nivel**: ${ levelIcon } ${ card.level } **ATK**: ${ card.atk } **DEF**: ${ card.def }"
 
 #: src\card.ts:507
 #, javascript-format
@@ -459,7 +459,7 @@ msgstr ""
 
 #: src\card.ts:462
 #, javascript-format
-msgid "**Master Duel rarity**: ${ rarity_icon } ${ localized_rarity }"
+msgid "**Master Duel rarity**: ${ rarityIcon } ${ localizedRarity }"
 msgstr ""
 
 #: src\rush-duel.ts:205

--- a/translations/es.po
+++ b/translations/es.po
@@ -6,50 +6,33 @@ msgstr ""
 "MIME-Version: 1.0\n"
 "Content-Transfer-Encoding: 8bit\n"
 
-#: src\card.ts:416
-#: src\rush-duel.ts:39
+#: src\card.ts:412
+#: src\rush-duel.ts:48
 msgid "🔗 Links"
 msgstr ""
 
-#: src\card.ts:417
+#: src\card.ts:413
 #, javascript-format
 msgid "[Official Konami DB](${ official }) | [OCG Rulings](${ rulings }) | [Yugipedia](${ yugipedia }) | [YGOPRODECK](${ ygoprodeck })"
 msgstr ""
 
-#: src\card.ts:420
+#: src\card.ts:416
 #, javascript-format
 msgid "[Yugipedia](${ yugipedia }) | [YGOPRODECK](${ ygoprodeck })"
 msgstr ""
 
-#: src\card.ts:489
-#: src\rush-duel.ts:92
+#: src\card.ts:490
+#: src\rush-duel.ts:103
 #, javascript-format
 msgid "**Type**: ${ raceIcon } ${ localizedMonsterTypeLine }"
 msgstr "**Tipo**: ${ raceIcon } ${ localizedMonsterTypeLine }"
 
-#: src\card.ts:491
-#: src\rush-duel.ts:94
-#, javascript-format
-msgid "**Attribute**: ${ AttributeIcon[card.attribute] } ${ localizedAttribute }"
-msgstr "**Atributo**: ${ AttributeIcon[card.attribute] } ${ localizedAttribute }"
-
-#: src\card.ts:495
-#, javascript-format
-msgid "**Rank**: ${ Icon.Rank } ${ card.rank } **ATK**: ${ card.atk } **DEF**: ${ card.def }"
-msgstr "**Rango**: ${ Icon.Rank } ${ card.rank } **ATK**: ${ card.atk } **DEF**: ${ card.def }"
-
-#: src\card.ts:498
+#: src\card.ts:500
 #, javascript-format
 msgid "**Link Rating**: ${ card.link_arrows.length } **ATK**: ${ card.atk } **Link Arrows**: ${ arrows }"
 msgstr ""
 
-#: src\card.ts:500
-#: src\rush-duel.ts:96
-#, javascript-format
-msgid "**Level**: ${ Icon.Level } ${ card.level } **ATK**: ${ card.atk } **DEF**: ${ card.def }"
-msgstr "**Nivel**: ${ Icon.Level } ${ card.level } **ATK**: ${ card.atk } **DEF**: ${ card.def }"
-
-#: src\card.ts:507
+#: src\card.ts:511
 #, javascript-format
 msgid "**Pendulum Scale**: ${ formattedScale }"
 msgstr "**Escala de Péndulo**: ${ formattedScale }"
@@ -70,7 +53,7 @@ msgid "Password: ${ card.password } | Not yet released"
 msgstr ""
 
 #: src\card.ts:351
-#: src\rush-duel.ts:146
+#: src\rush-duel.ts:158
 msgid "Not yet released"
 msgstr ""
 
@@ -79,64 +62,64 @@ msgstr ""
 msgid "Placeholder ID: ${ card.fake_password }"
 msgstr ""
 
-#: src\utils.ts:41
+#: src\utils.ts:44
 msgid "🛠️ This command is in development."
 msgstr ""
 
-#: src\utils.ts:42
+#: src\utils.ts:45
 msgid "📨 Please send feedback to [our issue tracker](https://github.com/DawnbrandBots/bastion-bot) or the [support server](https://discord.gg/4aFuPyuE96)!"
 msgstr ""
 
-#: src\utils.ts:53
+#: src\utils.ts:56
 msgid "Please consider supporting us!"
 msgstr ""
 
-#: src\utils.ts:54
+#: src\utils.ts:57
 msgid "Help keep Bastion online!"
 msgstr ""
 
-#: src\utils.ts:55
+#: src\utils.ts:58
 msgid "Please help keep Bastion online!"
 msgstr ""
 
-#: src\utils.ts:56
+#: src\utils.ts:59
 msgid "Was Bastion helpful? Consider supporting us!"
 msgstr ""
 
-#: src\utils.ts:57
+#: src\utils.ts:60
 msgid "Was Bastion helpful? We need your support!"
 msgstr ""
 
-#: src\utils.ts:58
+#: src\utils.ts:61
 msgid "Did you find Bastion useful? Consider supporting us!"
 msgstr ""
 
-#: src\utils.ts:59
+#: src\utils.ts:62
 msgid "Did you find Bastion useful? Help keep it online!"
 msgstr ""
 
-#: src\utils.ts:60
+#: src\utils.ts:63
 msgid "Did you find Bastion useful? We need your support!"
 msgstr ""
 
-#: src\utils.ts:61
+#: src\utils.ts:64
 msgid "Enjoy Bastion? Help keep it online!"
 msgstr ""
 
-#: src\utils.ts:62
+#: src\utils.ts:65
 msgid "Enjoy Bastion? Consider supporting us!"
 msgstr ""
 
-#: src\utils.ts:63
+#: src\utils.ts:66
 msgid "Found what you were looking for? Consider supporting us!"
 msgstr ""
 
 #: src\commands\art.ts:63
-#: src\commands\price.ts:131
-#: src\commands\rush-duel.ts:172
-#: src\commands\rush-duel.ts:203
+#: src\commands\price.ts:132
+#: src\commands\rush-duel.ts:171
+#: src\commands\rush-duel.ts:202
 #: src\commands\search.ts:64
-#: src\events\message-search.ts:258
+#: src\events\message-search.ts:265
 #, javascript-format
 msgid "Could not find a card matching `${ input }`!"
 msgstr ""
@@ -147,51 +130,51 @@ msgstr ""
 msgid "Could not find art for `${ name }`!"
 msgstr ""
 
-#: src\commands\deck.ts:244
+#: src\commands\deck.ts:205
 #, javascript-format
 msgid "${ counts.Monster } Monster"
 msgid_plural "${ counts.Monster } Monsters"
 msgstr[0] ""
 msgstr[1] ""
 
-#: src\commands\deck.ts:247
+#: src\commands\deck.ts:208
 #, javascript-format
 msgid "${ counts.Spell } Spell"
 msgid_plural "${ counts.Spell } Spells"
 msgstr[0] ""
 msgstr[1] ""
 
-#: src\commands\deck.ts:250
+#: src\commands\deck.ts:211
 #, javascript-format
 msgid "${ counts.Trap } Trap"
 msgid_plural "${ counts.Trap } Traps"
 msgstr[0] ""
 msgstr[1] ""
 
-#: src\commands\deck.ts:278
+#: src\commands\deck.ts:239
 msgid "Your Deck"
 msgstr ""
 
-#: src\commands\deck.ts:283
+#: src\commands\deck.ts:244
 #, javascript-format
 msgid "Main Deck (${ deck.main.length } card — ${ countDetail })"
 msgid_plural "Main Deck (${ deck.main.length } cards — ${ countDetail })"
 msgstr[0] ""
 msgstr[1] ""
 
-#: src\commands\deck.ts:290
+#: src\commands\deck.ts:251
 msgid "Main Deck (continued)"
 msgstr ""
 
-#: src\commands\deck.ts:304
+#: src\commands\deck.ts:265
 msgid "Extra Deck (continued)"
 msgstr ""
 
-#: src\commands\deck.ts:318
+#: src\commands\deck.ts:279
 msgid "Side Deck (continued)"
 msgstr ""
 
-#: src\commands\deck.ts:407
+#: src\commands\deck.ts:347
 msgid "Error: Your deck is empty."
 msgstr ""
 
@@ -211,11 +194,7 @@ msgstr ""
 msgid "Discord Community locale for this server: ${ interaction.guildLocale }"
 msgstr ""
 
-#: src\commands\locale.ts:89
-#, javascript-format
-msgid "Locale override for this direct message: ${ override }"
-msgstr ""
-
+#: src\commands\locale-user.ts:76
 #: src\commands\locale.ts:92
 #, javascript-format
 msgid "Your Discord locale: ${ interaction.locale }"
@@ -253,24 +232,14 @@ msgstr ""
 msgid "Sorry, you must have the Manage Server permission to do this. If you think this is an error, contact your server admin or report a bug."
 msgstr ""
 
-#: src\commands\locale.ts:146
-#, javascript-format
-msgid "Locale for this direct message overridden with ${ locale }. Your Discord setting is ${ interaction.locale }."
-msgstr ""
-
-#: src\commands\locale.ts:150
-#, javascript-format
-msgid "Locale for this direct message reset to Discord default. Your Discord setting is ${ interaction.locale }."
-msgstr ""
-
-#: src\commands\ping.ts:36
-#: src\events\message-ping.ts:47
+#: src\commands\ping.ts:38
+#: src\events\message-ping.ts:45
 #, javascript-format
 msgid "Average WebSocket ping (new instance): ${ ping } ms"
 msgstr ""
 
-#: src\commands\ping.ts:40
-#: src\events\message-ping.ts:112
+#: src\commands\ping.ts:42
+#: src\events\message-ping.ts:110
 #, javascript-format
 msgid "Total latency: ${ latency } ms"
 msgstr ""
@@ -280,86 +249,69 @@ msgstr ""
 msgid "Could not find a Yugipedia page named `${ page }`."
 msgstr ""
 
-#: src\events\message-ping.ts:49
+#: src\events\message-ping.ts:47
 msgid "Free and open source _Yu-Gi-Oh!_ bot"
 msgstr ""
 
-#: src\events\message-ping.ts:72
+#: src\events\message-ping.ts:70
 #, javascript-format
 msgid "Revision: ${ process.env.BOT_REVISION }."
 msgstr ""
 
-#: src\commands\deck.ts:328
+#: src\commands\deck.ts:289
 msgid ".ydk files must have the .ydk extension!"
 msgstr ""
 
-#: src\commands\deck.ts:331
+#: src\commands\deck.ts:292
 msgid ".ydk files should not be larger than 1 KB!"
 msgstr ""
 
-#: src\commands\deck.ts:321
+#: src\commands\deck.ts:282
 msgid "ydke URL"
 msgstr ""
 
 #: src\card.ts:455
-#: src\rush-duel.ts:61
+#: src\rush-duel.ts:75
 #. Forbidden/Limited Lists or Limit Regulations in the OCG
 #, javascript-format
 msgid "**Limit**: ${ limitRegulationDisplay }"
 msgstr ""
 
-#: src\commands\price.ts:69
+#: src\commands\price.ts:70
 msgid "TCGPlayer"
 msgstr ""
 
-#: src\commands\price.ts:70
+#: src\commands\price.ts:71
 msgid "Cardmarket"
 msgstr ""
 
-#: src\commands\price.ts:147
+#: src\commands\price.ts:148
 msgid "No market price"
 msgstr ""
 
-#: src\commands\price.ts:155
+#: src\commands\price.ts:156
 #, javascript-format
 msgid "Prices for ${ card.name[resultLanguage] } - ${ vendorName }"
 msgstr ""
 
-#: src\commands\price.ts:169
+#: src\commands\price.ts:170
 #, javascript-format
 msgid "Could not find prices for `${ name }`!"
 msgstr ""
 
-#: src\commands\deck.ts:425
-#. prepare interaction button for FTP upload
+#: src\commands\deck.ts:363
 msgid "Upload to YGOPRODECK"
 msgstr ""
 
-#: src\commands\deck.ts:483
-#. disable original button
-#. prepare row to disable button on original message
-msgid "Upload Complete"
-msgstr ""
-
-#: src\commands\deck.ts:470
-msgid "Deck upload failed!"
-msgstr ""
-
-#: src\commands\deck.ts:491
-#. reply in affirmation
-#, javascript-format
-msgid "Deck successfully uploaded to <${ url }>!"
-msgstr ""
-
-#: src\events\message-search.ts:264
+#: src\events\message-search.ts:271
 msgid "💬 Translations missing?"
 msgstr ""
 
-#: src\events\message-search.ts:265
+#: src\events\message-search.ts:272
 msgid "Help translate Bastion at the links above."
 msgstr ""
 
-#: src\events\message-ping.ts:50
+#: src\events\message-ping.ts:48
 msgid ""
 "❓ Help documentation on [GitHub](https://github.com/DawnbrandBots/bastion-bot), or use `.commands` and `.help`.\n"
 "🟢 Licence: [GNU AGPL 3.0+](https://choosealicense.com/licenses/agpl-3.0/).\n"
@@ -375,38 +327,38 @@ msgid ""
 "💬 Translations missing? Help translate Bastion on [GitHub](https://github.com/DawnbrandBots/bastion-bot)."
 msgstr ""
 
-#: src\events\message-search.ts:256
-#: src\events\message-search.ts:294
+#: src\events\message-search.ts:263
+#: src\events\message-search.ts:302
 #, javascript-format
 msgid "Search type: ${ localisedType }"
 msgstr ""
 
-#: src\events\message-search.ts:236
+#: src\events\message-search.ts:242
 #, javascript-format
 msgid "Search language: **${ localisedInputLanguage }** (${ inputLanguage }). Check defaults with </locale get:${ id }> and configure with </locale set:${ id }>"
 msgstr ""
 
-#: src\events\message-ping.ts:95
+#: src\events\message-ping.ts:93
 msgid "⚠️ You pinged me, but I am missing permissions in the channel!"
 msgstr ""
 
-#: src\events\message-ping.ts:98
-#: src\events\message-search.ts:332
+#: src\events\message-ping.ts:96
+#: src\events\message-search.ts:340
 msgid "Please have a server administrator [fix this](https://github.com/DawnbrandBots/bastion-bot#discord-permissions)."
 msgstr ""
 
-#: src\events\message-search.ts:329
+#: src\events\message-search.ts:337
 msgid "⚠️ I am missing permissions in the channel!"
 msgstr ""
 
-#: src\commands\deck.ts:297
+#: src\commands\deck.ts:258
 #, javascript-format
 msgid "Extra Deck (${ deck.extra.length } card — ${ countDetail })"
 msgid_plural "Extra Deck (${ deck.extra.length } cards — ${ countDetail })"
 msgstr[0] ""
 msgstr[1] ""
 
-#: src\commands\deck.ts:311
+#: src\commands\deck.ts:272
 #, javascript-format
 msgid "Side Deck (${ deck.side.length } card — ${ countDetail })"
 msgid_plural "Side Deck (${ deck.side.length } cards — ${ countDetail })"
@@ -428,48 +380,82 @@ msgstr ""
 msgid "Something went wrong searching Yugipedia for `${ page }`."
 msgstr ""
 
-#: src\rush-duel.ts:40
+#: src\rush-duel.ts:49
 #, javascript-format
 msgid "[Official Konami DB](${ official }) | [Rulings (Japanese)](${ rulings }) | [Yugipedia](${ yugipedia }) | [RushCard](${ rushcard })"
 msgstr ""
 
-#: src\rush-duel.ts:43
+#: src\rush-duel.ts:52
 #, javascript-format
 msgid "[Yugipedia](${ yugipedia }) | [RushCard](${ rushcard })"
 msgstr ""
 
-#: src\rush-duel.ts:57
+#: src\rush-duel.ts:71
 msgid "__**LEGEND**__"
 msgstr ""
 
-#: src\rush-duel.ts:99
+#: src\rush-duel.ts:110
 #, javascript-format
 msgid "**MAXIMUM ATK**: ${ card.maximum_atk }"
 msgstr ""
 
-#: src\rush-duel.ts:146
+#: src\rush-duel.ts:158
 #, javascript-format
 msgid "Konami ID #${ card.konami_id }"
 msgstr ""
 
 #: src\art.ts:129
-#: src\commands\deck.ts:451
 msgid "Buttons can only be used by the user who called Bastion."
 msgstr ""
 
-#: src\card.ts:462
-#, javascript-format
-msgid "**Master Duel rarity**: ${ rarity_icon } ${ localized_rarity }"
-msgstr ""
-
-#: src\rush-duel.ts:205
+#: src\rush-duel.ts:217
 #, javascript-format
 msgid "Using ${ searchTrigger }, you can search for Rush Duel cards directly in messages without autocomplete"
 msgstr ""
 
-#: src\events\message-search.ts:296
+#: src\events\message-search.ts:304
 #, javascript-format
 msgid "Could not find a Rush Duel card matching `${ input }`!"
+msgstr ""
+
+#: src\card.ts:462
+#, javascript-format
+msgid "**Master Duel rarity**: ${ rarityIcon } ${ localizedRarity }"
+msgstr ""
+
+#: src\card.ts:492
+#: src\rush-duel.ts:105
+#, javascript-format
+msgid "**Attribute**: ${ attributeIcon } ${ localizedAttribute }"
+msgstr ""
+
+#: src\card.ts:497
+#, javascript-format
+msgid "**Rank**: ${ rankIcon } ${ card.rank } **ATK**: ${ card.atk } **DEF**: ${ card.def }"
+msgstr ""
+
+#: src\card.ts:503
+#: src\rush-duel.ts:107
+#, javascript-format
+msgid "**Level**: ${ levelIcon } ${ card.level } **ATK**: ${ card.atk } **DEF**: ${ card.def }"
+msgstr ""
+
+#: src\commands\locale-user.ts:73
+#: src\commands\locale.ts:89
+#, javascript-format
+msgid "Locale override for your direct messages: ${ override }"
+msgstr ""
+
+#: src\commands\locale-user.ts:83
+#: src\commands\locale.ts:146
+#, javascript-format
+msgid "Locale for your direct messages overridden with ${ locale }. Your Discord setting is ${ interaction.locale }."
+msgstr ""
+
+#: src\commands\locale-user.ts:87
+#: src\commands\locale.ts:150
+#, javascript-format
+msgid "Locale for your direct messages reset to Discord default. Your Discord setting is ${ interaction.locale }."
 msgstr ""
 
 #: src\card.ts:40
@@ -836,65 +822,65 @@ msgctxt "master-duel-rarity"
 msgid "Ultra Rare (UR)"
 msgstr "Ultra Raro (UR)"
 
-#: src\card.ts:513
-#: src\card.ts:524
-#: src\rush-duel.ts:127
+#: src\card.ts:517
+#: src\card.ts:528
+#: src\rush-duel.ts:138
 msgctxt "card-embed"
 msgid "Card Text"
 msgstr "Texto de carta"
 
-#: src\card.ts:518
+#: src\card.ts:522
 msgctxt "card-embed"
 msgid "Pendulum Effect"
 msgstr "Efecto de Péndulo"
 
-#: src\card.ts:539
+#: src\card.ts:545
 msgctxt "card-embed"
 msgid "Card Effect"
 msgstr ""
 
-#: src\rush-duel.ts:118
-#: src\rush-duel.ts:139
+#: src\rush-duel.ts:129
+#: src\rush-duel.ts:151
 msgctxt "card-embed"
 msgid "[REQUIREMENT]"
 msgstr "[REQUISITO]"
 
-#: src\rush-duel.ts:119
-#: src\rush-duel.ts:140
+#: src\rush-duel.ts:130
+#: src\rush-duel.ts:152
 msgctxt "card-embed"
 msgid "[EFFECT]"
 msgstr "[EFECTO]"
 
-#: src\rush-duel.ts:121
+#: src\rush-duel.ts:132
 msgctxt "card-embed"
 msgid "[CONTINUOUS EFFECT]"
 msgstr "[EFECTO CONTINUO]"
 
-#: src\rush-duel.ts:123
+#: src\rush-duel.ts:134
 msgctxt "card-embed"
 msgid "[MULTI-CHOICE EFFECT]"
 msgstr ""
 
-#: src\locale.ts:71
+#: src\locale.ts:74
 msgctxt "command-option"
 msgid "result-language"
 msgstr ""
 
-#: src\locale.ts:131
+#: src\locale.ts:140
 msgctxt "command-option"
 msgid "input-language"
 msgstr ""
 
-#: src\commands\rush-duel.ts:68
-#: src\commands\rush-duel.ts:80
-#: src\locale.ts:147
-#: src\locale.ts:165
-#: src\locale.ts:181
+#: src\commands\rush-duel.ts:67
+#: src\commands\rush-duel.ts:79
+#: src\locale.ts:156
+#: src\locale.ts:174
+#: src\locale.ts:190
 msgctxt "command-option"
 msgid "input"
 msgstr ""
 
-#: src\commands\help.ts:52
+#: src\commands\help.ts:55
 msgctxt "command-option"
 msgid "command"
 msgstr ""
@@ -909,54 +895,56 @@ msgctxt "command-option"
 msgid "page"
 msgstr ""
 
-#: src\commands\deck.ts:126
+#: src\commands\deck.ts:87
 msgctxt "command-option"
 msgid "url"
 msgstr ""
 
-#: src\commands\deck.ts:132
+#: src\commands\deck.ts:93
 msgctxt "command-option"
 msgid "file"
 msgstr ""
 
-#: src\commands\deck.ts:138
-#: src\commands\deck.ts:144
+#: src\commands\deck.ts:99
+#: src\commands\deck.ts:105
 msgctxt "command-option"
 msgid "deck"
 msgstr ""
 
-#: src\commands\deck.ts:150
+#: src\commands\deck.ts:111
 msgctxt "command-option"
 msgid "public"
 msgstr ""
 
-#: src\commands\deck.ts:157
+#: src\commands\deck.ts:118
 msgctxt "command-option"
 msgid "stacked"
 msgstr ""
 
-#: src\locale.ts:142
+#: src\locale.ts:151
 msgctxt "command-option"
 msgid "name"
 msgstr ""
 
-#: src\locale.ts:160
+#: src\locale.ts:169
 msgctxt "command-option"
 msgid "password"
 msgstr ""
 
-#: src\commands\rush-duel.ts:73
-#: src\events\message-search.ts:293
-#: src\locale.ts:176
+#: src\commands\rush-duel.ts:72
+#: src\events\message-search.ts:301
+#: src\locale.ts:185
 msgctxt "command-option"
 msgid "konami-id"
 msgstr ""
 
+#: src\commands\locale-user.ts:36
 #: src\commands\locale.ts:30
 msgctxt "command-option"
 msgid "get"
 msgstr ""
 
+#: src\commands\locale-user.ts:41
 #: src\commands\locale.ts:35
 msgctxt "command-option"
 msgid "set"
@@ -967,47 +955,69 @@ msgctxt "command-option"
 msgid "scope"
 msgstr ""
 
+#: src\commands\locale-user.ts:46
 #: src\commands\locale.ts:48
 msgctxt "command-option"
 msgid "locale"
 msgstr ""
 
-#: src\commands\price.ts:94
+#: src\commands\price.ts:95
 msgctxt "command-option"
 msgid "vendor"
 msgstr ""
 
-#: src\commands\rush-duel.ts:63
+#: src\commands\rush-duel.ts:62
 msgctxt "command-option"
 msgid "search"
 msgstr ""
 
-#: src\commands\rush-duel.ts:85
+#: src\commands\rush-duel.ts:84
 msgctxt "command-option"
 msgid "random"
 msgstr ""
 
-#: src\commands\rush-duel.ts:90
+#: src\commands\rush-duel.ts:89
 msgctxt "command-option"
 msgid "art"
 msgstr ""
 
-#: src\commands\query.ts:36
+#: src\commands\query.ts:35
 msgctxt "command-option"
 msgid "lucene"
 msgstr ""
 
-#: src\locale.ts:74
+#: src\commands\metagame.ts:209
+msgctxt "command-option"
+msgid "strategies"
+msgstr ""
+
+#: src\commands\metagame.ts:234
+#: src\commands\metagame.ts:274
+msgctxt "command-option"
+msgid "format"
+msgstr ""
+
+#: src\commands\metagame.ts:240
+msgctxt "command-option"
+msgid "cards"
+msgstr ""
+
+#: src\commands\metagame.ts:310
+msgctxt "command-option"
+msgid "date-range"
+msgstr ""
+
+#: src\locale.ts:77
 msgctxt "command-option-description"
 msgid "The output language for the card embed, overriding other settings."
 msgstr ""
 
-#: src\locale.ts:132
+#: src\locale.ts:141
 msgctxt "command-option-description"
 msgid "The language to search in, defaulting to the result language."
 msgstr ""
 
-#: src\commands\help.ts:55
+#: src\commands\help.ts:58
 msgctxt "command-option-description"
 msgid "The name of a specific Slash Command."
 msgstr ""
@@ -1017,32 +1027,32 @@ msgctxt "command-option-description"
 msgid "The name of the Yugipedia page you want to search for."
 msgstr ""
 
-#: src\commands\deck.ts:129
+#: src\commands\deck.ts:90
 msgctxt "command-option-description"
 msgid "View a deck by entering a ydke:// URL."
 msgstr ""
 
-#: src\commands\deck.ts:135
+#: src\commands\deck.ts:96
 msgctxt "command-option-description"
 msgid "View a deck by uploading a .ydk file."
 msgstr ""
 
-#: src\commands\deck.ts:141
+#: src\commands\deck.ts:102
 msgctxt "command-option-description"
 msgid "The ydke:// URL of the deck you want to view."
 msgstr ""
 
-#: src\commands\deck.ts:147
+#: src\commands\deck.ts:108
 msgctxt "command-option-description"
 msgid "The .ydk file of the deck you want to view."
 msgstr ""
 
-#: src\commands\deck.ts:153
+#: src\commands\deck.ts:114
 msgctxt "command-option-description"
 msgid "Whether to display the deck details publicly in chat. This is false by default."
 msgstr ""
 
-#: src\commands\deck.ts:160
+#: src\commands\deck.ts:121
 msgctxt "command-option-description"
 msgid "Whether to display the deck sections as one stacked column. This is false (side-by-side) by default."
 msgstr ""
@@ -1052,8 +1062,8 @@ msgctxt "command-option-description"
 msgid "Display the art for the card with this name."
 msgstr ""
 
-#: src\commands\rush-duel.ts:69
-#: src\locale.ts:148
+#: src\commands\rush-duel.ts:68
+#: src\locale.ts:157
 msgctxt "command-option-description"
 msgid "Card name, fuzzy matching supported."
 msgstr ""
@@ -1063,7 +1073,7 @@ msgctxt "command-option-description"
 msgid "Display the art for the card with this password."
 msgstr ""
 
-#: src\locale.ts:167
+#: src\locale.ts:176
 msgctxt "command-option-description"
 msgid "Card password, the eight-digit number printed on the bottom left corner."
 msgstr ""
@@ -1073,8 +1083,8 @@ msgctxt "command-option-description"
 msgid "Display the art for the card with this official database ID."
 msgstr ""
 
-#: src\commands\rush-duel.ts:81
-#: src\locale.ts:182
+#: src\commands\rush-duel.ts:80
+#: src\locale.ts:191
 msgctxt "command-option-description"
 msgid "Konami's official card database identifier."
 msgstr ""
@@ -1114,22 +1124,22 @@ msgctxt "command-option-description"
 msgid "The new default language to use in this channel or server."
 msgstr ""
 
-#: src\commands\price.ts:98
+#: src\commands\price.ts:99
 msgctxt "command-option-description"
 msgid "Display the price for the card with this name."
 msgstr ""
 
-#: src\commands\price.ts:102
+#: src\commands\price.ts:103
 msgctxt "command-option-description"
 msgid "Display the price for the card with this password."
 msgstr ""
 
-#: src\commands\price.ts:105
+#: src\commands\price.ts:106
 msgctxt "command-option-description"
 msgid "Display the price for the card with this official database ID."
 msgstr ""
 
-#: src\commands\price.ts:95
+#: src\commands\price.ts:96
 msgctxt "command-option-description"
 msgid "The vendor to fetch the price data from."
 msgstr ""
@@ -1139,29 +1149,70 @@ msgctxt "command-option-description"
 msgid "The English name of the card you're looking for."
 msgstr ""
 
-#: src\commands\rush-duel.ts:64
+#: src\commands\rush-duel.ts:63
 msgctxt "command-option-description"
 msgid "Find all information for the Rush Duel card with this name."
 msgstr ""
 
-#: src\commands\rush-duel.ts:75
+#: src\commands\rush-duel.ts:74
 msgctxt "command-option-description"
 msgid "Find all information for the Rush Duel card with this official database ID."
 msgstr ""
 
-#: src\commands\rush-duel.ts:86
+#: src\commands\rush-duel.ts:85
 msgctxt "command-option-description"
 msgid "Get a random Rush Duel card."
 msgstr ""
 
-#: src\commands\rush-duel.ts:91
+#: src\commands\rush-duel.ts:90
 msgctxt "command-option-description"
 msgid "Display just the art for the Rush Duel card with this name."
 msgstr ""
 
-#: src\commands\query.ts:37
+#: src\commands\query.ts:36
 msgctxt "command-option-description"
 msgid "Lucene query on YAML Yugi"
+msgstr ""
+
+#: src\commands\locale-user.ts:37
+msgctxt "command-option-description"
+msgid "Check your user-installed Bastion's locale."
+msgstr ""
+
+#: src\commands\locale-user.ts:42
+msgctxt "command-option-description"
+msgid "Configure your user-installed Bastion's locale."
+msgstr ""
+
+#: src\commands\locale-user.ts:47
+msgctxt "command-option-description"
+msgid "The new default language to use for user-installed Bastion."
+msgstr ""
+
+#: src\commands\metagame.ts:212
+msgctxt "command-option-description"
+msgid "Show the top competitive strategies in tournaments and the Master Duel ranked ladder."
+msgstr ""
+
+#: src\commands\metagame.ts:214
+msgctxt "command-option-description"
+msgid "Show the top competitive strategies in tournaments."
+msgstr ""
+
+#: src\commands\metagame.ts:235
+#: src\commands\metagame.ts:275
+msgctxt "command-option-description"
+msgid "Game region."
+msgstr ""
+
+#: src\commands\metagame.ts:242
+msgctxt "command-option-description"
+msgid "Show the most popular cards in tournaments and the Master Duel ranked ladder."
+msgstr ""
+
+#: src\commands\metagame.ts:312
+msgctxt "command-option-description"
+msgid "Limit card usage statistics to this date range. Has no effect for Master Duel."
 msgstr ""
 
 #: src\commands\art.ts:36
@@ -1169,12 +1220,12 @@ msgctxt "command-name"
 msgid "art"
 msgstr ""
 
-#: src\commands\help.ts:49
+#: src\commands\help.ts:52
 msgctxt "command-name"
 msgid "help"
 msgstr ""
 
-#: src\commands\ping.ts:23
+#: src\commands\ping.ts:25
 msgctxt "command-name"
 msgid "ping"
 msgstr ""
@@ -1189,7 +1240,7 @@ msgctxt "command-name"
 msgid "yugipedia"
 msgstr ""
 
-#: src\commands\deck.ts:119
+#: src\commands\deck.ts:80
 msgctxt "command-name"
 msgid "deck"
 msgstr ""
@@ -1204,24 +1255,34 @@ msgctxt "command-name"
 msgid "locale"
 msgstr ""
 
-#: src\commands\random.ts:44
+#: src\commands\random.ts:43
 msgctxt "command-name"
 msgid "random"
 msgstr ""
 
-#: src\commands\price.ts:89
+#: src\commands\price.ts:90
 msgctxt "command-name"
 msgid "price"
 msgstr ""
 
-#: src\commands\rush-duel.ts:58
+#: src\commands\rush-duel.ts:57
 msgctxt "command-name"
 msgid "rush-duel"
 msgstr ""
 
-#: src\commands\query.ts:30
+#: src\commands\query.ts:29
 msgctxt "command-name"
 msgid "query"
+msgstr ""
+
+#: src\commands\locale-user.ts:31
+msgctxt "command-name"
+msgid "locale-user"
+msgstr ""
+
+#: src\commands\metagame.ts:204
+msgctxt "command-name"
+msgid "metagame"
 msgstr ""
 
 #: src\commands\art.ts:37
@@ -1229,12 +1290,12 @@ msgctxt "command-description"
 msgid "Display the art for a card!"
 msgstr ""
 
-#: src\commands\help.ts:50
+#: src\commands\help.ts:53
 msgctxt "command-description"
 msgid "Get help with a Slash Command."
 msgstr ""
 
-#: src\commands\ping.ts:24
+#: src\commands\ping.ts:26
 msgctxt "command-description"
 msgid "Test latency to the new bot instance."
 msgstr ""
@@ -1249,7 +1310,7 @@ msgctxt "command-description"
 msgid "Search the Yugipedia wiki for a page and link to it."
 msgstr ""
 
-#: src\commands\deck.ts:122
+#: src\commands\deck.ts:83
 msgctxt "command-description"
 msgid "Display a deck list from ydke:// or .ydk format, exported from a number of deck building programs."
 msgstr ""
@@ -1264,24 +1325,34 @@ msgctxt "command-description"
 msgid "Check or set Bastion's locale for this channel or server."
 msgstr ""
 
-#: src\commands\random.ts:45
+#: src\commands\random.ts:44
 msgctxt "command-description"
 msgid "Get a random Yu-Gi-Oh! card."
 msgstr ""
 
-#: src\commands\price.ts:90
+#: src\commands\price.ts:91
 msgctxt "command-description"
 msgid "Display the price for a card!"
 msgstr ""
 
-#: src\commands\rush-duel.ts:59
+#: src\commands\rush-duel.ts:58
 msgctxt "command-description"
 msgid "Find information on Rush Duel cards."
 msgstr ""
 
-#: src\commands\query.ts:31
+#: src\commands\query.ts:30
 msgctxt "command-description"
 msgid "Advanced search prototype"
+msgstr ""
+
+#: src\commands\locale-user.ts:32
+msgctxt "command-description"
+msgid "Check or set user-installed Bastion's locale."
+msgstr ""
+
+#: src\commands\metagame.ts:205
+msgctxt "command-description"
+msgid "Show statistics on the current competitive state of play."
 msgstr ""
 
 #: src\commands\locale.ts:43
@@ -1294,7 +1365,71 @@ msgctxt "command-option-choice"
 msgid "server"
 msgstr ""
 
+#: src\commands\locale-user.ts:49
 #: src\commands\locale.ts:51
 msgctxt "command-option-choice"
 msgid "Discord default"
+msgstr ""
+
+#: src\commands\metagame.ts:219
+#: src\commands\metagame.ts:251
+msgctxt "command-option-choice"
+msgid "TCG"
+msgstr ""
+
+#: src\commands\metagame.ts:220
+#: src\commands\metagame.ts:255
+msgctxt "command-option-choice"
+msgid "OCG"
+msgstr ""
+
+#: src\commands\metagame.ts:221
+#: src\commands\metagame.ts:259
+msgctxt "command-option-choice"
+msgid "OCG (Asian-English)"
+msgstr ""
+
+#: src\commands\metagame.ts:228
+msgctxt "command-option-choice"
+msgid "Master Duel Diamond+ tier list"
+msgstr ""
+
+#: src\commands\metagame.ts:261
+msgctxt "command-option-choice"
+msgid "Master Duel ranked ladder"
+msgstr ""
+
+#: src\commands\metagame.ts:283
+msgctxt "command-option-choice"
+msgid "Current format"
+msgstr ""
+
+#: src\commands\metagame.ts:287
+msgctxt "command-option-choice"
+msgid "Since last Forbidden/Limited List"
+msgstr ""
+
+#: src\commands\metagame.ts:291
+msgctxt "command-option-choice"
+msgid "Last 7 days"
+msgstr ""
+
+#: src\commands\metagame.ts:295
+msgctxt "command-option-choice"
+msgid "Last 14 days"
+msgstr ""
+
+#: src\commands\metagame.ts:299
+msgctxt "command-option-choice"
+msgid "Last 30 days"
+msgstr ""
+
+#: src\commands\metagame.ts:303
+msgctxt "command-option-choice"
+msgid "Last three months"
+msgstr ""
+
+#: src\commands\metagame.ts:307
+msgctxt "command-option-choice"
+msgid "Last six months"
 msgstr ""

--- a/translations/es.po
+++ b/translations/es.po
@@ -6,33 +6,50 @@ msgstr ""
 "MIME-Version: 1.0\n"
 "Content-Transfer-Encoding: 8bit\n"
 
-#: src\card.ts:412
-#: src\rush-duel.ts:48
+#: src\card.ts:416
+#: src\rush-duel.ts:39
 msgid "🔗 Links"
 msgstr ""
 
-#: src\card.ts:413
+#: src\card.ts:417
 #, javascript-format
 msgid "[Official Konami DB](${ official }) | [OCG Rulings](${ rulings }) | [Yugipedia](${ yugipedia }) | [YGOPRODECK](${ ygoprodeck })"
 msgstr ""
 
-#: src\card.ts:416
+#: src\card.ts:420
 #, javascript-format
 msgid "[Yugipedia](${ yugipedia }) | [YGOPRODECK](${ ygoprodeck })"
 msgstr ""
 
-#: src\card.ts:490
-#: src\rush-duel.ts:103
+#: src\card.ts:489
+#: src\rush-duel.ts:92
 #, javascript-format
 msgid "**Type**: ${ raceIcon } ${ localizedMonsterTypeLine }"
 msgstr "**Tipo**: ${ raceIcon } ${ localizedMonsterTypeLine }"
 
-#: src\card.ts:500
+#: src\card.ts:491
+#: src\rush-duel.ts:94
+#, javascript-format
+msgid "**Attribute**: ${ AttributeIcon[card.attribute] } ${ localizedAttribute }"
+msgstr "**Atributo**: ${ AttributeIcon[card.attribute] } ${ localizedAttribute }"
+
+#: src\card.ts:495
+#, javascript-format
+msgid "**Rank**: ${ Icon.Rank } ${ card.rank } **ATK**: ${ card.atk } **DEF**: ${ card.def }"
+msgstr "**Rango**: ${ Icon.Rank } ${ card.rank } **ATK**: ${ card.atk } **DEF**: ${ card.def }"
+
+#: src\card.ts:498
 #, javascript-format
 msgid "**Link Rating**: ${ card.link_arrows.length } **ATK**: ${ card.atk } **Link Arrows**: ${ arrows }"
 msgstr ""
 
-#: src\card.ts:511
+#: src\card.ts:500
+#: src\rush-duel.ts:96
+#, javascript-format
+msgid "**Level**: ${ Icon.Level } ${ card.level } **ATK**: ${ card.atk } **DEF**: ${ card.def }"
+msgstr "**Nivel**: ${ Icon.Level } ${ card.level } **ATK**: ${ card.atk } **DEF**: ${ card.def }"
+
+#: src\card.ts:507
 #, javascript-format
 msgid "**Pendulum Scale**: ${ formattedScale }"
 msgstr "**Escala de Péndulo**: ${ formattedScale }"
@@ -53,7 +70,7 @@ msgid "Password: ${ card.password } | Not yet released"
 msgstr ""
 
 #: src\card.ts:351
-#: src\rush-duel.ts:158
+#: src\rush-duel.ts:146
 msgid "Not yet released"
 msgstr ""
 
@@ -62,64 +79,64 @@ msgstr ""
 msgid "Placeholder ID: ${ card.fake_password }"
 msgstr ""
 
-#: src\utils.ts:44
+#: src\utils.ts:41
 msgid "🛠️ This command is in development."
 msgstr ""
 
-#: src\utils.ts:45
+#: src\utils.ts:42
 msgid "📨 Please send feedback to [our issue tracker](https://github.com/DawnbrandBots/bastion-bot) or the [support server](https://discord.gg/4aFuPyuE96)!"
 msgstr ""
 
-#: src\utils.ts:56
+#: src\utils.ts:53
 msgid "Please consider supporting us!"
 msgstr ""
 
-#: src\utils.ts:57
+#: src\utils.ts:54
 msgid "Help keep Bastion online!"
 msgstr ""
 
-#: src\utils.ts:58
+#: src\utils.ts:55
 msgid "Please help keep Bastion online!"
 msgstr ""
 
-#: src\utils.ts:59
+#: src\utils.ts:56
 msgid "Was Bastion helpful? Consider supporting us!"
 msgstr ""
 
-#: src\utils.ts:60
+#: src\utils.ts:57
 msgid "Was Bastion helpful? We need your support!"
 msgstr ""
 
-#: src\utils.ts:61
+#: src\utils.ts:58
 msgid "Did you find Bastion useful? Consider supporting us!"
 msgstr ""
 
-#: src\utils.ts:62
+#: src\utils.ts:59
 msgid "Did you find Bastion useful? Help keep it online!"
 msgstr ""
 
-#: src\utils.ts:63
+#: src\utils.ts:60
 msgid "Did you find Bastion useful? We need your support!"
 msgstr ""
 
-#: src\utils.ts:64
+#: src\utils.ts:61
 msgid "Enjoy Bastion? Help keep it online!"
 msgstr ""
 
-#: src\utils.ts:65
+#: src\utils.ts:62
 msgid "Enjoy Bastion? Consider supporting us!"
 msgstr ""
 
-#: src\utils.ts:66
+#: src\utils.ts:63
 msgid "Found what you were looking for? Consider supporting us!"
 msgstr ""
 
 #: src\commands\art.ts:63
-#: src\commands\price.ts:132
-#: src\commands\rush-duel.ts:171
-#: src\commands\rush-duel.ts:202
+#: src\commands\price.ts:131
+#: src\commands\rush-duel.ts:172
+#: src\commands\rush-duel.ts:203
 #: src\commands\search.ts:64
-#: src\events\message-search.ts:265
+#: src\events\message-search.ts:258
 #, javascript-format
 msgid "Could not find a card matching `${ input }`!"
 msgstr ""
@@ -130,51 +147,51 @@ msgstr ""
 msgid "Could not find art for `${ name }`!"
 msgstr ""
 
-#: src\commands\deck.ts:205
+#: src\commands\deck.ts:244
 #, javascript-format
 msgid "${ counts.Monster } Monster"
 msgid_plural "${ counts.Monster } Monsters"
 msgstr[0] ""
 msgstr[1] ""
 
-#: src\commands\deck.ts:208
+#: src\commands\deck.ts:247
 #, javascript-format
 msgid "${ counts.Spell } Spell"
 msgid_plural "${ counts.Spell } Spells"
 msgstr[0] ""
 msgstr[1] ""
 
-#: src\commands\deck.ts:211
+#: src\commands\deck.ts:250
 #, javascript-format
 msgid "${ counts.Trap } Trap"
 msgid_plural "${ counts.Trap } Traps"
 msgstr[0] ""
 msgstr[1] ""
 
-#: src\commands\deck.ts:239
+#: src\commands\deck.ts:278
 msgid "Your Deck"
 msgstr ""
 
-#: src\commands\deck.ts:244
+#: src\commands\deck.ts:283
 #, javascript-format
 msgid "Main Deck (${ deck.main.length } card — ${ countDetail })"
 msgid_plural "Main Deck (${ deck.main.length } cards — ${ countDetail })"
 msgstr[0] ""
 msgstr[1] ""
 
-#: src\commands\deck.ts:251
+#: src\commands\deck.ts:290
 msgid "Main Deck (continued)"
 msgstr ""
 
-#: src\commands\deck.ts:265
+#: src\commands\deck.ts:304
 msgid "Extra Deck (continued)"
 msgstr ""
 
-#: src\commands\deck.ts:279
+#: src\commands\deck.ts:318
 msgid "Side Deck (continued)"
 msgstr ""
 
-#: src\commands\deck.ts:347
+#: src\commands\deck.ts:407
 msgid "Error: Your deck is empty."
 msgstr ""
 
@@ -194,7 +211,11 @@ msgstr ""
 msgid "Discord Community locale for this server: ${ interaction.guildLocale }"
 msgstr ""
 
-#: src\commands\locale-user.ts:76
+#: src\commands\locale.ts:89
+#, javascript-format
+msgid "Locale override for this direct message: ${ override }"
+msgstr ""
+
 #: src\commands\locale.ts:92
 #, javascript-format
 msgid "Your Discord locale: ${ interaction.locale }"
@@ -232,14 +253,24 @@ msgstr ""
 msgid "Sorry, you must have the Manage Server permission to do this. If you think this is an error, contact your server admin or report a bug."
 msgstr ""
 
-#: src\commands\ping.ts:38
-#: src\events\message-ping.ts:45
+#: src\commands\locale.ts:146
+#, javascript-format
+msgid "Locale for this direct message overridden with ${ locale }. Your Discord setting is ${ interaction.locale }."
+msgstr ""
+
+#: src\commands\locale.ts:150
+#, javascript-format
+msgid "Locale for this direct message reset to Discord default. Your Discord setting is ${ interaction.locale }."
+msgstr ""
+
+#: src\commands\ping.ts:36
+#: src\events\message-ping.ts:47
 #, javascript-format
 msgid "Average WebSocket ping (new instance): ${ ping } ms"
 msgstr ""
 
-#: src\commands\ping.ts:42
-#: src\events\message-ping.ts:110
+#: src\commands\ping.ts:40
+#: src\events\message-ping.ts:112
 #, javascript-format
 msgid "Total latency: ${ latency } ms"
 msgstr ""
@@ -249,69 +280,86 @@ msgstr ""
 msgid "Could not find a Yugipedia page named `${ page }`."
 msgstr ""
 
-#: src\events\message-ping.ts:47
+#: src\events\message-ping.ts:49
 msgid "Free and open source _Yu-Gi-Oh!_ bot"
 msgstr ""
 
-#: src\events\message-ping.ts:70
+#: src\events\message-ping.ts:72
 #, javascript-format
 msgid "Revision: ${ process.env.BOT_REVISION }."
 msgstr ""
 
-#: src\commands\deck.ts:289
+#: src\commands\deck.ts:328
 msgid ".ydk files must have the .ydk extension!"
 msgstr ""
 
-#: src\commands\deck.ts:292
+#: src\commands\deck.ts:331
 msgid ".ydk files should not be larger than 1 KB!"
 msgstr ""
 
-#: src\commands\deck.ts:282
+#: src\commands\deck.ts:321
 msgid "ydke URL"
 msgstr ""
 
 #: src\card.ts:455
-#: src\rush-duel.ts:75
+#: src\rush-duel.ts:61
 #. Forbidden/Limited Lists or Limit Regulations in the OCG
 #, javascript-format
 msgid "**Limit**: ${ limitRegulationDisplay }"
 msgstr ""
 
-#: src\commands\price.ts:70
+#: src\commands\price.ts:69
 msgid "TCGPlayer"
 msgstr ""
 
-#: src\commands\price.ts:71
+#: src\commands\price.ts:70
 msgid "Cardmarket"
 msgstr ""
 
-#: src\commands\price.ts:148
+#: src\commands\price.ts:147
 msgid "No market price"
 msgstr ""
 
-#: src\commands\price.ts:156
+#: src\commands\price.ts:155
 #, javascript-format
 msgid "Prices for ${ card.name[resultLanguage] } - ${ vendorName }"
 msgstr ""
 
-#: src\commands\price.ts:170
+#: src\commands\price.ts:169
 #, javascript-format
 msgid "Could not find prices for `${ name }`!"
 msgstr ""
 
-#: src\commands\deck.ts:363
+#: src\commands\deck.ts:425
+#. prepare interaction button for FTP upload
 msgid "Upload to YGOPRODECK"
 msgstr ""
 
-#: src\events\message-search.ts:271
+#: src\commands\deck.ts:483
+#. disable original button
+#. prepare row to disable button on original message
+msgid "Upload Complete"
+msgstr ""
+
+#: src\commands\deck.ts:470
+msgid "Deck upload failed!"
+msgstr ""
+
+#: src\commands\deck.ts:491
+#. reply in affirmation
+#, javascript-format
+msgid "Deck successfully uploaded to <${ url }>!"
+msgstr ""
+
+#: src\events\message-search.ts:264
 msgid "💬 Translations missing?"
 msgstr ""
 
-#: src\events\message-search.ts:272
+#: src\events\message-search.ts:265
 msgid "Help translate Bastion at the links above."
 msgstr ""
 
-#: src\events\message-ping.ts:48
+#: src\events\message-ping.ts:50
 msgid ""
 "❓ Help documentation on [GitHub](https://github.com/DawnbrandBots/bastion-bot), or use `.commands` and `.help`.\n"
 "🟢 Licence: [GNU AGPL 3.0+](https://choosealicense.com/licenses/agpl-3.0/).\n"
@@ -327,38 +375,38 @@ msgid ""
 "💬 Translations missing? Help translate Bastion on [GitHub](https://github.com/DawnbrandBots/bastion-bot)."
 msgstr ""
 
-#: src\events\message-search.ts:263
-#: src\events\message-search.ts:302
+#: src\events\message-search.ts:256
+#: src\events\message-search.ts:294
 #, javascript-format
 msgid "Search type: ${ localisedType }"
 msgstr ""
 
-#: src\events\message-search.ts:242
+#: src\events\message-search.ts:236
 #, javascript-format
 msgid "Search language: **${ localisedInputLanguage }** (${ inputLanguage }). Check defaults with </locale get:${ id }> and configure with </locale set:${ id }>"
 msgstr ""
 
-#: src\events\message-ping.ts:93
+#: src\events\message-ping.ts:95
 msgid "⚠️ You pinged me, but I am missing permissions in the channel!"
 msgstr ""
 
-#: src\events\message-ping.ts:96
-#: src\events\message-search.ts:340
+#: src\events\message-ping.ts:98
+#: src\events\message-search.ts:332
 msgid "Please have a server administrator [fix this](https://github.com/DawnbrandBots/bastion-bot#discord-permissions)."
 msgstr ""
 
-#: src\events\message-search.ts:337
+#: src\events\message-search.ts:329
 msgid "⚠️ I am missing permissions in the channel!"
 msgstr ""
 
-#: src\commands\deck.ts:258
+#: src\commands\deck.ts:297
 #, javascript-format
 msgid "Extra Deck (${ deck.extra.length } card — ${ countDetail })"
 msgid_plural "Extra Deck (${ deck.extra.length } cards — ${ countDetail })"
 msgstr[0] ""
 msgstr[1] ""
 
-#: src\commands\deck.ts:272
+#: src\commands\deck.ts:311
 #, javascript-format
 msgid "Side Deck (${ deck.side.length } card — ${ countDetail })"
 msgid_plural "Side Deck (${ deck.side.length } cards — ${ countDetail })"
@@ -380,82 +428,48 @@ msgstr ""
 msgid "Something went wrong searching Yugipedia for `${ page }`."
 msgstr ""
 
-#: src\rush-duel.ts:49
+#: src\rush-duel.ts:40
 #, javascript-format
 msgid "[Official Konami DB](${ official }) | [Rulings (Japanese)](${ rulings }) | [Yugipedia](${ yugipedia }) | [RushCard](${ rushcard })"
 msgstr ""
 
-#: src\rush-duel.ts:52
+#: src\rush-duel.ts:43
 #, javascript-format
 msgid "[Yugipedia](${ yugipedia }) | [RushCard](${ rushcard })"
 msgstr ""
 
-#: src\rush-duel.ts:71
+#: src\rush-duel.ts:57
 msgid "__**LEGEND**__"
 msgstr ""
 
-#: src\rush-duel.ts:110
+#: src\rush-duel.ts:99
 #, javascript-format
 msgid "**MAXIMUM ATK**: ${ card.maximum_atk }"
 msgstr ""
 
-#: src\rush-duel.ts:158
+#: src\rush-duel.ts:146
 #, javascript-format
 msgid "Konami ID #${ card.konami_id }"
 msgstr ""
 
 #: src\art.ts:129
+#: src\commands\deck.ts:451
 msgid "Buttons can only be used by the user who called Bastion."
-msgstr ""
-
-#: src\rush-duel.ts:217
-#, javascript-format
-msgid "Using ${ searchTrigger }, you can search for Rush Duel cards directly in messages without autocomplete"
-msgstr ""
-
-#: src\events\message-search.ts:304
-#, javascript-format
-msgid "Could not find a Rush Duel card matching `${ input }`!"
 msgstr ""
 
 #: src\card.ts:462
 #, javascript-format
-msgid "**Master Duel rarity**: ${ rarityIcon } ${ localizedRarity }"
+msgid "**Master Duel rarity**: ${ rarity_icon } ${ localized_rarity }"
 msgstr ""
 
-#: src\card.ts:492
-#: src\rush-duel.ts:105
+#: src\rush-duel.ts:205
 #, javascript-format
-msgid "**Attribute**: ${ attributeIcon } ${ localizedAttribute }"
+msgid "Using ${ searchTrigger }, you can search for Rush Duel cards directly in messages without autocomplete"
 msgstr ""
 
-#: src\card.ts:497
+#: src\events\message-search.ts:296
 #, javascript-format
-msgid "**Rank**: ${ rankIcon } ${ card.rank } **ATK**: ${ card.atk } **DEF**: ${ card.def }"
-msgstr ""
-
-#: src\card.ts:503
-#: src\rush-duel.ts:107
-#, javascript-format
-msgid "**Level**: ${ levelIcon } ${ card.level } **ATK**: ${ card.atk } **DEF**: ${ card.def }"
-msgstr ""
-
-#: src\commands\locale-user.ts:73
-#: src\commands\locale.ts:89
-#, javascript-format
-msgid "Locale override for your direct messages: ${ override }"
-msgstr ""
-
-#: src\commands\locale-user.ts:83
-#: src\commands\locale.ts:146
-#, javascript-format
-msgid "Locale for your direct messages overridden with ${ locale }. Your Discord setting is ${ interaction.locale }."
-msgstr ""
-
-#: src\commands\locale-user.ts:87
-#: src\commands\locale.ts:150
-#, javascript-format
-msgid "Locale for your direct messages reset to Discord default. Your Discord setting is ${ interaction.locale }."
+msgid "Could not find a Rush Duel card matching `${ input }`!"
 msgstr ""
 
 #: src\card.ts:40
@@ -822,65 +836,65 @@ msgctxt "master-duel-rarity"
 msgid "Ultra Rare (UR)"
 msgstr "Ultra Raro (UR)"
 
-#: src\card.ts:517
-#: src\card.ts:528
-#: src\rush-duel.ts:138
+#: src\card.ts:513
+#: src\card.ts:524
+#: src\rush-duel.ts:127
 msgctxt "card-embed"
 msgid "Card Text"
 msgstr "Texto de carta"
 
-#: src\card.ts:522
+#: src\card.ts:518
 msgctxt "card-embed"
 msgid "Pendulum Effect"
 msgstr "Efecto de Péndulo"
 
-#: src\card.ts:545
+#: src\card.ts:539
 msgctxt "card-embed"
 msgid "Card Effect"
 msgstr ""
 
-#: src\rush-duel.ts:129
-#: src\rush-duel.ts:151
+#: src\rush-duel.ts:118
+#: src\rush-duel.ts:139
 msgctxt "card-embed"
 msgid "[REQUIREMENT]"
 msgstr "[REQUISITO]"
 
-#: src\rush-duel.ts:130
-#: src\rush-duel.ts:152
+#: src\rush-duel.ts:119
+#: src\rush-duel.ts:140
 msgctxt "card-embed"
 msgid "[EFFECT]"
 msgstr "[EFECTO]"
 
-#: src\rush-duel.ts:132
+#: src\rush-duel.ts:121
 msgctxt "card-embed"
 msgid "[CONTINUOUS EFFECT]"
 msgstr "[EFECTO CONTINUO]"
 
-#: src\rush-duel.ts:134
+#: src\rush-duel.ts:123
 msgctxt "card-embed"
 msgid "[MULTI-CHOICE EFFECT]"
 msgstr ""
 
-#: src\locale.ts:74
+#: src\locale.ts:71
 msgctxt "command-option"
 msgid "result-language"
 msgstr ""
 
-#: src\locale.ts:140
+#: src\locale.ts:131
 msgctxt "command-option"
 msgid "input-language"
 msgstr ""
 
-#: src\commands\rush-duel.ts:67
-#: src\commands\rush-duel.ts:79
-#: src\locale.ts:156
-#: src\locale.ts:174
-#: src\locale.ts:190
+#: src\commands\rush-duel.ts:68
+#: src\commands\rush-duel.ts:80
+#: src\locale.ts:147
+#: src\locale.ts:165
+#: src\locale.ts:181
 msgctxt "command-option"
 msgid "input"
 msgstr ""
 
-#: src\commands\help.ts:55
+#: src\commands\help.ts:52
 msgctxt "command-option"
 msgid "command"
 msgstr ""
@@ -895,56 +909,54 @@ msgctxt "command-option"
 msgid "page"
 msgstr ""
 
-#: src\commands\deck.ts:87
+#: src\commands\deck.ts:126
 msgctxt "command-option"
 msgid "url"
 msgstr ""
 
-#: src\commands\deck.ts:93
+#: src\commands\deck.ts:132
 msgctxt "command-option"
 msgid "file"
 msgstr ""
 
-#: src\commands\deck.ts:99
-#: src\commands\deck.ts:105
+#: src\commands\deck.ts:138
+#: src\commands\deck.ts:144
 msgctxt "command-option"
 msgid "deck"
 msgstr ""
 
-#: src\commands\deck.ts:111
+#: src\commands\deck.ts:150
 msgctxt "command-option"
 msgid "public"
 msgstr ""
 
-#: src\commands\deck.ts:118
+#: src\commands\deck.ts:157
 msgctxt "command-option"
 msgid "stacked"
 msgstr ""
 
-#: src\locale.ts:151
+#: src\locale.ts:142
 msgctxt "command-option"
 msgid "name"
 msgstr ""
 
-#: src\locale.ts:169
+#: src\locale.ts:160
 msgctxt "command-option"
 msgid "password"
 msgstr ""
 
-#: src\commands\rush-duel.ts:72
-#: src\events\message-search.ts:301
-#: src\locale.ts:185
+#: src\commands\rush-duel.ts:73
+#: src\events\message-search.ts:293
+#: src\locale.ts:176
 msgctxt "command-option"
 msgid "konami-id"
 msgstr ""
 
-#: src\commands\locale-user.ts:36
 #: src\commands\locale.ts:30
 msgctxt "command-option"
 msgid "get"
 msgstr ""
 
-#: src\commands\locale-user.ts:41
 #: src\commands\locale.ts:35
 msgctxt "command-option"
 msgid "set"
@@ -955,69 +967,47 @@ msgctxt "command-option"
 msgid "scope"
 msgstr ""
 
-#: src\commands\locale-user.ts:46
 #: src\commands\locale.ts:48
 msgctxt "command-option"
 msgid "locale"
 msgstr ""
 
-#: src\commands\price.ts:95
+#: src\commands\price.ts:94
 msgctxt "command-option"
 msgid "vendor"
 msgstr ""
 
-#: src\commands\rush-duel.ts:62
+#: src\commands\rush-duel.ts:63
 msgctxt "command-option"
 msgid "search"
 msgstr ""
 
-#: src\commands\rush-duel.ts:84
+#: src\commands\rush-duel.ts:85
 msgctxt "command-option"
 msgid "random"
 msgstr ""
 
-#: src\commands\rush-duel.ts:89
+#: src\commands\rush-duel.ts:90
 msgctxt "command-option"
 msgid "art"
 msgstr ""
 
-#: src\commands\query.ts:35
+#: src\commands\query.ts:36
 msgctxt "command-option"
 msgid "lucene"
 msgstr ""
 
-#: src\commands\metagame.ts:209
-msgctxt "command-option"
-msgid "strategies"
-msgstr ""
-
-#: src\commands\metagame.ts:234
-#: src\commands\metagame.ts:274
-msgctxt "command-option"
-msgid "format"
-msgstr ""
-
-#: src\commands\metagame.ts:240
-msgctxt "command-option"
-msgid "cards"
-msgstr ""
-
-#: src\commands\metagame.ts:310
-msgctxt "command-option"
-msgid "date-range"
-msgstr ""
-
-#: src\locale.ts:77
+#: src\locale.ts:74
 msgctxt "command-option-description"
 msgid "The output language for the card embed, overriding other settings."
 msgstr ""
 
-#: src\locale.ts:141
+#: src\locale.ts:132
 msgctxt "command-option-description"
 msgid "The language to search in, defaulting to the result language."
 msgstr ""
 
-#: src\commands\help.ts:58
+#: src\commands\help.ts:55
 msgctxt "command-option-description"
 msgid "The name of a specific Slash Command."
 msgstr ""
@@ -1027,32 +1017,32 @@ msgctxt "command-option-description"
 msgid "The name of the Yugipedia page you want to search for."
 msgstr ""
 
-#: src\commands\deck.ts:90
+#: src\commands\deck.ts:129
 msgctxt "command-option-description"
 msgid "View a deck by entering a ydke:// URL."
 msgstr ""
 
-#: src\commands\deck.ts:96
+#: src\commands\deck.ts:135
 msgctxt "command-option-description"
 msgid "View a deck by uploading a .ydk file."
 msgstr ""
 
-#: src\commands\deck.ts:102
+#: src\commands\deck.ts:141
 msgctxt "command-option-description"
 msgid "The ydke:// URL of the deck you want to view."
 msgstr ""
 
-#: src\commands\deck.ts:108
+#: src\commands\deck.ts:147
 msgctxt "command-option-description"
 msgid "The .ydk file of the deck you want to view."
 msgstr ""
 
-#: src\commands\deck.ts:114
+#: src\commands\deck.ts:153
 msgctxt "command-option-description"
 msgid "Whether to display the deck details publicly in chat. This is false by default."
 msgstr ""
 
-#: src\commands\deck.ts:121
+#: src\commands\deck.ts:160
 msgctxt "command-option-description"
 msgid "Whether to display the deck sections as one stacked column. This is false (side-by-side) by default."
 msgstr ""
@@ -1062,8 +1052,8 @@ msgctxt "command-option-description"
 msgid "Display the art for the card with this name."
 msgstr ""
 
-#: src\commands\rush-duel.ts:68
-#: src\locale.ts:157
+#: src\commands\rush-duel.ts:69
+#: src\locale.ts:148
 msgctxt "command-option-description"
 msgid "Card name, fuzzy matching supported."
 msgstr ""
@@ -1073,7 +1063,7 @@ msgctxt "command-option-description"
 msgid "Display the art for the card with this password."
 msgstr ""
 
-#: src\locale.ts:176
+#: src\locale.ts:167
 msgctxt "command-option-description"
 msgid "Card password, the eight-digit number printed on the bottom left corner."
 msgstr ""
@@ -1083,8 +1073,8 @@ msgctxt "command-option-description"
 msgid "Display the art for the card with this official database ID."
 msgstr ""
 
-#: src\commands\rush-duel.ts:80
-#: src\locale.ts:191
+#: src\commands\rush-duel.ts:81
+#: src\locale.ts:182
 msgctxt "command-option-description"
 msgid "Konami's official card database identifier."
 msgstr ""
@@ -1124,22 +1114,22 @@ msgctxt "command-option-description"
 msgid "The new default language to use in this channel or server."
 msgstr ""
 
-#: src\commands\price.ts:99
+#: src\commands\price.ts:98
 msgctxt "command-option-description"
 msgid "Display the price for the card with this name."
 msgstr ""
 
-#: src\commands\price.ts:103
+#: src\commands\price.ts:102
 msgctxt "command-option-description"
 msgid "Display the price for the card with this password."
 msgstr ""
 
-#: src\commands\price.ts:106
+#: src\commands\price.ts:105
 msgctxt "command-option-description"
 msgid "Display the price for the card with this official database ID."
 msgstr ""
 
-#: src\commands\price.ts:96
+#: src\commands\price.ts:95
 msgctxt "command-option-description"
 msgid "The vendor to fetch the price data from."
 msgstr ""
@@ -1149,70 +1139,29 @@ msgctxt "command-option-description"
 msgid "The English name of the card you're looking for."
 msgstr ""
 
-#: src\commands\rush-duel.ts:63
+#: src\commands\rush-duel.ts:64
 msgctxt "command-option-description"
 msgid "Find all information for the Rush Duel card with this name."
 msgstr ""
 
-#: src\commands\rush-duel.ts:74
+#: src\commands\rush-duel.ts:75
 msgctxt "command-option-description"
 msgid "Find all information for the Rush Duel card with this official database ID."
 msgstr ""
 
-#: src\commands\rush-duel.ts:85
+#: src\commands\rush-duel.ts:86
 msgctxt "command-option-description"
 msgid "Get a random Rush Duel card."
 msgstr ""
 
-#: src\commands\rush-duel.ts:90
+#: src\commands\rush-duel.ts:91
 msgctxt "command-option-description"
 msgid "Display just the art for the Rush Duel card with this name."
 msgstr ""
 
-#: src\commands\query.ts:36
+#: src\commands\query.ts:37
 msgctxt "command-option-description"
 msgid "Lucene query on YAML Yugi"
-msgstr ""
-
-#: src\commands\locale-user.ts:37
-msgctxt "command-option-description"
-msgid "Check your user-installed Bastion's locale."
-msgstr ""
-
-#: src\commands\locale-user.ts:42
-msgctxt "command-option-description"
-msgid "Configure your user-installed Bastion's locale."
-msgstr ""
-
-#: src\commands\locale-user.ts:47
-msgctxt "command-option-description"
-msgid "The new default language to use for user-installed Bastion."
-msgstr ""
-
-#: src\commands\metagame.ts:212
-msgctxt "command-option-description"
-msgid "Show the top competitive strategies in tournaments and the Master Duel ranked ladder."
-msgstr ""
-
-#: src\commands\metagame.ts:214
-msgctxt "command-option-description"
-msgid "Show the top competitive strategies in tournaments."
-msgstr ""
-
-#: src\commands\metagame.ts:235
-#: src\commands\metagame.ts:275
-msgctxt "command-option-description"
-msgid "Game region."
-msgstr ""
-
-#: src\commands\metagame.ts:242
-msgctxt "command-option-description"
-msgid "Show the most popular cards in tournaments and the Master Duel ranked ladder."
-msgstr ""
-
-#: src\commands\metagame.ts:312
-msgctxt "command-option-description"
-msgid "Limit card usage statistics to this date range. Has no effect for Master Duel."
 msgstr ""
 
 #: src\commands\art.ts:36
@@ -1220,12 +1169,12 @@ msgctxt "command-name"
 msgid "art"
 msgstr ""
 
-#: src\commands\help.ts:52
+#: src\commands\help.ts:49
 msgctxt "command-name"
 msgid "help"
 msgstr ""
 
-#: src\commands\ping.ts:25
+#: src\commands\ping.ts:23
 msgctxt "command-name"
 msgid "ping"
 msgstr ""
@@ -1240,7 +1189,7 @@ msgctxt "command-name"
 msgid "yugipedia"
 msgstr ""
 
-#: src\commands\deck.ts:80
+#: src\commands\deck.ts:119
 msgctxt "command-name"
 msgid "deck"
 msgstr ""
@@ -1255,34 +1204,24 @@ msgctxt "command-name"
 msgid "locale"
 msgstr ""
 
-#: src\commands\random.ts:43
+#: src\commands\random.ts:44
 msgctxt "command-name"
 msgid "random"
 msgstr ""
 
-#: src\commands\price.ts:90
+#: src\commands\price.ts:89
 msgctxt "command-name"
 msgid "price"
 msgstr ""
 
-#: src\commands\rush-duel.ts:57
+#: src\commands\rush-duel.ts:58
 msgctxt "command-name"
 msgid "rush-duel"
 msgstr ""
 
-#: src\commands\query.ts:29
+#: src\commands\query.ts:30
 msgctxt "command-name"
 msgid "query"
-msgstr ""
-
-#: src\commands\locale-user.ts:31
-msgctxt "command-name"
-msgid "locale-user"
-msgstr ""
-
-#: src\commands\metagame.ts:204
-msgctxt "command-name"
-msgid "metagame"
 msgstr ""
 
 #: src\commands\art.ts:37
@@ -1290,12 +1229,12 @@ msgctxt "command-description"
 msgid "Display the art for a card!"
 msgstr ""
 
-#: src\commands\help.ts:53
+#: src\commands\help.ts:50
 msgctxt "command-description"
 msgid "Get help with a Slash Command."
 msgstr ""
 
-#: src\commands\ping.ts:26
+#: src\commands\ping.ts:24
 msgctxt "command-description"
 msgid "Test latency to the new bot instance."
 msgstr ""
@@ -1310,7 +1249,7 @@ msgctxt "command-description"
 msgid "Search the Yugipedia wiki for a page and link to it."
 msgstr ""
 
-#: src\commands\deck.ts:83
+#: src\commands\deck.ts:122
 msgctxt "command-description"
 msgid "Display a deck list from ydke:// or .ydk format, exported from a number of deck building programs."
 msgstr ""
@@ -1325,34 +1264,24 @@ msgctxt "command-description"
 msgid "Check or set Bastion's locale for this channel or server."
 msgstr ""
 
-#: src\commands\random.ts:44
+#: src\commands\random.ts:45
 msgctxt "command-description"
 msgid "Get a random Yu-Gi-Oh! card."
 msgstr ""
 
-#: src\commands\price.ts:91
+#: src\commands\price.ts:90
 msgctxt "command-description"
 msgid "Display the price for a card!"
 msgstr ""
 
-#: src\commands\rush-duel.ts:58
+#: src\commands\rush-duel.ts:59
 msgctxt "command-description"
 msgid "Find information on Rush Duel cards."
 msgstr ""
 
-#: src\commands\query.ts:30
+#: src\commands\query.ts:31
 msgctxt "command-description"
 msgid "Advanced search prototype"
-msgstr ""
-
-#: src\commands\locale-user.ts:32
-msgctxt "command-description"
-msgid "Check or set user-installed Bastion's locale."
-msgstr ""
-
-#: src\commands\metagame.ts:205
-msgctxt "command-description"
-msgid "Show statistics on the current competitive state of play."
 msgstr ""
 
 #: src\commands\locale.ts:43
@@ -1365,71 +1294,7 @@ msgctxt "command-option-choice"
 msgid "server"
 msgstr ""
 
-#: src\commands\locale-user.ts:49
 #: src\commands\locale.ts:51
 msgctxt "command-option-choice"
 msgid "Discord default"
-msgstr ""
-
-#: src\commands\metagame.ts:219
-#: src\commands\metagame.ts:251
-msgctxt "command-option-choice"
-msgid "TCG"
-msgstr ""
-
-#: src\commands\metagame.ts:220
-#: src\commands\metagame.ts:255
-msgctxt "command-option-choice"
-msgid "OCG"
-msgstr ""
-
-#: src\commands\metagame.ts:221
-#: src\commands\metagame.ts:259
-msgctxt "command-option-choice"
-msgid "OCG (Asian-English)"
-msgstr ""
-
-#: src\commands\metagame.ts:228
-msgctxt "command-option-choice"
-msgid "Master Duel Diamond+ tier list"
-msgstr ""
-
-#: src\commands\metagame.ts:261
-msgctxt "command-option-choice"
-msgid "Master Duel ranked ladder"
-msgstr ""
-
-#: src\commands\metagame.ts:283
-msgctxt "command-option-choice"
-msgid "Current format"
-msgstr ""
-
-#: src\commands\metagame.ts:287
-msgctxt "command-option-choice"
-msgid "Since last Forbidden/Limited List"
-msgstr ""
-
-#: src\commands\metagame.ts:291
-msgctxt "command-option-choice"
-msgid "Last 7 days"
-msgstr ""
-
-#: src\commands\metagame.ts:295
-msgctxt "command-option-choice"
-msgid "Last 14 days"
-msgstr ""
-
-#: src\commands\metagame.ts:299
-msgctxt "command-option-choice"
-msgid "Last 30 days"
-msgstr ""
-
-#: src\commands\metagame.ts:303
-msgctxt "command-option-choice"
-msgid "Last three months"
-msgstr ""
-
-#: src\commands\metagame.ts:307
-msgctxt "command-option-choice"
-msgid "Last six months"
 msgstr ""

--- a/translations/fr.po
+++ b/translations/fr.po
@@ -6,50 +6,33 @@ msgstr ""
 "MIME-Version: 1.0\n"
 "Content-Transfer-Encoding: 8bit\n"
 
-#: src\card.ts:416
-#: src\rush-duel.ts:39
+#: src\card.ts:412
+#: src\rush-duel.ts:48
 msgid "🔗 Links"
 msgstr ""
 
-#: src\card.ts:417
+#: src\card.ts:413
 #, javascript-format
 msgid "[Official Konami DB](${ official }) | [OCG Rulings](${ rulings }) | [Yugipedia](${ yugipedia }) | [YGOPRODECK](${ ygoprodeck })"
 msgstr ""
 
-#: src\card.ts:420
+#: src\card.ts:416
 #, javascript-format
 msgid "[Yugipedia](${ yugipedia }) | [YGOPRODECK](${ ygoprodeck })"
 msgstr ""
 
-#: src\card.ts:489
-#: src\rush-duel.ts:92
+#: src\card.ts:490
+#: src\rush-duel.ts:103
 #, javascript-format
 msgid "**Type**: ${ raceIcon } ${ localizedMonsterTypeLine }"
 msgstr "**Type**: ${ raceIcon } ${ localizedMonsterTypeLine }"
 
-#: src\card.ts:491
-#: src\rush-duel.ts:94
-#, javascript-format
-msgid "**Attribute**: ${ AttributeIcon[card.attribute] } ${ localizedAttribute }"
-msgstr "**Attribut**: ${ AttributeIcon[card.attribute] } ${ localizedAttribute }"
-
-#: src\card.ts:495
-#, javascript-format
-msgid "**Rank**: ${ Icon.Rank } ${ card.rank } **ATK**: ${ card.atk } **DEF**: ${ card.def }"
-msgstr "**Rang**: ${ Icon.Rank } ${ card.rank } **ATK**: ${ card.atk } **DEF**: ${ card.def }"
-
-#: src\card.ts:498
+#: src\card.ts:500
 #, javascript-format
 msgid "**Link Rating**: ${ card.link_arrows.length } **ATK**: ${ card.atk } **Link Arrows**: ${ arrows }"
 msgstr ""
 
-#: src\card.ts:500
-#: src\rush-duel.ts:96
-#, javascript-format
-msgid "**Level**: ${ Icon.Level } ${ card.level } **ATK**: ${ card.atk } **DEF**: ${ card.def }"
-msgstr "**Niveau**: ${ Icon.Level } ${ card.level } **ATK**: ${ card.atk } **DEF**: ${ card.def }"
-
-#: src\card.ts:507
+#: src\card.ts:511
 #, javascript-format
 msgid "**Pendulum Scale**: ${ formattedScale }"
 msgstr "**Échelle Pendule**: ${ formattedScale }"
@@ -70,7 +53,7 @@ msgid "Password: ${ card.password } | Not yet released"
 msgstr ""
 
 #: src\card.ts:351
-#: src\rush-duel.ts:146
+#: src\rush-duel.ts:158
 msgid "Not yet released"
 msgstr ""
 
@@ -79,64 +62,64 @@ msgstr ""
 msgid "Placeholder ID: ${ card.fake_password }"
 msgstr ""
 
-#: src\utils.ts:41
+#: src\utils.ts:44
 msgid "🛠️ This command is in development."
 msgstr ""
 
-#: src\utils.ts:42
+#: src\utils.ts:45
 msgid "📨 Please send feedback to [our issue tracker](https://github.com/DawnbrandBots/bastion-bot) or the [support server](https://discord.gg/4aFuPyuE96)!"
 msgstr ""
 
-#: src\utils.ts:53
+#: src\utils.ts:56
 msgid "Please consider supporting us!"
 msgstr ""
 
-#: src\utils.ts:54
+#: src\utils.ts:57
 msgid "Help keep Bastion online!"
 msgstr ""
 
-#: src\utils.ts:55
+#: src\utils.ts:58
 msgid "Please help keep Bastion online!"
 msgstr ""
 
-#: src\utils.ts:56
+#: src\utils.ts:59
 msgid "Was Bastion helpful? Consider supporting us!"
 msgstr ""
 
-#: src\utils.ts:57
+#: src\utils.ts:60
 msgid "Was Bastion helpful? We need your support!"
 msgstr ""
 
-#: src\utils.ts:58
+#: src\utils.ts:61
 msgid "Did you find Bastion useful? Consider supporting us!"
 msgstr ""
 
-#: src\utils.ts:59
+#: src\utils.ts:62
 msgid "Did you find Bastion useful? Help keep it online!"
 msgstr ""
 
-#: src\utils.ts:60
+#: src\utils.ts:63
 msgid "Did you find Bastion useful? We need your support!"
 msgstr ""
 
-#: src\utils.ts:61
+#: src\utils.ts:64
 msgid "Enjoy Bastion? Help keep it online!"
 msgstr ""
 
-#: src\utils.ts:62
+#: src\utils.ts:65
 msgid "Enjoy Bastion? Consider supporting us!"
 msgstr ""
 
-#: src\utils.ts:63
+#: src\utils.ts:66
 msgid "Found what you were looking for? Consider supporting us!"
 msgstr ""
 
 #: src\commands\art.ts:63
-#: src\commands\price.ts:131
-#: src\commands\rush-duel.ts:172
-#: src\commands\rush-duel.ts:203
+#: src\commands\price.ts:132
+#: src\commands\rush-duel.ts:171
+#: src\commands\rush-duel.ts:202
 #: src\commands\search.ts:64
-#: src\events\message-search.ts:258
+#: src\events\message-search.ts:265
 #, javascript-format
 msgid "Could not find a card matching `${ input }`!"
 msgstr ""
@@ -147,51 +130,51 @@ msgstr ""
 msgid "Could not find art for `${ name }`!"
 msgstr ""
 
-#: src\commands\deck.ts:244
+#: src\commands\deck.ts:205
 #, javascript-format
 msgid "${ counts.Monster } Monster"
 msgid_plural "${ counts.Monster } Monsters"
 msgstr[0] ""
 msgstr[1] ""
 
-#: src\commands\deck.ts:247
+#: src\commands\deck.ts:208
 #, javascript-format
 msgid "${ counts.Spell } Spell"
 msgid_plural "${ counts.Spell } Spells"
 msgstr[0] ""
 msgstr[1] ""
 
-#: src\commands\deck.ts:250
+#: src\commands\deck.ts:211
 #, javascript-format
 msgid "${ counts.Trap } Trap"
 msgid_plural "${ counts.Trap } Traps"
 msgstr[0] ""
 msgstr[1] ""
 
-#: src\commands\deck.ts:278
+#: src\commands\deck.ts:239
 msgid "Your Deck"
 msgstr ""
 
-#: src\commands\deck.ts:283
+#: src\commands\deck.ts:244
 #, javascript-format
 msgid "Main Deck (${ deck.main.length } card — ${ countDetail })"
 msgid_plural "Main Deck (${ deck.main.length } cards — ${ countDetail })"
 msgstr[0] ""
 msgstr[1] ""
 
-#: src\commands\deck.ts:290
+#: src\commands\deck.ts:251
 msgid "Main Deck (continued)"
 msgstr ""
 
-#: src\commands\deck.ts:304
+#: src\commands\deck.ts:265
 msgid "Extra Deck (continued)"
 msgstr ""
 
-#: src\commands\deck.ts:318
+#: src\commands\deck.ts:279
 msgid "Side Deck (continued)"
 msgstr ""
 
-#: src\commands\deck.ts:407
+#: src\commands\deck.ts:347
 msgid "Error: Your deck is empty."
 msgstr ""
 
@@ -211,11 +194,7 @@ msgstr ""
 msgid "Discord Community locale for this server: ${ interaction.guildLocale }"
 msgstr ""
 
-#: src\commands\locale.ts:89
-#, javascript-format
-msgid "Locale override for this direct message: ${ override }"
-msgstr ""
-
+#: src\commands\locale-user.ts:76
 #: src\commands\locale.ts:92
 #, javascript-format
 msgid "Your Discord locale: ${ interaction.locale }"
@@ -253,24 +232,14 @@ msgstr ""
 msgid "Sorry, you must have the Manage Server permission to do this. If you think this is an error, contact your server admin or report a bug."
 msgstr ""
 
-#: src\commands\locale.ts:146
-#, javascript-format
-msgid "Locale for this direct message overridden with ${ locale }. Your Discord setting is ${ interaction.locale }."
-msgstr ""
-
-#: src\commands\locale.ts:150
-#, javascript-format
-msgid "Locale for this direct message reset to Discord default. Your Discord setting is ${ interaction.locale }."
-msgstr ""
-
-#: src\commands\ping.ts:36
-#: src\events\message-ping.ts:47
+#: src\commands\ping.ts:38
+#: src\events\message-ping.ts:45
 #, javascript-format
 msgid "Average WebSocket ping (new instance): ${ ping } ms"
 msgstr ""
 
-#: src\commands\ping.ts:40
-#: src\events\message-ping.ts:112
+#: src\commands\ping.ts:42
+#: src\events\message-ping.ts:110
 #, javascript-format
 msgid "Total latency: ${ latency } ms"
 msgstr ""
@@ -280,86 +249,69 @@ msgstr ""
 msgid "Could not find a Yugipedia page named `${ page }`."
 msgstr ""
 
-#: src\events\message-ping.ts:49
+#: src\events\message-ping.ts:47
 msgid "Free and open source _Yu-Gi-Oh!_ bot"
 msgstr ""
 
-#: src\events\message-ping.ts:72
+#: src\events\message-ping.ts:70
 #, javascript-format
 msgid "Revision: ${ process.env.BOT_REVISION }."
 msgstr ""
 
-#: src\commands\deck.ts:328
+#: src\commands\deck.ts:289
 msgid ".ydk files must have the .ydk extension!"
 msgstr ""
 
-#: src\commands\deck.ts:331
+#: src\commands\deck.ts:292
 msgid ".ydk files should not be larger than 1 KB!"
 msgstr ""
 
-#: src\commands\deck.ts:321
+#: src\commands\deck.ts:282
 msgid "ydke URL"
 msgstr ""
 
 #: src\card.ts:455
-#: src\rush-duel.ts:61
+#: src\rush-duel.ts:75
 #. Forbidden/Limited Lists or Limit Regulations in the OCG
 #, javascript-format
 msgid "**Limit**: ${ limitRegulationDisplay }"
 msgstr ""
 
-#: src\commands\price.ts:69
+#: src\commands\price.ts:70
 msgid "TCGPlayer"
 msgstr ""
 
-#: src\commands\price.ts:70
+#: src\commands\price.ts:71
 msgid "Cardmarket"
 msgstr ""
 
-#: src\commands\price.ts:147
+#: src\commands\price.ts:148
 msgid "No market price"
 msgstr ""
 
-#: src\commands\price.ts:155
+#: src\commands\price.ts:156
 #, javascript-format
 msgid "Prices for ${ card.name[resultLanguage] } - ${ vendorName }"
 msgstr ""
 
-#: src\commands\price.ts:169
+#: src\commands\price.ts:170
 #, javascript-format
 msgid "Could not find prices for `${ name }`!"
 msgstr ""
 
-#: src\commands\deck.ts:425
-#. prepare interaction button for FTP upload
+#: src\commands\deck.ts:363
 msgid "Upload to YGOPRODECK"
 msgstr ""
 
-#: src\commands\deck.ts:483
-#. disable original button
-#. prepare row to disable button on original message
-msgid "Upload Complete"
-msgstr ""
-
-#: src\commands\deck.ts:470
-msgid "Deck upload failed!"
-msgstr ""
-
-#: src\commands\deck.ts:491
-#. reply in affirmation
-#, javascript-format
-msgid "Deck successfully uploaded to <${ url }>!"
-msgstr ""
-
-#: src\events\message-search.ts:264
+#: src\events\message-search.ts:271
 msgid "💬 Translations missing?"
 msgstr ""
 
-#: src\events\message-search.ts:265
+#: src\events\message-search.ts:272
 msgid "Help translate Bastion at the links above."
 msgstr ""
 
-#: src\events\message-ping.ts:50
+#: src\events\message-ping.ts:48
 msgid ""
 "❓ Help documentation on [GitHub](https://github.com/DawnbrandBots/bastion-bot), or use `.commands` and `.help`.\n"
 "🟢 Licence: [GNU AGPL 3.0+](https://choosealicense.com/licenses/agpl-3.0/).\n"
@@ -375,38 +327,38 @@ msgid ""
 "💬 Translations missing? Help translate Bastion on [GitHub](https://github.com/DawnbrandBots/bastion-bot)."
 msgstr ""
 
-#: src\events\message-search.ts:256
-#: src\events\message-search.ts:294
+#: src\events\message-search.ts:263
+#: src\events\message-search.ts:302
 #, javascript-format
 msgid "Search type: ${ localisedType }"
 msgstr ""
 
-#: src\events\message-search.ts:236
+#: src\events\message-search.ts:242
 #, javascript-format
 msgid "Search language: **${ localisedInputLanguage }** (${ inputLanguage }). Check defaults with </locale get:${ id }> and configure with </locale set:${ id }>"
 msgstr ""
 
-#: src\events\message-ping.ts:95
+#: src\events\message-ping.ts:93
 msgid "⚠️ You pinged me, but I am missing permissions in the channel!"
 msgstr ""
 
-#: src\events\message-ping.ts:98
-#: src\events\message-search.ts:332
+#: src\events\message-ping.ts:96
+#: src\events\message-search.ts:340
 msgid "Please have a server administrator [fix this](https://github.com/DawnbrandBots/bastion-bot#discord-permissions)."
 msgstr ""
 
-#: src\events\message-search.ts:329
+#: src\events\message-search.ts:337
 msgid "⚠️ I am missing permissions in the channel!"
 msgstr ""
 
-#: src\commands\deck.ts:297
+#: src\commands\deck.ts:258
 #, javascript-format
 msgid "Extra Deck (${ deck.extra.length } card — ${ countDetail })"
 msgid_plural "Extra Deck (${ deck.extra.length } cards — ${ countDetail })"
 msgstr[0] ""
 msgstr[1] ""
 
-#: src\commands\deck.ts:311
+#: src\commands\deck.ts:272
 #, javascript-format
 msgid "Side Deck (${ deck.side.length } card — ${ countDetail })"
 msgid_plural "Side Deck (${ deck.side.length } cards — ${ countDetail })"
@@ -428,48 +380,82 @@ msgstr ""
 msgid "Something went wrong searching Yugipedia for `${ page }`."
 msgstr ""
 
-#: src\rush-duel.ts:40
+#: src\rush-duel.ts:49
 #, javascript-format
 msgid "[Official Konami DB](${ official }) | [Rulings (Japanese)](${ rulings }) | [Yugipedia](${ yugipedia }) | [RushCard](${ rushcard })"
 msgstr ""
 
-#: src\rush-duel.ts:43
+#: src\rush-duel.ts:52
 #, javascript-format
 msgid "[Yugipedia](${ yugipedia }) | [RushCard](${ rushcard })"
 msgstr ""
 
-#: src\rush-duel.ts:57
+#: src\rush-duel.ts:71
 msgid "__**LEGEND**__"
 msgstr ""
 
-#: src\rush-duel.ts:99
+#: src\rush-duel.ts:110
 #, javascript-format
 msgid "**MAXIMUM ATK**: ${ card.maximum_atk }"
 msgstr ""
 
-#: src\rush-duel.ts:146
+#: src\rush-duel.ts:158
 #, javascript-format
 msgid "Konami ID #${ card.konami_id }"
 msgstr ""
 
 #: src\art.ts:129
-#: src\commands\deck.ts:451
 msgid "Buttons can only be used by the user who called Bastion."
 msgstr ""
 
-#: src\card.ts:462
-#, javascript-format
-msgid "**Master Duel rarity**: ${ rarity_icon } ${ localized_rarity }"
-msgstr ""
-
-#: src\rush-duel.ts:205
+#: src\rush-duel.ts:217
 #, javascript-format
 msgid "Using ${ searchTrigger }, you can search for Rush Duel cards directly in messages without autocomplete"
 msgstr ""
 
-#: src\events\message-search.ts:296
+#: src\events\message-search.ts:304
 #, javascript-format
 msgid "Could not find a Rush Duel card matching `${ input }`!"
+msgstr ""
+
+#: src\card.ts:462
+#, javascript-format
+msgid "**Master Duel rarity**: ${ rarityIcon } ${ localizedRarity }"
+msgstr ""
+
+#: src\card.ts:492
+#: src\rush-duel.ts:105
+#, javascript-format
+msgid "**Attribute**: ${ attributeIcon } ${ localizedAttribute }"
+msgstr ""
+
+#: src\card.ts:497
+#, javascript-format
+msgid "**Rank**: ${ rankIcon } ${ card.rank } **ATK**: ${ card.atk } **DEF**: ${ card.def }"
+msgstr ""
+
+#: src\card.ts:503
+#: src\rush-duel.ts:107
+#, javascript-format
+msgid "**Level**: ${ levelIcon } ${ card.level } **ATK**: ${ card.atk } **DEF**: ${ card.def }"
+msgstr ""
+
+#: src\commands\locale-user.ts:73
+#: src\commands\locale.ts:89
+#, javascript-format
+msgid "Locale override for your direct messages: ${ override }"
+msgstr ""
+
+#: src\commands\locale-user.ts:83
+#: src\commands\locale.ts:146
+#, javascript-format
+msgid "Locale for your direct messages overridden with ${ locale }. Your Discord setting is ${ interaction.locale }."
+msgstr ""
+
+#: src\commands\locale-user.ts:87
+#: src\commands\locale.ts:150
+#, javascript-format
+msgid "Locale for your direct messages reset to Discord default. Your Discord setting is ${ interaction.locale }."
 msgstr ""
 
 #: src\card.ts:40
@@ -836,65 +822,65 @@ msgctxt "master-duel-rarity"
 msgid "Ultra Rare (UR)"
 msgstr "Ultra Rare (UR)"
 
-#: src\card.ts:513
-#: src\card.ts:524
-#: src\rush-duel.ts:127
+#: src\card.ts:517
+#: src\card.ts:528
+#: src\rush-duel.ts:138
 msgctxt "card-embed"
 msgid "Card Text"
 msgstr "Texte de carte"
 
-#: src\card.ts:518
+#: src\card.ts:522
 msgctxt "card-embed"
 msgid "Pendulum Effect"
 msgstr "Effet Pendule"
 
-#: src\card.ts:539
+#: src\card.ts:545
 msgctxt "card-embed"
 msgid "Card Effect"
 msgstr ""
 
-#: src\rush-duel.ts:118
-#: src\rush-duel.ts:139
+#: src\rush-duel.ts:129
+#: src\rush-duel.ts:151
 msgctxt "card-embed"
 msgid "[REQUIREMENT]"
 msgstr "[CONDITION]"
 
-#: src\rush-duel.ts:119
-#: src\rush-duel.ts:140
+#: src\rush-duel.ts:130
+#: src\rush-duel.ts:152
 msgctxt "card-embed"
 msgid "[EFFECT]"
 msgstr "[EFFET]"
 
-#: src\rush-duel.ts:121
+#: src\rush-duel.ts:132
 msgctxt "card-embed"
 msgid "[CONTINUOUS EFFECT]"
 msgstr "[EFFET CONTINU]"
 
-#: src\rush-duel.ts:123
+#: src\rush-duel.ts:134
 msgctxt "card-embed"
 msgid "[MULTI-CHOICE EFFECT]"
 msgstr ""
 
-#: src\locale.ts:71
+#: src\locale.ts:74
 msgctxt "command-option"
 msgid "result-language"
 msgstr ""
 
-#: src\locale.ts:131
+#: src\locale.ts:140
 msgctxt "command-option"
 msgid "input-language"
 msgstr ""
 
-#: src\commands\rush-duel.ts:68
-#: src\commands\rush-duel.ts:80
-#: src\locale.ts:147
-#: src\locale.ts:165
-#: src\locale.ts:181
+#: src\commands\rush-duel.ts:67
+#: src\commands\rush-duel.ts:79
+#: src\locale.ts:156
+#: src\locale.ts:174
+#: src\locale.ts:190
 msgctxt "command-option"
 msgid "input"
 msgstr ""
 
-#: src\commands\help.ts:52
+#: src\commands\help.ts:55
 msgctxt "command-option"
 msgid "command"
 msgstr ""
@@ -909,54 +895,56 @@ msgctxt "command-option"
 msgid "page"
 msgstr ""
 
-#: src\commands\deck.ts:126
+#: src\commands\deck.ts:87
 msgctxt "command-option"
 msgid "url"
 msgstr ""
 
-#: src\commands\deck.ts:132
+#: src\commands\deck.ts:93
 msgctxt "command-option"
 msgid "file"
 msgstr ""
 
-#: src\commands\deck.ts:138
-#: src\commands\deck.ts:144
+#: src\commands\deck.ts:99
+#: src\commands\deck.ts:105
 msgctxt "command-option"
 msgid "deck"
 msgstr ""
 
-#: src\commands\deck.ts:150
+#: src\commands\deck.ts:111
 msgctxt "command-option"
 msgid "public"
 msgstr ""
 
-#: src\commands\deck.ts:157
+#: src\commands\deck.ts:118
 msgctxt "command-option"
 msgid "stacked"
 msgstr ""
 
-#: src\locale.ts:142
+#: src\locale.ts:151
 msgctxt "command-option"
 msgid "name"
 msgstr ""
 
-#: src\locale.ts:160
+#: src\locale.ts:169
 msgctxt "command-option"
 msgid "password"
 msgstr ""
 
-#: src\commands\rush-duel.ts:73
-#: src\events\message-search.ts:293
-#: src\locale.ts:176
+#: src\commands\rush-duel.ts:72
+#: src\events\message-search.ts:301
+#: src\locale.ts:185
 msgctxt "command-option"
 msgid "konami-id"
 msgstr ""
 
+#: src\commands\locale-user.ts:36
 #: src\commands\locale.ts:30
 msgctxt "command-option"
 msgid "get"
 msgstr ""
 
+#: src\commands\locale-user.ts:41
 #: src\commands\locale.ts:35
 msgctxt "command-option"
 msgid "set"
@@ -967,47 +955,69 @@ msgctxt "command-option"
 msgid "scope"
 msgstr ""
 
+#: src\commands\locale-user.ts:46
 #: src\commands\locale.ts:48
 msgctxt "command-option"
 msgid "locale"
 msgstr ""
 
-#: src\commands\price.ts:94
+#: src\commands\price.ts:95
 msgctxt "command-option"
 msgid "vendor"
 msgstr ""
 
-#: src\commands\rush-duel.ts:63
+#: src\commands\rush-duel.ts:62
 msgctxt "command-option"
 msgid "search"
 msgstr ""
 
-#: src\commands\rush-duel.ts:85
+#: src\commands\rush-duel.ts:84
 msgctxt "command-option"
 msgid "random"
 msgstr ""
 
-#: src\commands\rush-duel.ts:90
+#: src\commands\rush-duel.ts:89
 msgctxt "command-option"
 msgid "art"
 msgstr ""
 
-#: src\commands\query.ts:36
+#: src\commands\query.ts:35
 msgctxt "command-option"
 msgid "lucene"
 msgstr ""
 
-#: src\locale.ts:74
+#: src\commands\metagame.ts:209
+msgctxt "command-option"
+msgid "strategies"
+msgstr ""
+
+#: src\commands\metagame.ts:234
+#: src\commands\metagame.ts:274
+msgctxt "command-option"
+msgid "format"
+msgstr ""
+
+#: src\commands\metagame.ts:240
+msgctxt "command-option"
+msgid "cards"
+msgstr ""
+
+#: src\commands\metagame.ts:310
+msgctxt "command-option"
+msgid "date-range"
+msgstr ""
+
+#: src\locale.ts:77
 msgctxt "command-option-description"
 msgid "The output language for the card embed, overriding other settings."
 msgstr ""
 
-#: src\locale.ts:132
+#: src\locale.ts:141
 msgctxt "command-option-description"
 msgid "The language to search in, defaulting to the result language."
 msgstr ""
 
-#: src\commands\help.ts:55
+#: src\commands\help.ts:58
 msgctxt "command-option-description"
 msgid "The name of a specific Slash Command."
 msgstr ""
@@ -1017,32 +1027,32 @@ msgctxt "command-option-description"
 msgid "The name of the Yugipedia page you want to search for."
 msgstr ""
 
-#: src\commands\deck.ts:129
+#: src\commands\deck.ts:90
 msgctxt "command-option-description"
 msgid "View a deck by entering a ydke:// URL."
 msgstr ""
 
-#: src\commands\deck.ts:135
+#: src\commands\deck.ts:96
 msgctxt "command-option-description"
 msgid "View a deck by uploading a .ydk file."
 msgstr ""
 
-#: src\commands\deck.ts:141
+#: src\commands\deck.ts:102
 msgctxt "command-option-description"
 msgid "The ydke:// URL of the deck you want to view."
 msgstr ""
 
-#: src\commands\deck.ts:147
+#: src\commands\deck.ts:108
 msgctxt "command-option-description"
 msgid "The .ydk file of the deck you want to view."
 msgstr ""
 
-#: src\commands\deck.ts:153
+#: src\commands\deck.ts:114
 msgctxt "command-option-description"
 msgid "Whether to display the deck details publicly in chat. This is false by default."
 msgstr ""
 
-#: src\commands\deck.ts:160
+#: src\commands\deck.ts:121
 msgctxt "command-option-description"
 msgid "Whether to display the deck sections as one stacked column. This is false (side-by-side) by default."
 msgstr ""
@@ -1052,8 +1062,8 @@ msgctxt "command-option-description"
 msgid "Display the art for the card with this name."
 msgstr ""
 
-#: src\commands\rush-duel.ts:69
-#: src\locale.ts:148
+#: src\commands\rush-duel.ts:68
+#: src\locale.ts:157
 msgctxt "command-option-description"
 msgid "Card name, fuzzy matching supported."
 msgstr ""
@@ -1063,7 +1073,7 @@ msgctxt "command-option-description"
 msgid "Display the art for the card with this password."
 msgstr ""
 
-#: src\locale.ts:167
+#: src\locale.ts:176
 msgctxt "command-option-description"
 msgid "Card password, the eight-digit number printed on the bottom left corner."
 msgstr ""
@@ -1073,8 +1083,8 @@ msgctxt "command-option-description"
 msgid "Display the art for the card with this official database ID."
 msgstr ""
 
-#: src\commands\rush-duel.ts:81
-#: src\locale.ts:182
+#: src\commands\rush-duel.ts:80
+#: src\locale.ts:191
 msgctxt "command-option-description"
 msgid "Konami's official card database identifier."
 msgstr ""
@@ -1114,22 +1124,22 @@ msgctxt "command-option-description"
 msgid "The new default language to use in this channel or server."
 msgstr ""
 
-#: src\commands\price.ts:98
+#: src\commands\price.ts:99
 msgctxt "command-option-description"
 msgid "Display the price for the card with this name."
 msgstr ""
 
-#: src\commands\price.ts:102
+#: src\commands\price.ts:103
 msgctxt "command-option-description"
 msgid "Display the price for the card with this password."
 msgstr ""
 
-#: src\commands\price.ts:105
+#: src\commands\price.ts:106
 msgctxt "command-option-description"
 msgid "Display the price for the card with this official database ID."
 msgstr ""
 
-#: src\commands\price.ts:95
+#: src\commands\price.ts:96
 msgctxt "command-option-description"
 msgid "The vendor to fetch the price data from."
 msgstr ""
@@ -1139,29 +1149,70 @@ msgctxt "command-option-description"
 msgid "The English name of the card you're looking for."
 msgstr ""
 
-#: src\commands\rush-duel.ts:64
+#: src\commands\rush-duel.ts:63
 msgctxt "command-option-description"
 msgid "Find all information for the Rush Duel card with this name."
 msgstr ""
 
-#: src\commands\rush-duel.ts:75
+#: src\commands\rush-duel.ts:74
 msgctxt "command-option-description"
 msgid "Find all information for the Rush Duel card with this official database ID."
 msgstr ""
 
-#: src\commands\rush-duel.ts:86
+#: src\commands\rush-duel.ts:85
 msgctxt "command-option-description"
 msgid "Get a random Rush Duel card."
 msgstr ""
 
-#: src\commands\rush-duel.ts:91
+#: src\commands\rush-duel.ts:90
 msgctxt "command-option-description"
 msgid "Display just the art for the Rush Duel card with this name."
 msgstr ""
 
-#: src\commands\query.ts:37
+#: src\commands\query.ts:36
 msgctxt "command-option-description"
 msgid "Lucene query on YAML Yugi"
+msgstr ""
+
+#: src\commands\locale-user.ts:37
+msgctxt "command-option-description"
+msgid "Check your user-installed Bastion's locale."
+msgstr ""
+
+#: src\commands\locale-user.ts:42
+msgctxt "command-option-description"
+msgid "Configure your user-installed Bastion's locale."
+msgstr ""
+
+#: src\commands\locale-user.ts:47
+msgctxt "command-option-description"
+msgid "The new default language to use for user-installed Bastion."
+msgstr ""
+
+#: src\commands\metagame.ts:212
+msgctxt "command-option-description"
+msgid "Show the top competitive strategies in tournaments and the Master Duel ranked ladder."
+msgstr ""
+
+#: src\commands\metagame.ts:214
+msgctxt "command-option-description"
+msgid "Show the top competitive strategies in tournaments."
+msgstr ""
+
+#: src\commands\metagame.ts:235
+#: src\commands\metagame.ts:275
+msgctxt "command-option-description"
+msgid "Game region."
+msgstr ""
+
+#: src\commands\metagame.ts:242
+msgctxt "command-option-description"
+msgid "Show the most popular cards in tournaments and the Master Duel ranked ladder."
+msgstr ""
+
+#: src\commands\metagame.ts:312
+msgctxt "command-option-description"
+msgid "Limit card usage statistics to this date range. Has no effect for Master Duel."
 msgstr ""
 
 #: src\commands\art.ts:36
@@ -1169,12 +1220,12 @@ msgctxt "command-name"
 msgid "art"
 msgstr ""
 
-#: src\commands\help.ts:49
+#: src\commands\help.ts:52
 msgctxt "command-name"
 msgid "help"
 msgstr ""
 
-#: src\commands\ping.ts:23
+#: src\commands\ping.ts:25
 msgctxt "command-name"
 msgid "ping"
 msgstr ""
@@ -1189,7 +1240,7 @@ msgctxt "command-name"
 msgid "yugipedia"
 msgstr ""
 
-#: src\commands\deck.ts:119
+#: src\commands\deck.ts:80
 msgctxt "command-name"
 msgid "deck"
 msgstr ""
@@ -1204,24 +1255,34 @@ msgctxt "command-name"
 msgid "locale"
 msgstr ""
 
-#: src\commands\random.ts:44
+#: src\commands\random.ts:43
 msgctxt "command-name"
 msgid "random"
 msgstr ""
 
-#: src\commands\price.ts:89
+#: src\commands\price.ts:90
 msgctxt "command-name"
 msgid "price"
 msgstr ""
 
-#: src\commands\rush-duel.ts:58
+#: src\commands\rush-duel.ts:57
 msgctxt "command-name"
 msgid "rush-duel"
 msgstr ""
 
-#: src\commands\query.ts:30
+#: src\commands\query.ts:29
 msgctxt "command-name"
 msgid "query"
+msgstr ""
+
+#: src\commands\locale-user.ts:31
+msgctxt "command-name"
+msgid "locale-user"
+msgstr ""
+
+#: src\commands\metagame.ts:204
+msgctxt "command-name"
+msgid "metagame"
 msgstr ""
 
 #: src\commands\art.ts:37
@@ -1229,12 +1290,12 @@ msgctxt "command-description"
 msgid "Display the art for a card!"
 msgstr ""
 
-#: src\commands\help.ts:50
+#: src\commands\help.ts:53
 msgctxt "command-description"
 msgid "Get help with a Slash Command."
 msgstr ""
 
-#: src\commands\ping.ts:24
+#: src\commands\ping.ts:26
 msgctxt "command-description"
 msgid "Test latency to the new bot instance."
 msgstr ""
@@ -1249,7 +1310,7 @@ msgctxt "command-description"
 msgid "Search the Yugipedia wiki for a page and link to it."
 msgstr ""
 
-#: src\commands\deck.ts:122
+#: src\commands\deck.ts:83
 msgctxt "command-description"
 msgid "Display a deck list from ydke:// or .ydk format, exported from a number of deck building programs."
 msgstr ""
@@ -1264,24 +1325,34 @@ msgctxt "command-description"
 msgid "Check or set Bastion's locale for this channel or server."
 msgstr ""
 
-#: src\commands\random.ts:45
+#: src\commands\random.ts:44
 msgctxt "command-description"
 msgid "Get a random Yu-Gi-Oh! card."
 msgstr ""
 
-#: src\commands\price.ts:90
+#: src\commands\price.ts:91
 msgctxt "command-description"
 msgid "Display the price for a card!"
 msgstr ""
 
-#: src\commands\rush-duel.ts:59
+#: src\commands\rush-duel.ts:58
 msgctxt "command-description"
 msgid "Find information on Rush Duel cards."
 msgstr ""
 
-#: src\commands\query.ts:31
+#: src\commands\query.ts:30
 msgctxt "command-description"
 msgid "Advanced search prototype"
+msgstr ""
+
+#: src\commands\locale-user.ts:32
+msgctxt "command-description"
+msgid "Check or set user-installed Bastion's locale."
+msgstr ""
+
+#: src\commands\metagame.ts:205
+msgctxt "command-description"
+msgid "Show statistics on the current competitive state of play."
 msgstr ""
 
 #: src\commands\locale.ts:43
@@ -1294,7 +1365,71 @@ msgctxt "command-option-choice"
 msgid "server"
 msgstr ""
 
+#: src\commands\locale-user.ts:49
 #: src\commands\locale.ts:51
 msgctxt "command-option-choice"
 msgid "Discord default"
+msgstr ""
+
+#: src\commands\metagame.ts:219
+#: src\commands\metagame.ts:251
+msgctxt "command-option-choice"
+msgid "TCG"
+msgstr ""
+
+#: src\commands\metagame.ts:220
+#: src\commands\metagame.ts:255
+msgctxt "command-option-choice"
+msgid "OCG"
+msgstr ""
+
+#: src\commands\metagame.ts:221
+#: src\commands\metagame.ts:259
+msgctxt "command-option-choice"
+msgid "OCG (Asian-English)"
+msgstr ""
+
+#: src\commands\metagame.ts:228
+msgctxt "command-option-choice"
+msgid "Master Duel Diamond+ tier list"
+msgstr ""
+
+#: src\commands\metagame.ts:261
+msgctxt "command-option-choice"
+msgid "Master Duel ranked ladder"
+msgstr ""
+
+#: src\commands\metagame.ts:283
+msgctxt "command-option-choice"
+msgid "Current format"
+msgstr ""
+
+#: src\commands\metagame.ts:287
+msgctxt "command-option-choice"
+msgid "Since last Forbidden/Limited List"
+msgstr ""
+
+#: src\commands\metagame.ts:291
+msgctxt "command-option-choice"
+msgid "Last 7 days"
+msgstr ""
+
+#: src\commands\metagame.ts:295
+msgctxt "command-option-choice"
+msgid "Last 14 days"
+msgstr ""
+
+#: src\commands\metagame.ts:299
+msgctxt "command-option-choice"
+msgid "Last 30 days"
+msgstr ""
+
+#: src\commands\metagame.ts:303
+msgctxt "command-option-choice"
+msgid "Last three months"
+msgstr ""
+
+#: src\commands\metagame.ts:307
+msgctxt "command-option-choice"
+msgid "Last six months"
 msgstr ""

--- a/translations/fr.po
+++ b/translations/fr.po
@@ -6,50 +6,50 @@ msgstr ""
 "MIME-Version: 1.0\n"
 "Content-Transfer-Encoding: 8bit\n"
 
-#: src\card.ts:416
-#: src\rush-duel.ts:39
+#: src\card.ts:412
+#: src\rush-duel.ts:48
 msgid "🔗 Links"
 msgstr ""
 
-#: src\card.ts:417
+#: src\card.ts:413
 #, javascript-format
 msgid "[Official Konami DB](${ official }) | [OCG Rulings](${ rulings }) | [Yugipedia](${ yugipedia }) | [YGOPRODECK](${ ygoprodeck })"
 msgstr ""
 
-#: src\card.ts:420
+#: src\card.ts:416
 #, javascript-format
 msgid "[Yugipedia](${ yugipedia }) | [YGOPRODECK](${ ygoprodeck })"
 msgstr ""
 
-#: src\card.ts:489
-#: src\rush-duel.ts:92
+#: src\card.ts:490
+#: src\rush-duel.ts:103
 #, javascript-format
 msgid "**Type**: ${ raceIcon } ${ localizedMonsterTypeLine }"
 msgstr "**Type**: ${ raceIcon } ${ localizedMonsterTypeLine }"
 
-#: src\card.ts:491
-#: src\rush-duel.ts:94
+#: src\card.ts:492
+#: src\rush-duel.ts:105
 #, javascript-format
 msgid "**Attribute**: ${ attributeIcon } ${ localizedAttribute }"
 msgstr "**Attribut**: ${ attributeIcon } ${ localizedAttribute }"
 
-#: src\card.ts:495
+#: src\card.ts:497
 #, javascript-format
 msgid "**Rank**: ${ rankIcon } ${ card.rank } **ATK**: ${ card.atk } **DEF**: ${ card.def }"
 msgstr "**Rang**: ${ rankIcon } ${ card.rank } **ATK**: ${ card.atk } **DEF**: ${ card.def }"
 
-#: src\card.ts:498
+#: src\card.ts:500
 #, javascript-format
 msgid "**Link Rating**: ${ card.link_arrows.length } **ATK**: ${ card.atk } **Link Arrows**: ${ arrows }"
 msgstr ""
 
-#: src\card.ts:500
-#: src\rush-duel.ts:96
+#: src\card.ts:503
+#: src\rush-duel.ts:107
 #, javascript-format
 msgid "**Level**: ${ levelIcon } ${ card.level } **ATK**: ${ card.atk } **DEF**: ${ card.def }"
 msgstr "**Niveau**: ${ levelIcon } ${ card.level } **ATK**: ${ card.atk } **DEF**: ${ card.def }"
 
-#: src\card.ts:507
+#: src\card.ts:511
 #, javascript-format
 msgid "**Pendulum Scale**: ${ formattedScale }"
 msgstr "**Échelle Pendule**: ${ formattedScale }"
@@ -70,7 +70,7 @@ msgid "Password: ${ card.password } | Not yet released"
 msgstr ""
 
 #: src\card.ts:351
-#: src\rush-duel.ts:146
+#: src\rush-duel.ts:158
 msgid "Not yet released"
 msgstr ""
 
@@ -79,64 +79,64 @@ msgstr ""
 msgid "Placeholder ID: ${ card.fake_password }"
 msgstr ""
 
-#: src\utils.ts:41
+#: src\utils.ts:44
 msgid "🛠️ This command is in development."
 msgstr ""
 
-#: src\utils.ts:42
+#: src\utils.ts:45
 msgid "📨 Please send feedback to [our issue tracker](https://github.com/DawnbrandBots/bastion-bot) or the [support server](https://discord.gg/4aFuPyuE96)!"
 msgstr ""
 
-#: src\utils.ts:53
+#: src\utils.ts:56
 msgid "Please consider supporting us!"
 msgstr ""
 
-#: src\utils.ts:54
+#: src\utils.ts:57
 msgid "Help keep Bastion online!"
 msgstr ""
 
-#: src\utils.ts:55
+#: src\utils.ts:58
 msgid "Please help keep Bastion online!"
 msgstr ""
 
-#: src\utils.ts:56
+#: src\utils.ts:59
 msgid "Was Bastion helpful? Consider supporting us!"
 msgstr ""
 
-#: src\utils.ts:57
+#: src\utils.ts:60
 msgid "Was Bastion helpful? We need your support!"
 msgstr ""
 
-#: src\utils.ts:58
+#: src\utils.ts:61
 msgid "Did you find Bastion useful? Consider supporting us!"
 msgstr ""
 
-#: src\utils.ts:59
+#: src\utils.ts:62
 msgid "Did you find Bastion useful? Help keep it online!"
 msgstr ""
 
-#: src\utils.ts:60
+#: src\utils.ts:63
 msgid "Did you find Bastion useful? We need your support!"
 msgstr ""
 
-#: src\utils.ts:61
+#: src\utils.ts:64
 msgid "Enjoy Bastion? Help keep it online!"
 msgstr ""
 
-#: src\utils.ts:62
+#: src\utils.ts:65
 msgid "Enjoy Bastion? Consider supporting us!"
 msgstr ""
 
-#: src\utils.ts:63
+#: src\utils.ts:66
 msgid "Found what you were looking for? Consider supporting us!"
 msgstr ""
 
 #: src\commands\art.ts:63
-#: src\commands\price.ts:131
-#: src\commands\rush-duel.ts:172
-#: src\commands\rush-duel.ts:203
+#: src\commands\price.ts:132
+#: src\commands\rush-duel.ts:171
+#: src\commands\rush-duel.ts:202
 #: src\commands\search.ts:64
-#: src\events\message-search.ts:258
+#: src\events\message-search.ts:265
 #, javascript-format
 msgid "Could not find a card matching `${ input }`!"
 msgstr ""
@@ -147,51 +147,51 @@ msgstr ""
 msgid "Could not find art for `${ name }`!"
 msgstr ""
 
-#: src\commands\deck.ts:244
+#: src\commands\deck.ts:205
 #, javascript-format
 msgid "${ counts.Monster } Monster"
 msgid_plural "${ counts.Monster } Monsters"
 msgstr[0] ""
 msgstr[1] ""
 
-#: src\commands\deck.ts:247
+#: src\commands\deck.ts:208
 #, javascript-format
 msgid "${ counts.Spell } Spell"
 msgid_plural "${ counts.Spell } Spells"
 msgstr[0] ""
 msgstr[1] ""
 
-#: src\commands\deck.ts:250
+#: src\commands\deck.ts:211
 #, javascript-format
 msgid "${ counts.Trap } Trap"
 msgid_plural "${ counts.Trap } Traps"
 msgstr[0] ""
 msgstr[1] ""
 
-#: src\commands\deck.ts:278
+#: src\commands\deck.ts:239
 msgid "Your Deck"
 msgstr ""
 
-#: src\commands\deck.ts:283
+#: src\commands\deck.ts:244
 #, javascript-format
 msgid "Main Deck (${ deck.main.length } card — ${ countDetail })"
 msgid_plural "Main Deck (${ deck.main.length } cards — ${ countDetail })"
 msgstr[0] ""
 msgstr[1] ""
 
-#: src\commands\deck.ts:290
+#: src\commands\deck.ts:251
 msgid "Main Deck (continued)"
 msgstr ""
 
-#: src\commands\deck.ts:304
+#: src\commands\deck.ts:265
 msgid "Extra Deck (continued)"
 msgstr ""
 
-#: src\commands\deck.ts:318
+#: src\commands\deck.ts:279
 msgid "Side Deck (continued)"
 msgstr ""
 
-#: src\commands\deck.ts:407
+#: src\commands\deck.ts:347
 msgid "Error: Your deck is empty."
 msgstr ""
 
@@ -211,11 +211,7 @@ msgstr ""
 msgid "Discord Community locale for this server: ${ interaction.guildLocale }"
 msgstr ""
 
-#: src\commands\locale.ts:89
-#, javascript-format
-msgid "Locale override for this direct message: ${ override }"
-msgstr ""
-
+#: src\commands\locale-user.ts:76
 #: src\commands\locale.ts:92
 #, javascript-format
 msgid "Your Discord locale: ${ interaction.locale }"
@@ -253,24 +249,14 @@ msgstr ""
 msgid "Sorry, you must have the Manage Server permission to do this. If you think this is an error, contact your server admin or report a bug."
 msgstr ""
 
-#: src\commands\locale.ts:146
-#, javascript-format
-msgid "Locale for this direct message overridden with ${ locale }. Your Discord setting is ${ interaction.locale }."
-msgstr ""
-
-#: src\commands\locale.ts:150
-#, javascript-format
-msgid "Locale for this direct message reset to Discord default. Your Discord setting is ${ interaction.locale }."
-msgstr ""
-
-#: src\commands\ping.ts:36
-#: src\events\message-ping.ts:47
+#: src\commands\ping.ts:38
+#: src\events\message-ping.ts:45
 #, javascript-format
 msgid "Average WebSocket ping (new instance): ${ ping } ms"
 msgstr ""
 
-#: src\commands\ping.ts:40
-#: src\events\message-ping.ts:112
+#: src\commands\ping.ts:42
+#: src\events\message-ping.ts:110
 #, javascript-format
 msgid "Total latency: ${ latency } ms"
 msgstr ""
@@ -280,86 +266,69 @@ msgstr ""
 msgid "Could not find a Yugipedia page named `${ page }`."
 msgstr ""
 
-#: src\events\message-ping.ts:49
+#: src\events\message-ping.ts:47
 msgid "Free and open source _Yu-Gi-Oh!_ bot"
 msgstr ""
 
-#: src\events\message-ping.ts:72
+#: src\events\message-ping.ts:70
 #, javascript-format
 msgid "Revision: ${ process.env.BOT_REVISION }."
 msgstr ""
 
-#: src\commands\deck.ts:328
+#: src\commands\deck.ts:289
 msgid ".ydk files must have the .ydk extension!"
 msgstr ""
 
-#: src\commands\deck.ts:331
+#: src\commands\deck.ts:292
 msgid ".ydk files should not be larger than 1 KB!"
 msgstr ""
 
-#: src\commands\deck.ts:321
+#: src\commands\deck.ts:282
 msgid "ydke URL"
 msgstr ""
 
 #: src\card.ts:455
-#: src\rush-duel.ts:61
+#: src\rush-duel.ts:75
 #. Forbidden/Limited Lists or Limit Regulations in the OCG
 #, javascript-format
 msgid "**Limit**: ${ limitRegulationDisplay }"
 msgstr ""
 
-#: src\commands\price.ts:69
+#: src\commands\price.ts:70
 msgid "TCGPlayer"
 msgstr ""
 
-#: src\commands\price.ts:70
+#: src\commands\price.ts:71
 msgid "Cardmarket"
 msgstr ""
 
-#: src\commands\price.ts:147
+#: src\commands\price.ts:148
 msgid "No market price"
 msgstr ""
 
-#: src\commands\price.ts:155
+#: src\commands\price.ts:156
 #, javascript-format
 msgid "Prices for ${ card.name[resultLanguage] } - ${ vendorName }"
 msgstr ""
 
-#: src\commands\price.ts:169
+#: src\commands\price.ts:170
 #, javascript-format
 msgid "Could not find prices for `${ name }`!"
 msgstr ""
 
-#: src\commands\deck.ts:425
-#. prepare interaction button for FTP upload
+#: src\commands\deck.ts:363
 msgid "Upload to YGOPRODECK"
 msgstr ""
 
-#: src\commands\deck.ts:483
-#. disable original button
-#. prepare row to disable button on original message
-msgid "Upload Complete"
-msgstr ""
-
-#: src\commands\deck.ts:470
-msgid "Deck upload failed!"
-msgstr ""
-
-#: src\commands\deck.ts:491
-#. reply in affirmation
-#, javascript-format
-msgid "Deck successfully uploaded to <${ url }>!"
-msgstr ""
-
-#: src\events\message-search.ts:264
+#: src\events\message-search.ts:271
 msgid "💬 Translations missing?"
 msgstr ""
 
-#: src\events\message-search.ts:265
+#: src\events\message-search.ts:272
 msgid "Help translate Bastion at the links above."
 msgstr ""
 
-#: src\events\message-ping.ts:50
+#: src\events\message-ping.ts:48
 msgid ""
 "❓ Help documentation on [GitHub](https://github.com/DawnbrandBots/bastion-bot), or use `.commands` and `.help`.\n"
 "🟢 Licence: [GNU AGPL 3.0+](https://choosealicense.com/licenses/agpl-3.0/).\n"
@@ -375,38 +344,38 @@ msgid ""
 "💬 Translations missing? Help translate Bastion on [GitHub](https://github.com/DawnbrandBots/bastion-bot)."
 msgstr ""
 
-#: src\events\message-search.ts:256
-#: src\events\message-search.ts:294
+#: src\events\message-search.ts:263
+#: src\events\message-search.ts:302
 #, javascript-format
 msgid "Search type: ${ localisedType }"
 msgstr ""
 
-#: src\events\message-search.ts:236
+#: src\events\message-search.ts:242
 #, javascript-format
 msgid "Search language: **${ localisedInputLanguage }** (${ inputLanguage }). Check defaults with </locale get:${ id }> and configure with </locale set:${ id }>"
 msgstr ""
 
-#: src\events\message-ping.ts:95
+#: src\events\message-ping.ts:93
 msgid "⚠️ You pinged me, but I am missing permissions in the channel!"
 msgstr ""
 
-#: src\events\message-ping.ts:98
-#: src\events\message-search.ts:332
+#: src\events\message-ping.ts:96
+#: src\events\message-search.ts:340
 msgid "Please have a server administrator [fix this](https://github.com/DawnbrandBots/bastion-bot#discord-permissions)."
 msgstr ""
 
-#: src\events\message-search.ts:329
+#: src\events\message-search.ts:337
 msgid "⚠️ I am missing permissions in the channel!"
 msgstr ""
 
-#: src\commands\deck.ts:297
+#: src\commands\deck.ts:258
 #, javascript-format
 msgid "Extra Deck (${ deck.extra.length } card — ${ countDetail })"
 msgid_plural "Extra Deck (${ deck.extra.length } cards — ${ countDetail })"
 msgstr[0] ""
 msgstr[1] ""
 
-#: src\commands\deck.ts:311
+#: src\commands\deck.ts:272
 #, javascript-format
 msgid "Side Deck (${ deck.side.length } card — ${ countDetail })"
 msgid_plural "Side Deck (${ deck.side.length } cards — ${ countDetail })"
@@ -428,32 +397,31 @@ msgstr ""
 msgid "Something went wrong searching Yugipedia for `${ page }`."
 msgstr ""
 
-#: src\rush-duel.ts:40
+#: src\rush-duel.ts:49
 #, javascript-format
 msgid "[Official Konami DB](${ official }) | [Rulings (Japanese)](${ rulings }) | [Yugipedia](${ yugipedia }) | [RushCard](${ rushcard })"
 msgstr ""
 
-#: src\rush-duel.ts:43
+#: src\rush-duel.ts:52
 #, javascript-format
 msgid "[Yugipedia](${ yugipedia }) | [RushCard](${ rushcard })"
 msgstr ""
 
-#: src\rush-duel.ts:57
+#: src\rush-duel.ts:71
 msgid "__**LEGEND**__"
 msgstr ""
 
-#: src\rush-duel.ts:99
+#: src\rush-duel.ts:110
 #, javascript-format
 msgid "**MAXIMUM ATK**: ${ card.maximum_atk }"
 msgstr ""
 
-#: src\rush-duel.ts:146
+#: src\rush-duel.ts:158
 #, javascript-format
 msgid "Konami ID #${ card.konami_id }"
 msgstr ""
 
 #: src\art.ts:129
-#: src\commands\deck.ts:451
 msgid "Buttons can only be used by the user who called Bastion."
 msgstr ""
 
@@ -462,14 +430,32 @@ msgstr ""
 msgid "**Master Duel rarity**: ${ rarityIcon } ${ localizedRarity }"
 msgstr ""
 
-#: src\rush-duel.ts:205
+#: src\rush-duel.ts:217
 #, javascript-format
 msgid "Using ${ searchTrigger }, you can search for Rush Duel cards directly in messages without autocomplete"
 msgstr ""
 
-#: src\events\message-search.ts:296
+#: src\events\message-search.ts:304
 #, javascript-format
 msgid "Could not find a Rush Duel card matching `${ input }`!"
+msgstr ""
+
+#: src\commands\locale-user.ts:73
+#: src\commands\locale.ts:89
+#, javascript-format
+msgid "Locale override for your direct messages: ${ override }"
+msgstr ""
+
+#: src\commands\locale-user.ts:83
+#: src\commands\locale.ts:146
+#, javascript-format
+msgid "Locale for your direct messages overridden with ${ locale }. Your Discord setting is ${ interaction.locale }."
+msgstr ""
+
+#: src\commands\locale-user.ts:87
+#: src\commands\locale.ts:150
+#, javascript-format
+msgid "Locale for your direct messages reset to Discord default. Your Discord setting is ${ interaction.locale }."
 msgstr ""
 
 #: src\card.ts:40
@@ -836,65 +822,65 @@ msgctxt "master-duel-rarity"
 msgid "Ultra Rare (UR)"
 msgstr "Ultra Rare (UR)"
 
-#: src\card.ts:513
-#: src\card.ts:524
-#: src\rush-duel.ts:127
+#: src\card.ts:517
+#: src\card.ts:528
+#: src\rush-duel.ts:138
 msgctxt "card-embed"
 msgid "Card Text"
 msgstr "Texte de carte"
 
-#: src\card.ts:518
+#: src\card.ts:522
 msgctxt "card-embed"
 msgid "Pendulum Effect"
 msgstr "Effet Pendule"
 
-#: src\card.ts:539
+#: src\card.ts:545
 msgctxt "card-embed"
 msgid "Card Effect"
 msgstr ""
 
-#: src\rush-duel.ts:118
-#: src\rush-duel.ts:139
+#: src\rush-duel.ts:129
+#: src\rush-duel.ts:151
 msgctxt "card-embed"
 msgid "[REQUIREMENT]"
 msgstr "[CONDITION]"
 
-#: src\rush-duel.ts:119
-#: src\rush-duel.ts:140
+#: src\rush-duel.ts:130
+#: src\rush-duel.ts:152
 msgctxt "card-embed"
 msgid "[EFFECT]"
 msgstr "[EFFET]"
 
-#: src\rush-duel.ts:121
+#: src\rush-duel.ts:132
 msgctxt "card-embed"
 msgid "[CONTINUOUS EFFECT]"
 msgstr "[EFFET CONTINU]"
 
-#: src\rush-duel.ts:123
+#: src\rush-duel.ts:134
 msgctxt "card-embed"
 msgid "[MULTI-CHOICE EFFECT]"
 msgstr ""
 
-#: src\locale.ts:71
+#: src\locale.ts:74
 msgctxt "command-option"
 msgid "result-language"
 msgstr ""
 
-#: src\locale.ts:131
+#: src\locale.ts:140
 msgctxt "command-option"
 msgid "input-language"
 msgstr ""
 
-#: src\commands\rush-duel.ts:68
-#: src\commands\rush-duel.ts:80
-#: src\locale.ts:147
-#: src\locale.ts:165
-#: src\locale.ts:181
+#: src\commands\rush-duel.ts:67
+#: src\commands\rush-duel.ts:79
+#: src\locale.ts:156
+#: src\locale.ts:174
+#: src\locale.ts:190
 msgctxt "command-option"
 msgid "input"
 msgstr ""
 
-#: src\commands\help.ts:52
+#: src\commands\help.ts:55
 msgctxt "command-option"
 msgid "command"
 msgstr ""
@@ -909,54 +895,56 @@ msgctxt "command-option"
 msgid "page"
 msgstr ""
 
-#: src\commands\deck.ts:126
+#: src\commands\deck.ts:87
 msgctxt "command-option"
 msgid "url"
 msgstr ""
 
-#: src\commands\deck.ts:132
+#: src\commands\deck.ts:93
 msgctxt "command-option"
 msgid "file"
 msgstr ""
 
-#: src\commands\deck.ts:138
-#: src\commands\deck.ts:144
+#: src\commands\deck.ts:99
+#: src\commands\deck.ts:105
 msgctxt "command-option"
 msgid "deck"
 msgstr ""
 
-#: src\commands\deck.ts:150
+#: src\commands\deck.ts:111
 msgctxt "command-option"
 msgid "public"
 msgstr ""
 
-#: src\commands\deck.ts:157
+#: src\commands\deck.ts:118
 msgctxt "command-option"
 msgid "stacked"
 msgstr ""
 
-#: src\locale.ts:142
+#: src\locale.ts:151
 msgctxt "command-option"
 msgid "name"
 msgstr ""
 
-#: src\locale.ts:160
+#: src\locale.ts:169
 msgctxt "command-option"
 msgid "password"
 msgstr ""
 
-#: src\commands\rush-duel.ts:73
-#: src\events\message-search.ts:293
-#: src\locale.ts:176
+#: src\commands\rush-duel.ts:72
+#: src\events\message-search.ts:301
+#: src\locale.ts:185
 msgctxt "command-option"
 msgid "konami-id"
 msgstr ""
 
+#: src\commands\locale-user.ts:36
 #: src\commands\locale.ts:30
 msgctxt "command-option"
 msgid "get"
 msgstr ""
 
+#: src\commands\locale-user.ts:41
 #: src\commands\locale.ts:35
 msgctxt "command-option"
 msgid "set"
@@ -967,47 +955,69 @@ msgctxt "command-option"
 msgid "scope"
 msgstr ""
 
+#: src\commands\locale-user.ts:46
 #: src\commands\locale.ts:48
 msgctxt "command-option"
 msgid "locale"
 msgstr ""
 
-#: src\commands\price.ts:94
+#: src\commands\price.ts:95
 msgctxt "command-option"
 msgid "vendor"
 msgstr ""
 
-#: src\commands\rush-duel.ts:63
+#: src\commands\rush-duel.ts:62
 msgctxt "command-option"
 msgid "search"
 msgstr ""
 
-#: src\commands\rush-duel.ts:85
+#: src\commands\rush-duel.ts:84
 msgctxt "command-option"
 msgid "random"
 msgstr ""
 
-#: src\commands\rush-duel.ts:90
+#: src\commands\rush-duel.ts:89
 msgctxt "command-option"
 msgid "art"
 msgstr ""
 
-#: src\commands\query.ts:36
+#: src\commands\query.ts:35
 msgctxt "command-option"
 msgid "lucene"
 msgstr ""
 
-#: src\locale.ts:74
+#: src\commands\metagame.ts:209
+msgctxt "command-option"
+msgid "strategies"
+msgstr ""
+
+#: src\commands\metagame.ts:234
+#: src\commands\metagame.ts:274
+msgctxt "command-option"
+msgid "format"
+msgstr ""
+
+#: src\commands\metagame.ts:240
+msgctxt "command-option"
+msgid "cards"
+msgstr ""
+
+#: src\commands\metagame.ts:310
+msgctxt "command-option"
+msgid "date-range"
+msgstr ""
+
+#: src\locale.ts:77
 msgctxt "command-option-description"
 msgid "The output language for the card embed, overriding other settings."
 msgstr ""
 
-#: src\locale.ts:132
+#: src\locale.ts:141
 msgctxt "command-option-description"
 msgid "The language to search in, defaulting to the result language."
 msgstr ""
 
-#: src\commands\help.ts:55
+#: src\commands\help.ts:58
 msgctxt "command-option-description"
 msgid "The name of a specific Slash Command."
 msgstr ""
@@ -1017,32 +1027,32 @@ msgctxt "command-option-description"
 msgid "The name of the Yugipedia page you want to search for."
 msgstr ""
 
-#: src\commands\deck.ts:129
+#: src\commands\deck.ts:90
 msgctxt "command-option-description"
 msgid "View a deck by entering a ydke:// URL."
 msgstr ""
 
-#: src\commands\deck.ts:135
+#: src\commands\deck.ts:96
 msgctxt "command-option-description"
 msgid "View a deck by uploading a .ydk file."
 msgstr ""
 
-#: src\commands\deck.ts:141
+#: src\commands\deck.ts:102
 msgctxt "command-option-description"
 msgid "The ydke:// URL of the deck you want to view."
 msgstr ""
 
-#: src\commands\deck.ts:147
+#: src\commands\deck.ts:108
 msgctxt "command-option-description"
 msgid "The .ydk file of the deck you want to view."
 msgstr ""
 
-#: src\commands\deck.ts:153
+#: src\commands\deck.ts:114
 msgctxt "command-option-description"
 msgid "Whether to display the deck details publicly in chat. This is false by default."
 msgstr ""
 
-#: src\commands\deck.ts:160
+#: src\commands\deck.ts:121
 msgctxt "command-option-description"
 msgid "Whether to display the deck sections as one stacked column. This is false (side-by-side) by default."
 msgstr ""
@@ -1052,8 +1062,8 @@ msgctxt "command-option-description"
 msgid "Display the art for the card with this name."
 msgstr ""
 
-#: src\commands\rush-duel.ts:69
-#: src\locale.ts:148
+#: src\commands\rush-duel.ts:68
+#: src\locale.ts:157
 msgctxt "command-option-description"
 msgid "Card name, fuzzy matching supported."
 msgstr ""
@@ -1063,7 +1073,7 @@ msgctxt "command-option-description"
 msgid "Display the art for the card with this password."
 msgstr ""
 
-#: src\locale.ts:167
+#: src\locale.ts:176
 msgctxt "command-option-description"
 msgid "Card password, the eight-digit number printed on the bottom left corner."
 msgstr ""
@@ -1073,8 +1083,8 @@ msgctxt "command-option-description"
 msgid "Display the art for the card with this official database ID."
 msgstr ""
 
-#: src\commands\rush-duel.ts:81
-#: src\locale.ts:182
+#: src\commands\rush-duel.ts:80
+#: src\locale.ts:191
 msgctxt "command-option-description"
 msgid "Konami's official card database identifier."
 msgstr ""
@@ -1114,22 +1124,22 @@ msgctxt "command-option-description"
 msgid "The new default language to use in this channel or server."
 msgstr ""
 
-#: src\commands\price.ts:98
+#: src\commands\price.ts:99
 msgctxt "command-option-description"
 msgid "Display the price for the card with this name."
 msgstr ""
 
-#: src\commands\price.ts:102
+#: src\commands\price.ts:103
 msgctxt "command-option-description"
 msgid "Display the price for the card with this password."
 msgstr ""
 
-#: src\commands\price.ts:105
+#: src\commands\price.ts:106
 msgctxt "command-option-description"
 msgid "Display the price for the card with this official database ID."
 msgstr ""
 
-#: src\commands\price.ts:95
+#: src\commands\price.ts:96
 msgctxt "command-option-description"
 msgid "The vendor to fetch the price data from."
 msgstr ""
@@ -1139,29 +1149,70 @@ msgctxt "command-option-description"
 msgid "The English name of the card you're looking for."
 msgstr ""
 
-#: src\commands\rush-duel.ts:64
+#: src\commands\rush-duel.ts:63
 msgctxt "command-option-description"
 msgid "Find all information for the Rush Duel card with this name."
 msgstr ""
 
-#: src\commands\rush-duel.ts:75
+#: src\commands\rush-duel.ts:74
 msgctxt "command-option-description"
 msgid "Find all information for the Rush Duel card with this official database ID."
 msgstr ""
 
-#: src\commands\rush-duel.ts:86
+#: src\commands\rush-duel.ts:85
 msgctxt "command-option-description"
 msgid "Get a random Rush Duel card."
 msgstr ""
 
-#: src\commands\rush-duel.ts:91
+#: src\commands\rush-duel.ts:90
 msgctxt "command-option-description"
 msgid "Display just the art for the Rush Duel card with this name."
 msgstr ""
 
-#: src\commands\query.ts:37
+#: src\commands\query.ts:36
 msgctxt "command-option-description"
 msgid "Lucene query on YAML Yugi"
+msgstr ""
+
+#: src\commands\locale-user.ts:37
+msgctxt "command-option-description"
+msgid "Check your user-installed Bastion's locale."
+msgstr ""
+
+#: src\commands\locale-user.ts:42
+msgctxt "command-option-description"
+msgid "Configure your user-installed Bastion's locale."
+msgstr ""
+
+#: src\commands\locale-user.ts:47
+msgctxt "command-option-description"
+msgid "The new default language to use for user-installed Bastion."
+msgstr ""
+
+#: src\commands\metagame.ts:212
+msgctxt "command-option-description"
+msgid "Show the top competitive strategies in tournaments and the Master Duel ranked ladder."
+msgstr ""
+
+#: src\commands\metagame.ts:214
+msgctxt "command-option-description"
+msgid "Show the top competitive strategies in tournaments."
+msgstr ""
+
+#: src\commands\metagame.ts:235
+#: src\commands\metagame.ts:275
+msgctxt "command-option-description"
+msgid "Game region."
+msgstr ""
+
+#: src\commands\metagame.ts:242
+msgctxt "command-option-description"
+msgid "Show the most popular cards in tournaments and the Master Duel ranked ladder."
+msgstr ""
+
+#: src\commands\metagame.ts:312
+msgctxt "command-option-description"
+msgid "Limit card usage statistics to this date range. Has no effect for Master Duel."
 msgstr ""
 
 #: src\commands\art.ts:36
@@ -1169,12 +1220,12 @@ msgctxt "command-name"
 msgid "art"
 msgstr ""
 
-#: src\commands\help.ts:49
+#: src\commands\help.ts:52
 msgctxt "command-name"
 msgid "help"
 msgstr ""
 
-#: src\commands\ping.ts:23
+#: src\commands\ping.ts:25
 msgctxt "command-name"
 msgid "ping"
 msgstr ""
@@ -1189,7 +1240,7 @@ msgctxt "command-name"
 msgid "yugipedia"
 msgstr ""
 
-#: src\commands\deck.ts:119
+#: src\commands\deck.ts:80
 msgctxt "command-name"
 msgid "deck"
 msgstr ""
@@ -1204,24 +1255,34 @@ msgctxt "command-name"
 msgid "locale"
 msgstr ""
 
-#: src\commands\random.ts:44
+#: src\commands\random.ts:43
 msgctxt "command-name"
 msgid "random"
 msgstr ""
 
-#: src\commands\price.ts:89
+#: src\commands\price.ts:90
 msgctxt "command-name"
 msgid "price"
 msgstr ""
 
-#: src\commands\rush-duel.ts:58
+#: src\commands\rush-duel.ts:57
 msgctxt "command-name"
 msgid "rush-duel"
 msgstr ""
 
-#: src\commands\query.ts:30
+#: src\commands\query.ts:29
 msgctxt "command-name"
 msgid "query"
+msgstr ""
+
+#: src\commands\locale-user.ts:31
+msgctxt "command-name"
+msgid "locale-user"
+msgstr ""
+
+#: src\commands\metagame.ts:204
+msgctxt "command-name"
+msgid "metagame"
 msgstr ""
 
 #: src\commands\art.ts:37
@@ -1229,12 +1290,12 @@ msgctxt "command-description"
 msgid "Display the art for a card!"
 msgstr ""
 
-#: src\commands\help.ts:50
+#: src\commands\help.ts:53
 msgctxt "command-description"
 msgid "Get help with a Slash Command."
 msgstr ""
 
-#: src\commands\ping.ts:24
+#: src\commands\ping.ts:26
 msgctxt "command-description"
 msgid "Test latency to the new bot instance."
 msgstr ""
@@ -1249,7 +1310,7 @@ msgctxt "command-description"
 msgid "Search the Yugipedia wiki for a page and link to it."
 msgstr ""
 
-#: src\commands\deck.ts:122
+#: src\commands\deck.ts:83
 msgctxt "command-description"
 msgid "Display a deck list from ydke:// or .ydk format, exported from a number of deck building programs."
 msgstr ""
@@ -1264,24 +1325,34 @@ msgctxt "command-description"
 msgid "Check or set Bastion's locale for this channel or server."
 msgstr ""
 
-#: src\commands\random.ts:45
+#: src\commands\random.ts:44
 msgctxt "command-description"
 msgid "Get a random Yu-Gi-Oh! card."
 msgstr ""
 
-#: src\commands\price.ts:90
+#: src\commands\price.ts:91
 msgctxt "command-description"
 msgid "Display the price for a card!"
 msgstr ""
 
-#: src\commands\rush-duel.ts:59
+#: src\commands\rush-duel.ts:58
 msgctxt "command-description"
 msgid "Find information on Rush Duel cards."
 msgstr ""
 
-#: src\commands\query.ts:31
+#: src\commands\query.ts:30
 msgctxt "command-description"
 msgid "Advanced search prototype"
+msgstr ""
+
+#: src\commands\locale-user.ts:32
+msgctxt "command-description"
+msgid "Check or set user-installed Bastion's locale."
+msgstr ""
+
+#: src\commands\metagame.ts:205
+msgctxt "command-description"
+msgid "Show statistics on the current competitive state of play."
 msgstr ""
 
 #: src\commands\locale.ts:43
@@ -1294,7 +1365,71 @@ msgctxt "command-option-choice"
 msgid "server"
 msgstr ""
 
+#: src\commands\locale-user.ts:49
 #: src\commands\locale.ts:51
 msgctxt "command-option-choice"
 msgid "Discord default"
+msgstr ""
+
+#: src\commands\metagame.ts:219
+#: src\commands\metagame.ts:251
+msgctxt "command-option-choice"
+msgid "TCG"
+msgstr ""
+
+#: src\commands\metagame.ts:220
+#: src\commands\metagame.ts:255
+msgctxt "command-option-choice"
+msgid "OCG"
+msgstr ""
+
+#: src\commands\metagame.ts:221
+#: src\commands\metagame.ts:259
+msgctxt "command-option-choice"
+msgid "OCG (Asian-English)"
+msgstr ""
+
+#: src\commands\metagame.ts:228
+msgctxt "command-option-choice"
+msgid "Master Duel Diamond+ tier list"
+msgstr ""
+
+#: src\commands\metagame.ts:261
+msgctxt "command-option-choice"
+msgid "Master Duel ranked ladder"
+msgstr ""
+
+#: src\commands\metagame.ts:283
+msgctxt "command-option-choice"
+msgid "Current format"
+msgstr ""
+
+#: src\commands\metagame.ts:287
+msgctxt "command-option-choice"
+msgid "Since last Forbidden/Limited List"
+msgstr ""
+
+#: src\commands\metagame.ts:291
+msgctxt "command-option-choice"
+msgid "Last 7 days"
+msgstr ""
+
+#: src\commands\metagame.ts:295
+msgctxt "command-option-choice"
+msgid "Last 14 days"
+msgstr ""
+
+#: src\commands\metagame.ts:299
+msgctxt "command-option-choice"
+msgid "Last 30 days"
+msgstr ""
+
+#: src\commands\metagame.ts:303
+msgctxt "command-option-choice"
+msgid "Last three months"
+msgstr ""
+
+#: src\commands\metagame.ts:307
+msgctxt "command-option-choice"
+msgid "Last six months"
 msgstr ""

--- a/translations/fr.po
+++ b/translations/fr.po
@@ -30,13 +30,13 @@ msgstr "**Type**: ${ raceIcon } ${ localizedMonsterTypeLine }"
 #: src\card.ts:491
 #: src\rush-duel.ts:94
 #, javascript-format
-msgid "**Attribute**: ${ AttributeIcon[card.attribute] } ${ localizedAttribute }"
-msgstr "**Attribut**: ${ AttributeIcon[card.attribute] } ${ localizedAttribute }"
+msgid "**Attribute**: ${ attributeIcon } ${ localizedAttribute }"
+msgstr "**Attribut**: ${ attributeIcon } ${ localizedAttribute }"
 
 #: src\card.ts:495
 #, javascript-format
-msgid "**Rank**: ${ Icon.Rank } ${ card.rank } **ATK**: ${ card.atk } **DEF**: ${ card.def }"
-msgstr "**Rang**: ${ Icon.Rank } ${ card.rank } **ATK**: ${ card.atk } **DEF**: ${ card.def }"
+msgid "**Rank**: ${ rankIcon } ${ card.rank } **ATK**: ${ card.atk } **DEF**: ${ card.def }"
+msgstr "**Rang**: ${ rankIcon } ${ card.rank } **ATK**: ${ card.atk } **DEF**: ${ card.def }"
 
 #: src\card.ts:498
 #, javascript-format
@@ -46,8 +46,8 @@ msgstr ""
 #: src\card.ts:500
 #: src\rush-duel.ts:96
 #, javascript-format
-msgid "**Level**: ${ Icon.Level } ${ card.level } **ATK**: ${ card.atk } **DEF**: ${ card.def }"
-msgstr "**Niveau**: ${ Icon.Level } ${ card.level } **ATK**: ${ card.atk } **DEF**: ${ card.def }"
+msgid "**Level**: ${ levelIcon } ${ card.level } **ATK**: ${ card.atk } **DEF**: ${ card.def }"
+msgstr "**Niveau**: ${ levelIcon } ${ card.level } **ATK**: ${ card.atk } **DEF**: ${ card.def }"
 
 #: src\card.ts:507
 #, javascript-format
@@ -459,7 +459,7 @@ msgstr ""
 
 #: src\card.ts:462
 #, javascript-format
-msgid "**Master Duel rarity**: ${ rarity_icon } ${ localized_rarity }"
+msgid "**Master Duel rarity**: ${ rarityIcon } ${ localizedRarity }"
 msgstr ""
 
 #: src\rush-duel.ts:205

--- a/translations/fr.po
+++ b/translations/fr.po
@@ -6,33 +6,50 @@ msgstr ""
 "MIME-Version: 1.0\n"
 "Content-Transfer-Encoding: 8bit\n"
 
-#: src\card.ts:412
-#: src\rush-duel.ts:48
+#: src\card.ts:416
+#: src\rush-duel.ts:39
 msgid "🔗 Links"
 msgstr ""
 
-#: src\card.ts:413
+#: src\card.ts:417
 #, javascript-format
 msgid "[Official Konami DB](${ official }) | [OCG Rulings](${ rulings }) | [Yugipedia](${ yugipedia }) | [YGOPRODECK](${ ygoprodeck })"
 msgstr ""
 
-#: src\card.ts:416
+#: src\card.ts:420
 #, javascript-format
 msgid "[Yugipedia](${ yugipedia }) | [YGOPRODECK](${ ygoprodeck })"
 msgstr ""
 
-#: src\card.ts:490
-#: src\rush-duel.ts:103
+#: src\card.ts:489
+#: src\rush-duel.ts:92
 #, javascript-format
 msgid "**Type**: ${ raceIcon } ${ localizedMonsterTypeLine }"
 msgstr "**Type**: ${ raceIcon } ${ localizedMonsterTypeLine }"
 
-#: src\card.ts:500
+#: src\card.ts:491
+#: src\rush-duel.ts:94
+#, javascript-format
+msgid "**Attribute**: ${ AttributeIcon[card.attribute] } ${ localizedAttribute }"
+msgstr "**Attribut**: ${ AttributeIcon[card.attribute] } ${ localizedAttribute }"
+
+#: src\card.ts:495
+#, javascript-format
+msgid "**Rank**: ${ Icon.Rank } ${ card.rank } **ATK**: ${ card.atk } **DEF**: ${ card.def }"
+msgstr "**Rang**: ${ Icon.Rank } ${ card.rank } **ATK**: ${ card.atk } **DEF**: ${ card.def }"
+
+#: src\card.ts:498
 #, javascript-format
 msgid "**Link Rating**: ${ card.link_arrows.length } **ATK**: ${ card.atk } **Link Arrows**: ${ arrows }"
 msgstr ""
 
-#: src\card.ts:511
+#: src\card.ts:500
+#: src\rush-duel.ts:96
+#, javascript-format
+msgid "**Level**: ${ Icon.Level } ${ card.level } **ATK**: ${ card.atk } **DEF**: ${ card.def }"
+msgstr "**Niveau**: ${ Icon.Level } ${ card.level } **ATK**: ${ card.atk } **DEF**: ${ card.def }"
+
+#: src\card.ts:507
 #, javascript-format
 msgid "**Pendulum Scale**: ${ formattedScale }"
 msgstr "**Échelle Pendule**: ${ formattedScale }"
@@ -53,7 +70,7 @@ msgid "Password: ${ card.password } | Not yet released"
 msgstr ""
 
 #: src\card.ts:351
-#: src\rush-duel.ts:158
+#: src\rush-duel.ts:146
 msgid "Not yet released"
 msgstr ""
 
@@ -62,64 +79,64 @@ msgstr ""
 msgid "Placeholder ID: ${ card.fake_password }"
 msgstr ""
 
-#: src\utils.ts:44
+#: src\utils.ts:41
 msgid "🛠️ This command is in development."
 msgstr ""
 
-#: src\utils.ts:45
+#: src\utils.ts:42
 msgid "📨 Please send feedback to [our issue tracker](https://github.com/DawnbrandBots/bastion-bot) or the [support server](https://discord.gg/4aFuPyuE96)!"
 msgstr ""
 
-#: src\utils.ts:56
+#: src\utils.ts:53
 msgid "Please consider supporting us!"
 msgstr ""
 
-#: src\utils.ts:57
+#: src\utils.ts:54
 msgid "Help keep Bastion online!"
 msgstr ""
 
-#: src\utils.ts:58
+#: src\utils.ts:55
 msgid "Please help keep Bastion online!"
 msgstr ""
 
-#: src\utils.ts:59
+#: src\utils.ts:56
 msgid "Was Bastion helpful? Consider supporting us!"
 msgstr ""
 
-#: src\utils.ts:60
+#: src\utils.ts:57
 msgid "Was Bastion helpful? We need your support!"
 msgstr ""
 
-#: src\utils.ts:61
+#: src\utils.ts:58
 msgid "Did you find Bastion useful? Consider supporting us!"
 msgstr ""
 
-#: src\utils.ts:62
+#: src\utils.ts:59
 msgid "Did you find Bastion useful? Help keep it online!"
 msgstr ""
 
-#: src\utils.ts:63
+#: src\utils.ts:60
 msgid "Did you find Bastion useful? We need your support!"
 msgstr ""
 
-#: src\utils.ts:64
+#: src\utils.ts:61
 msgid "Enjoy Bastion? Help keep it online!"
 msgstr ""
 
-#: src\utils.ts:65
+#: src\utils.ts:62
 msgid "Enjoy Bastion? Consider supporting us!"
 msgstr ""
 
-#: src\utils.ts:66
+#: src\utils.ts:63
 msgid "Found what you were looking for? Consider supporting us!"
 msgstr ""
 
 #: src\commands\art.ts:63
-#: src\commands\price.ts:132
-#: src\commands\rush-duel.ts:171
-#: src\commands\rush-duel.ts:202
+#: src\commands\price.ts:131
+#: src\commands\rush-duel.ts:172
+#: src\commands\rush-duel.ts:203
 #: src\commands\search.ts:64
-#: src\events\message-search.ts:265
+#: src\events\message-search.ts:258
 #, javascript-format
 msgid "Could not find a card matching `${ input }`!"
 msgstr ""
@@ -130,51 +147,51 @@ msgstr ""
 msgid "Could not find art for `${ name }`!"
 msgstr ""
 
-#: src\commands\deck.ts:205
+#: src\commands\deck.ts:244
 #, javascript-format
 msgid "${ counts.Monster } Monster"
 msgid_plural "${ counts.Monster } Monsters"
 msgstr[0] ""
 msgstr[1] ""
 
-#: src\commands\deck.ts:208
+#: src\commands\deck.ts:247
 #, javascript-format
 msgid "${ counts.Spell } Spell"
 msgid_plural "${ counts.Spell } Spells"
 msgstr[0] ""
 msgstr[1] ""
 
-#: src\commands\deck.ts:211
+#: src\commands\deck.ts:250
 #, javascript-format
 msgid "${ counts.Trap } Trap"
 msgid_plural "${ counts.Trap } Traps"
 msgstr[0] ""
 msgstr[1] ""
 
-#: src\commands\deck.ts:239
+#: src\commands\deck.ts:278
 msgid "Your Deck"
 msgstr ""
 
-#: src\commands\deck.ts:244
+#: src\commands\deck.ts:283
 #, javascript-format
 msgid "Main Deck (${ deck.main.length } card — ${ countDetail })"
 msgid_plural "Main Deck (${ deck.main.length } cards — ${ countDetail })"
 msgstr[0] ""
 msgstr[1] ""
 
-#: src\commands\deck.ts:251
+#: src\commands\deck.ts:290
 msgid "Main Deck (continued)"
 msgstr ""
 
-#: src\commands\deck.ts:265
+#: src\commands\deck.ts:304
 msgid "Extra Deck (continued)"
 msgstr ""
 
-#: src\commands\deck.ts:279
+#: src\commands\deck.ts:318
 msgid "Side Deck (continued)"
 msgstr ""
 
-#: src\commands\deck.ts:347
+#: src\commands\deck.ts:407
 msgid "Error: Your deck is empty."
 msgstr ""
 
@@ -194,7 +211,11 @@ msgstr ""
 msgid "Discord Community locale for this server: ${ interaction.guildLocale }"
 msgstr ""
 
-#: src\commands\locale-user.ts:76
+#: src\commands\locale.ts:89
+#, javascript-format
+msgid "Locale override for this direct message: ${ override }"
+msgstr ""
+
 #: src\commands\locale.ts:92
 #, javascript-format
 msgid "Your Discord locale: ${ interaction.locale }"
@@ -232,14 +253,24 @@ msgstr ""
 msgid "Sorry, you must have the Manage Server permission to do this. If you think this is an error, contact your server admin or report a bug."
 msgstr ""
 
-#: src\commands\ping.ts:38
-#: src\events\message-ping.ts:45
+#: src\commands\locale.ts:146
+#, javascript-format
+msgid "Locale for this direct message overridden with ${ locale }. Your Discord setting is ${ interaction.locale }."
+msgstr ""
+
+#: src\commands\locale.ts:150
+#, javascript-format
+msgid "Locale for this direct message reset to Discord default. Your Discord setting is ${ interaction.locale }."
+msgstr ""
+
+#: src\commands\ping.ts:36
+#: src\events\message-ping.ts:47
 #, javascript-format
 msgid "Average WebSocket ping (new instance): ${ ping } ms"
 msgstr ""
 
-#: src\commands\ping.ts:42
-#: src\events\message-ping.ts:110
+#: src\commands\ping.ts:40
+#: src\events\message-ping.ts:112
 #, javascript-format
 msgid "Total latency: ${ latency } ms"
 msgstr ""
@@ -249,69 +280,86 @@ msgstr ""
 msgid "Could not find a Yugipedia page named `${ page }`."
 msgstr ""
 
-#: src\events\message-ping.ts:47
+#: src\events\message-ping.ts:49
 msgid "Free and open source _Yu-Gi-Oh!_ bot"
 msgstr ""
 
-#: src\events\message-ping.ts:70
+#: src\events\message-ping.ts:72
 #, javascript-format
 msgid "Revision: ${ process.env.BOT_REVISION }."
 msgstr ""
 
-#: src\commands\deck.ts:289
+#: src\commands\deck.ts:328
 msgid ".ydk files must have the .ydk extension!"
 msgstr ""
 
-#: src\commands\deck.ts:292
+#: src\commands\deck.ts:331
 msgid ".ydk files should not be larger than 1 KB!"
 msgstr ""
 
-#: src\commands\deck.ts:282
+#: src\commands\deck.ts:321
 msgid "ydke URL"
 msgstr ""
 
 #: src\card.ts:455
-#: src\rush-duel.ts:75
+#: src\rush-duel.ts:61
 #. Forbidden/Limited Lists or Limit Regulations in the OCG
 #, javascript-format
 msgid "**Limit**: ${ limitRegulationDisplay }"
 msgstr ""
 
-#: src\commands\price.ts:70
+#: src\commands\price.ts:69
 msgid "TCGPlayer"
 msgstr ""
 
-#: src\commands\price.ts:71
+#: src\commands\price.ts:70
 msgid "Cardmarket"
 msgstr ""
 
-#: src\commands\price.ts:148
+#: src\commands\price.ts:147
 msgid "No market price"
 msgstr ""
 
-#: src\commands\price.ts:156
+#: src\commands\price.ts:155
 #, javascript-format
 msgid "Prices for ${ card.name[resultLanguage] } - ${ vendorName }"
 msgstr ""
 
-#: src\commands\price.ts:170
+#: src\commands\price.ts:169
 #, javascript-format
 msgid "Could not find prices for `${ name }`!"
 msgstr ""
 
-#: src\commands\deck.ts:363
+#: src\commands\deck.ts:425
+#. prepare interaction button for FTP upload
 msgid "Upload to YGOPRODECK"
 msgstr ""
 
-#: src\events\message-search.ts:271
+#: src\commands\deck.ts:483
+#. disable original button
+#. prepare row to disable button on original message
+msgid "Upload Complete"
+msgstr ""
+
+#: src\commands\deck.ts:470
+msgid "Deck upload failed!"
+msgstr ""
+
+#: src\commands\deck.ts:491
+#. reply in affirmation
+#, javascript-format
+msgid "Deck successfully uploaded to <${ url }>!"
+msgstr ""
+
+#: src\events\message-search.ts:264
 msgid "💬 Translations missing?"
 msgstr ""
 
-#: src\events\message-search.ts:272
+#: src\events\message-search.ts:265
 msgid "Help translate Bastion at the links above."
 msgstr ""
 
-#: src\events\message-ping.ts:48
+#: src\events\message-ping.ts:50
 msgid ""
 "❓ Help documentation on [GitHub](https://github.com/DawnbrandBots/bastion-bot), or use `.commands` and `.help`.\n"
 "🟢 Licence: [GNU AGPL 3.0+](https://choosealicense.com/licenses/agpl-3.0/).\n"
@@ -327,38 +375,38 @@ msgid ""
 "💬 Translations missing? Help translate Bastion on [GitHub](https://github.com/DawnbrandBots/bastion-bot)."
 msgstr ""
 
-#: src\events\message-search.ts:263
-#: src\events\message-search.ts:302
+#: src\events\message-search.ts:256
+#: src\events\message-search.ts:294
 #, javascript-format
 msgid "Search type: ${ localisedType }"
 msgstr ""
 
-#: src\events\message-search.ts:242
+#: src\events\message-search.ts:236
 #, javascript-format
 msgid "Search language: **${ localisedInputLanguage }** (${ inputLanguage }). Check defaults with </locale get:${ id }> and configure with </locale set:${ id }>"
 msgstr ""
 
-#: src\events\message-ping.ts:93
+#: src\events\message-ping.ts:95
 msgid "⚠️ You pinged me, but I am missing permissions in the channel!"
 msgstr ""
 
-#: src\events\message-ping.ts:96
-#: src\events\message-search.ts:340
+#: src\events\message-ping.ts:98
+#: src\events\message-search.ts:332
 msgid "Please have a server administrator [fix this](https://github.com/DawnbrandBots/bastion-bot#discord-permissions)."
 msgstr ""
 
-#: src\events\message-search.ts:337
+#: src\events\message-search.ts:329
 msgid "⚠️ I am missing permissions in the channel!"
 msgstr ""
 
-#: src\commands\deck.ts:258
+#: src\commands\deck.ts:297
 #, javascript-format
 msgid "Extra Deck (${ deck.extra.length } card — ${ countDetail })"
 msgid_plural "Extra Deck (${ deck.extra.length } cards — ${ countDetail })"
 msgstr[0] ""
 msgstr[1] ""
 
-#: src\commands\deck.ts:272
+#: src\commands\deck.ts:311
 #, javascript-format
 msgid "Side Deck (${ deck.side.length } card — ${ countDetail })"
 msgid_plural "Side Deck (${ deck.side.length } cards — ${ countDetail })"
@@ -380,82 +428,48 @@ msgstr ""
 msgid "Something went wrong searching Yugipedia for `${ page }`."
 msgstr ""
 
-#: src\rush-duel.ts:49
+#: src\rush-duel.ts:40
 #, javascript-format
 msgid "[Official Konami DB](${ official }) | [Rulings (Japanese)](${ rulings }) | [Yugipedia](${ yugipedia }) | [RushCard](${ rushcard })"
 msgstr ""
 
-#: src\rush-duel.ts:52
+#: src\rush-duel.ts:43
 #, javascript-format
 msgid "[Yugipedia](${ yugipedia }) | [RushCard](${ rushcard })"
 msgstr ""
 
-#: src\rush-duel.ts:71
+#: src\rush-duel.ts:57
 msgid "__**LEGEND**__"
 msgstr ""
 
-#: src\rush-duel.ts:110
+#: src\rush-duel.ts:99
 #, javascript-format
 msgid "**MAXIMUM ATK**: ${ card.maximum_atk }"
 msgstr ""
 
-#: src\rush-duel.ts:158
+#: src\rush-duel.ts:146
 #, javascript-format
 msgid "Konami ID #${ card.konami_id }"
 msgstr ""
 
 #: src\art.ts:129
+#: src\commands\deck.ts:451
 msgid "Buttons can only be used by the user who called Bastion."
-msgstr ""
-
-#: src\rush-duel.ts:217
-#, javascript-format
-msgid "Using ${ searchTrigger }, you can search for Rush Duel cards directly in messages without autocomplete"
-msgstr ""
-
-#: src\events\message-search.ts:304
-#, javascript-format
-msgid "Could not find a Rush Duel card matching `${ input }`!"
 msgstr ""
 
 #: src\card.ts:462
 #, javascript-format
-msgid "**Master Duel rarity**: ${ rarityIcon } ${ localizedRarity }"
+msgid "**Master Duel rarity**: ${ rarity_icon } ${ localized_rarity }"
 msgstr ""
 
-#: src\card.ts:492
-#: src\rush-duel.ts:105
+#: src\rush-duel.ts:205
 #, javascript-format
-msgid "**Attribute**: ${ attributeIcon } ${ localizedAttribute }"
+msgid "Using ${ searchTrigger }, you can search for Rush Duel cards directly in messages without autocomplete"
 msgstr ""
 
-#: src\card.ts:497
+#: src\events\message-search.ts:296
 #, javascript-format
-msgid "**Rank**: ${ rankIcon } ${ card.rank } **ATK**: ${ card.atk } **DEF**: ${ card.def }"
-msgstr ""
-
-#: src\card.ts:503
-#: src\rush-duel.ts:107
-#, javascript-format
-msgid "**Level**: ${ levelIcon } ${ card.level } **ATK**: ${ card.atk } **DEF**: ${ card.def }"
-msgstr ""
-
-#: src\commands\locale-user.ts:73
-#: src\commands\locale.ts:89
-#, javascript-format
-msgid "Locale override for your direct messages: ${ override }"
-msgstr ""
-
-#: src\commands\locale-user.ts:83
-#: src\commands\locale.ts:146
-#, javascript-format
-msgid "Locale for your direct messages overridden with ${ locale }. Your Discord setting is ${ interaction.locale }."
-msgstr ""
-
-#: src\commands\locale-user.ts:87
-#: src\commands\locale.ts:150
-#, javascript-format
-msgid "Locale for your direct messages reset to Discord default. Your Discord setting is ${ interaction.locale }."
+msgid "Could not find a Rush Duel card matching `${ input }`!"
 msgstr ""
 
 #: src\card.ts:40
@@ -822,65 +836,65 @@ msgctxt "master-duel-rarity"
 msgid "Ultra Rare (UR)"
 msgstr "Ultra Rare (UR)"
 
-#: src\card.ts:517
-#: src\card.ts:528
-#: src\rush-duel.ts:138
+#: src\card.ts:513
+#: src\card.ts:524
+#: src\rush-duel.ts:127
 msgctxt "card-embed"
 msgid "Card Text"
 msgstr "Texte de carte"
 
-#: src\card.ts:522
+#: src\card.ts:518
 msgctxt "card-embed"
 msgid "Pendulum Effect"
 msgstr "Effet Pendule"
 
-#: src\card.ts:545
+#: src\card.ts:539
 msgctxt "card-embed"
 msgid "Card Effect"
 msgstr ""
 
-#: src\rush-duel.ts:129
-#: src\rush-duel.ts:151
+#: src\rush-duel.ts:118
+#: src\rush-duel.ts:139
 msgctxt "card-embed"
 msgid "[REQUIREMENT]"
 msgstr "[CONDITION]"
 
-#: src\rush-duel.ts:130
-#: src\rush-duel.ts:152
+#: src\rush-duel.ts:119
+#: src\rush-duel.ts:140
 msgctxt "card-embed"
 msgid "[EFFECT]"
 msgstr "[EFFET]"
 
-#: src\rush-duel.ts:132
+#: src\rush-duel.ts:121
 msgctxt "card-embed"
 msgid "[CONTINUOUS EFFECT]"
 msgstr "[EFFET CONTINU]"
 
-#: src\rush-duel.ts:134
+#: src\rush-duel.ts:123
 msgctxt "card-embed"
 msgid "[MULTI-CHOICE EFFECT]"
 msgstr ""
 
-#: src\locale.ts:74
+#: src\locale.ts:71
 msgctxt "command-option"
 msgid "result-language"
 msgstr ""
 
-#: src\locale.ts:140
+#: src\locale.ts:131
 msgctxt "command-option"
 msgid "input-language"
 msgstr ""
 
-#: src\commands\rush-duel.ts:67
-#: src\commands\rush-duel.ts:79
-#: src\locale.ts:156
-#: src\locale.ts:174
-#: src\locale.ts:190
+#: src\commands\rush-duel.ts:68
+#: src\commands\rush-duel.ts:80
+#: src\locale.ts:147
+#: src\locale.ts:165
+#: src\locale.ts:181
 msgctxt "command-option"
 msgid "input"
 msgstr ""
 
-#: src\commands\help.ts:55
+#: src\commands\help.ts:52
 msgctxt "command-option"
 msgid "command"
 msgstr ""
@@ -895,56 +909,54 @@ msgctxt "command-option"
 msgid "page"
 msgstr ""
 
-#: src\commands\deck.ts:87
+#: src\commands\deck.ts:126
 msgctxt "command-option"
 msgid "url"
 msgstr ""
 
-#: src\commands\deck.ts:93
+#: src\commands\deck.ts:132
 msgctxt "command-option"
 msgid "file"
 msgstr ""
 
-#: src\commands\deck.ts:99
-#: src\commands\deck.ts:105
+#: src\commands\deck.ts:138
+#: src\commands\deck.ts:144
 msgctxt "command-option"
 msgid "deck"
 msgstr ""
 
-#: src\commands\deck.ts:111
+#: src\commands\deck.ts:150
 msgctxt "command-option"
 msgid "public"
 msgstr ""
 
-#: src\commands\deck.ts:118
+#: src\commands\deck.ts:157
 msgctxt "command-option"
 msgid "stacked"
 msgstr ""
 
-#: src\locale.ts:151
+#: src\locale.ts:142
 msgctxt "command-option"
 msgid "name"
 msgstr ""
 
-#: src\locale.ts:169
+#: src\locale.ts:160
 msgctxt "command-option"
 msgid "password"
 msgstr ""
 
-#: src\commands\rush-duel.ts:72
-#: src\events\message-search.ts:301
-#: src\locale.ts:185
+#: src\commands\rush-duel.ts:73
+#: src\events\message-search.ts:293
+#: src\locale.ts:176
 msgctxt "command-option"
 msgid "konami-id"
 msgstr ""
 
-#: src\commands\locale-user.ts:36
 #: src\commands\locale.ts:30
 msgctxt "command-option"
 msgid "get"
 msgstr ""
 
-#: src\commands\locale-user.ts:41
 #: src\commands\locale.ts:35
 msgctxt "command-option"
 msgid "set"
@@ -955,69 +967,47 @@ msgctxt "command-option"
 msgid "scope"
 msgstr ""
 
-#: src\commands\locale-user.ts:46
 #: src\commands\locale.ts:48
 msgctxt "command-option"
 msgid "locale"
 msgstr ""
 
-#: src\commands\price.ts:95
+#: src\commands\price.ts:94
 msgctxt "command-option"
 msgid "vendor"
 msgstr ""
 
-#: src\commands\rush-duel.ts:62
+#: src\commands\rush-duel.ts:63
 msgctxt "command-option"
 msgid "search"
 msgstr ""
 
-#: src\commands\rush-duel.ts:84
+#: src\commands\rush-duel.ts:85
 msgctxt "command-option"
 msgid "random"
 msgstr ""
 
-#: src\commands\rush-duel.ts:89
+#: src\commands\rush-duel.ts:90
 msgctxt "command-option"
 msgid "art"
 msgstr ""
 
-#: src\commands\query.ts:35
+#: src\commands\query.ts:36
 msgctxt "command-option"
 msgid "lucene"
 msgstr ""
 
-#: src\commands\metagame.ts:209
-msgctxt "command-option"
-msgid "strategies"
-msgstr ""
-
-#: src\commands\metagame.ts:234
-#: src\commands\metagame.ts:274
-msgctxt "command-option"
-msgid "format"
-msgstr ""
-
-#: src\commands\metagame.ts:240
-msgctxt "command-option"
-msgid "cards"
-msgstr ""
-
-#: src\commands\metagame.ts:310
-msgctxt "command-option"
-msgid "date-range"
-msgstr ""
-
-#: src\locale.ts:77
+#: src\locale.ts:74
 msgctxt "command-option-description"
 msgid "The output language for the card embed, overriding other settings."
 msgstr ""
 
-#: src\locale.ts:141
+#: src\locale.ts:132
 msgctxt "command-option-description"
 msgid "The language to search in, defaulting to the result language."
 msgstr ""
 
-#: src\commands\help.ts:58
+#: src\commands\help.ts:55
 msgctxt "command-option-description"
 msgid "The name of a specific Slash Command."
 msgstr ""
@@ -1027,32 +1017,32 @@ msgctxt "command-option-description"
 msgid "The name of the Yugipedia page you want to search for."
 msgstr ""
 
-#: src\commands\deck.ts:90
+#: src\commands\deck.ts:129
 msgctxt "command-option-description"
 msgid "View a deck by entering a ydke:// URL."
 msgstr ""
 
-#: src\commands\deck.ts:96
+#: src\commands\deck.ts:135
 msgctxt "command-option-description"
 msgid "View a deck by uploading a .ydk file."
 msgstr ""
 
-#: src\commands\deck.ts:102
+#: src\commands\deck.ts:141
 msgctxt "command-option-description"
 msgid "The ydke:// URL of the deck you want to view."
 msgstr ""
 
-#: src\commands\deck.ts:108
+#: src\commands\deck.ts:147
 msgctxt "command-option-description"
 msgid "The .ydk file of the deck you want to view."
 msgstr ""
 
-#: src\commands\deck.ts:114
+#: src\commands\deck.ts:153
 msgctxt "command-option-description"
 msgid "Whether to display the deck details publicly in chat. This is false by default."
 msgstr ""
 
-#: src\commands\deck.ts:121
+#: src\commands\deck.ts:160
 msgctxt "command-option-description"
 msgid "Whether to display the deck sections as one stacked column. This is false (side-by-side) by default."
 msgstr ""
@@ -1062,8 +1052,8 @@ msgctxt "command-option-description"
 msgid "Display the art for the card with this name."
 msgstr ""
 
-#: src\commands\rush-duel.ts:68
-#: src\locale.ts:157
+#: src\commands\rush-duel.ts:69
+#: src\locale.ts:148
 msgctxt "command-option-description"
 msgid "Card name, fuzzy matching supported."
 msgstr ""
@@ -1073,7 +1063,7 @@ msgctxt "command-option-description"
 msgid "Display the art for the card with this password."
 msgstr ""
 
-#: src\locale.ts:176
+#: src\locale.ts:167
 msgctxt "command-option-description"
 msgid "Card password, the eight-digit number printed on the bottom left corner."
 msgstr ""
@@ -1083,8 +1073,8 @@ msgctxt "command-option-description"
 msgid "Display the art for the card with this official database ID."
 msgstr ""
 
-#: src\commands\rush-duel.ts:80
-#: src\locale.ts:191
+#: src\commands\rush-duel.ts:81
+#: src\locale.ts:182
 msgctxt "command-option-description"
 msgid "Konami's official card database identifier."
 msgstr ""
@@ -1124,22 +1114,22 @@ msgctxt "command-option-description"
 msgid "The new default language to use in this channel or server."
 msgstr ""
 
-#: src\commands\price.ts:99
+#: src\commands\price.ts:98
 msgctxt "command-option-description"
 msgid "Display the price for the card with this name."
 msgstr ""
 
-#: src\commands\price.ts:103
+#: src\commands\price.ts:102
 msgctxt "command-option-description"
 msgid "Display the price for the card with this password."
 msgstr ""
 
-#: src\commands\price.ts:106
+#: src\commands\price.ts:105
 msgctxt "command-option-description"
 msgid "Display the price for the card with this official database ID."
 msgstr ""
 
-#: src\commands\price.ts:96
+#: src\commands\price.ts:95
 msgctxt "command-option-description"
 msgid "The vendor to fetch the price data from."
 msgstr ""
@@ -1149,70 +1139,29 @@ msgctxt "command-option-description"
 msgid "The English name of the card you're looking for."
 msgstr ""
 
-#: src\commands\rush-duel.ts:63
+#: src\commands\rush-duel.ts:64
 msgctxt "command-option-description"
 msgid "Find all information for the Rush Duel card with this name."
 msgstr ""
 
-#: src\commands\rush-duel.ts:74
+#: src\commands\rush-duel.ts:75
 msgctxt "command-option-description"
 msgid "Find all information for the Rush Duel card with this official database ID."
 msgstr ""
 
-#: src\commands\rush-duel.ts:85
+#: src\commands\rush-duel.ts:86
 msgctxt "command-option-description"
 msgid "Get a random Rush Duel card."
 msgstr ""
 
-#: src\commands\rush-duel.ts:90
+#: src\commands\rush-duel.ts:91
 msgctxt "command-option-description"
 msgid "Display just the art for the Rush Duel card with this name."
 msgstr ""
 
-#: src\commands\query.ts:36
+#: src\commands\query.ts:37
 msgctxt "command-option-description"
 msgid "Lucene query on YAML Yugi"
-msgstr ""
-
-#: src\commands\locale-user.ts:37
-msgctxt "command-option-description"
-msgid "Check your user-installed Bastion's locale."
-msgstr ""
-
-#: src\commands\locale-user.ts:42
-msgctxt "command-option-description"
-msgid "Configure your user-installed Bastion's locale."
-msgstr ""
-
-#: src\commands\locale-user.ts:47
-msgctxt "command-option-description"
-msgid "The new default language to use for user-installed Bastion."
-msgstr ""
-
-#: src\commands\metagame.ts:212
-msgctxt "command-option-description"
-msgid "Show the top competitive strategies in tournaments and the Master Duel ranked ladder."
-msgstr ""
-
-#: src\commands\metagame.ts:214
-msgctxt "command-option-description"
-msgid "Show the top competitive strategies in tournaments."
-msgstr ""
-
-#: src\commands\metagame.ts:235
-#: src\commands\metagame.ts:275
-msgctxt "command-option-description"
-msgid "Game region."
-msgstr ""
-
-#: src\commands\metagame.ts:242
-msgctxt "command-option-description"
-msgid "Show the most popular cards in tournaments and the Master Duel ranked ladder."
-msgstr ""
-
-#: src\commands\metagame.ts:312
-msgctxt "command-option-description"
-msgid "Limit card usage statistics to this date range. Has no effect for Master Duel."
 msgstr ""
 
 #: src\commands\art.ts:36
@@ -1220,12 +1169,12 @@ msgctxt "command-name"
 msgid "art"
 msgstr ""
 
-#: src\commands\help.ts:52
+#: src\commands\help.ts:49
 msgctxt "command-name"
 msgid "help"
 msgstr ""
 
-#: src\commands\ping.ts:25
+#: src\commands\ping.ts:23
 msgctxt "command-name"
 msgid "ping"
 msgstr ""
@@ -1240,7 +1189,7 @@ msgctxt "command-name"
 msgid "yugipedia"
 msgstr ""
 
-#: src\commands\deck.ts:80
+#: src\commands\deck.ts:119
 msgctxt "command-name"
 msgid "deck"
 msgstr ""
@@ -1255,34 +1204,24 @@ msgctxt "command-name"
 msgid "locale"
 msgstr ""
 
-#: src\commands\random.ts:43
+#: src\commands\random.ts:44
 msgctxt "command-name"
 msgid "random"
 msgstr ""
 
-#: src\commands\price.ts:90
+#: src\commands\price.ts:89
 msgctxt "command-name"
 msgid "price"
 msgstr ""
 
-#: src\commands\rush-duel.ts:57
+#: src\commands\rush-duel.ts:58
 msgctxt "command-name"
 msgid "rush-duel"
 msgstr ""
 
-#: src\commands\query.ts:29
+#: src\commands\query.ts:30
 msgctxt "command-name"
 msgid "query"
-msgstr ""
-
-#: src\commands\locale-user.ts:31
-msgctxt "command-name"
-msgid "locale-user"
-msgstr ""
-
-#: src\commands\metagame.ts:204
-msgctxt "command-name"
-msgid "metagame"
 msgstr ""
 
 #: src\commands\art.ts:37
@@ -1290,12 +1229,12 @@ msgctxt "command-description"
 msgid "Display the art for a card!"
 msgstr ""
 
-#: src\commands\help.ts:53
+#: src\commands\help.ts:50
 msgctxt "command-description"
 msgid "Get help with a Slash Command."
 msgstr ""
 
-#: src\commands\ping.ts:26
+#: src\commands\ping.ts:24
 msgctxt "command-description"
 msgid "Test latency to the new bot instance."
 msgstr ""
@@ -1310,7 +1249,7 @@ msgctxt "command-description"
 msgid "Search the Yugipedia wiki for a page and link to it."
 msgstr ""
 
-#: src\commands\deck.ts:83
+#: src\commands\deck.ts:122
 msgctxt "command-description"
 msgid "Display a deck list from ydke:// or .ydk format, exported from a number of deck building programs."
 msgstr ""
@@ -1325,34 +1264,24 @@ msgctxt "command-description"
 msgid "Check or set Bastion's locale for this channel or server."
 msgstr ""
 
-#: src\commands\random.ts:44
+#: src\commands\random.ts:45
 msgctxt "command-description"
 msgid "Get a random Yu-Gi-Oh! card."
 msgstr ""
 
-#: src\commands\price.ts:91
+#: src\commands\price.ts:90
 msgctxt "command-description"
 msgid "Display the price for a card!"
 msgstr ""
 
-#: src\commands\rush-duel.ts:58
+#: src\commands\rush-duel.ts:59
 msgctxt "command-description"
 msgid "Find information on Rush Duel cards."
 msgstr ""
 
-#: src\commands\query.ts:30
+#: src\commands\query.ts:31
 msgctxt "command-description"
 msgid "Advanced search prototype"
-msgstr ""
-
-#: src\commands\locale-user.ts:32
-msgctxt "command-description"
-msgid "Check or set user-installed Bastion's locale."
-msgstr ""
-
-#: src\commands\metagame.ts:205
-msgctxt "command-description"
-msgid "Show statistics on the current competitive state of play."
 msgstr ""
 
 #: src\commands\locale.ts:43
@@ -1365,71 +1294,7 @@ msgctxt "command-option-choice"
 msgid "server"
 msgstr ""
 
-#: src\commands\locale-user.ts:49
 #: src\commands\locale.ts:51
 msgctxt "command-option-choice"
 msgid "Discord default"
-msgstr ""
-
-#: src\commands\metagame.ts:219
-#: src\commands\metagame.ts:251
-msgctxt "command-option-choice"
-msgid "TCG"
-msgstr ""
-
-#: src\commands\metagame.ts:220
-#: src\commands\metagame.ts:255
-msgctxt "command-option-choice"
-msgid "OCG"
-msgstr ""
-
-#: src\commands\metagame.ts:221
-#: src\commands\metagame.ts:259
-msgctxt "command-option-choice"
-msgid "OCG (Asian-English)"
-msgstr ""
-
-#: src\commands\metagame.ts:228
-msgctxt "command-option-choice"
-msgid "Master Duel Diamond+ tier list"
-msgstr ""
-
-#: src\commands\metagame.ts:261
-msgctxt "command-option-choice"
-msgid "Master Duel ranked ladder"
-msgstr ""
-
-#: src\commands\metagame.ts:283
-msgctxt "command-option-choice"
-msgid "Current format"
-msgstr ""
-
-#: src\commands\metagame.ts:287
-msgctxt "command-option-choice"
-msgid "Since last Forbidden/Limited List"
-msgstr ""
-
-#: src\commands\metagame.ts:291
-msgctxt "command-option-choice"
-msgid "Last 7 days"
-msgstr ""
-
-#: src\commands\metagame.ts:295
-msgctxt "command-option-choice"
-msgid "Last 14 days"
-msgstr ""
-
-#: src\commands\metagame.ts:299
-msgctxt "command-option-choice"
-msgid "Last 30 days"
-msgstr ""
-
-#: src\commands\metagame.ts:303
-msgctxt "command-option-choice"
-msgid "Last three months"
-msgstr ""
-
-#: src\commands\metagame.ts:307
-msgctxt "command-option-choice"
-msgid "Last six months"
 msgstr ""

--- a/translations/it.po
+++ b/translations/it.po
@@ -6,50 +6,33 @@ msgstr ""
 "MIME-Version: 1.0\n"
 "Content-Transfer-Encoding: 8bit\n"
 
-#: src\card.ts:416
-#: src\rush-duel.ts:39
+#: src\card.ts:412
+#: src\rush-duel.ts:48
 msgid "🔗 Links"
 msgstr ""
 
-#: src\card.ts:417
+#: src\card.ts:413
 #, javascript-format
 msgid "[Official Konami DB](${ official }) | [OCG Rulings](${ rulings }) | [Yugipedia](${ yugipedia }) | [YGOPRODECK](${ ygoprodeck })"
 msgstr ""
 
-#: src\card.ts:420
+#: src\card.ts:416
 #, javascript-format
 msgid "[Yugipedia](${ yugipedia }) | [YGOPRODECK](${ ygoprodeck })"
 msgstr ""
 
-#: src\card.ts:489
-#: src\rush-duel.ts:92
+#: src\card.ts:490
+#: src\rush-duel.ts:103
 #, javascript-format
 msgid "**Type**: ${ raceIcon } ${ localizedMonsterTypeLine }"
 msgstr "**Tipo**: ${ raceIcon } ${ localizedMonsterTypeLine }"
 
-#: src\card.ts:491
-#: src\rush-duel.ts:94
-#, javascript-format
-msgid "**Attribute**: ${ AttributeIcon[card.attribute] } ${ localizedAttribute }"
-msgstr "**Attributo**: ${ AttributeIcon[card.attribute] } ${ localizedAttribute }"
-
-#: src\card.ts:495
-#, javascript-format
-msgid "**Rank**: ${ Icon.Rank } ${ card.rank } **ATK**: ${ card.atk } **DEF**: ${ card.def }"
-msgstr "**Rango**: ${ Icon.Rank } ${ card.rank } **ATK**: ${ card.atk } **DEF**: ${ card.def }"
-
-#: src\card.ts:498
+#: src\card.ts:500
 #, javascript-format
 msgid "**Link Rating**: ${ card.link_arrows.length } **ATK**: ${ card.atk } **Link Arrows**: ${ arrows }"
 msgstr ""
 
-#: src\card.ts:500
-#: src\rush-duel.ts:96
-#, javascript-format
-msgid "**Level**: ${ Icon.Level } ${ card.level } **ATK**: ${ card.atk } **DEF**: ${ card.def }"
-msgstr "**Livello**: ${ Icon.Level } ${ card.level } **ATK**: ${ card.atk } **DEF**: ${ card.def }"
-
-#: src\card.ts:507
+#: src\card.ts:511
 #, javascript-format
 msgid "**Pendulum Scale**: ${ formattedScale }"
 msgstr "**Valore Pendulum**: ${ formattedScale }"
@@ -70,7 +53,7 @@ msgid "Password: ${ card.password } | Not yet released"
 msgstr ""
 
 #: src\card.ts:351
-#: src\rush-duel.ts:146
+#: src\rush-duel.ts:158
 msgid "Not yet released"
 msgstr ""
 
@@ -79,64 +62,64 @@ msgstr ""
 msgid "Placeholder ID: ${ card.fake_password }"
 msgstr ""
 
-#: src\utils.ts:41
+#: src\utils.ts:44
 msgid "🛠️ This command is in development."
 msgstr ""
 
-#: src\utils.ts:42
+#: src\utils.ts:45
 msgid "📨 Please send feedback to [our issue tracker](https://github.com/DawnbrandBots/bastion-bot) or the [support server](https://discord.gg/4aFuPyuE96)!"
 msgstr ""
 
-#: src\utils.ts:53
+#: src\utils.ts:56
 msgid "Please consider supporting us!"
 msgstr ""
 
-#: src\utils.ts:54
+#: src\utils.ts:57
 msgid "Help keep Bastion online!"
 msgstr ""
 
-#: src\utils.ts:55
+#: src\utils.ts:58
 msgid "Please help keep Bastion online!"
 msgstr ""
 
-#: src\utils.ts:56
+#: src\utils.ts:59
 msgid "Was Bastion helpful? Consider supporting us!"
 msgstr ""
 
-#: src\utils.ts:57
+#: src\utils.ts:60
 msgid "Was Bastion helpful? We need your support!"
 msgstr ""
 
-#: src\utils.ts:58
+#: src\utils.ts:61
 msgid "Did you find Bastion useful? Consider supporting us!"
 msgstr ""
 
-#: src\utils.ts:59
+#: src\utils.ts:62
 msgid "Did you find Bastion useful? Help keep it online!"
 msgstr ""
 
-#: src\utils.ts:60
+#: src\utils.ts:63
 msgid "Did you find Bastion useful? We need your support!"
 msgstr ""
 
-#: src\utils.ts:61
+#: src\utils.ts:64
 msgid "Enjoy Bastion? Help keep it online!"
 msgstr ""
 
-#: src\utils.ts:62
+#: src\utils.ts:65
 msgid "Enjoy Bastion? Consider supporting us!"
 msgstr ""
 
-#: src\utils.ts:63
+#: src\utils.ts:66
 msgid "Found what you were looking for? Consider supporting us!"
 msgstr ""
 
 #: src\commands\art.ts:63
-#: src\commands\price.ts:131
-#: src\commands\rush-duel.ts:172
-#: src\commands\rush-duel.ts:203
+#: src\commands\price.ts:132
+#: src\commands\rush-duel.ts:171
+#: src\commands\rush-duel.ts:202
 #: src\commands\search.ts:64
-#: src\events\message-search.ts:258
+#: src\events\message-search.ts:265
 #, javascript-format
 msgid "Could not find a card matching `${ input }`!"
 msgstr ""
@@ -147,51 +130,51 @@ msgstr ""
 msgid "Could not find art for `${ name }`!"
 msgstr ""
 
-#: src\commands\deck.ts:244
+#: src\commands\deck.ts:205
 #, javascript-format
 msgid "${ counts.Monster } Monster"
 msgid_plural "${ counts.Monster } Monsters"
 msgstr[0] ""
 msgstr[1] ""
 
-#: src\commands\deck.ts:247
+#: src\commands\deck.ts:208
 #, javascript-format
 msgid "${ counts.Spell } Spell"
 msgid_plural "${ counts.Spell } Spells"
 msgstr[0] ""
 msgstr[1] ""
 
-#: src\commands\deck.ts:250
+#: src\commands\deck.ts:211
 #, javascript-format
 msgid "${ counts.Trap } Trap"
 msgid_plural "${ counts.Trap } Traps"
 msgstr[0] ""
 msgstr[1] ""
 
-#: src\commands\deck.ts:278
+#: src\commands\deck.ts:239
 msgid "Your Deck"
 msgstr ""
 
-#: src\commands\deck.ts:283
+#: src\commands\deck.ts:244
 #, javascript-format
 msgid "Main Deck (${ deck.main.length } card — ${ countDetail })"
 msgid_plural "Main Deck (${ deck.main.length } cards — ${ countDetail })"
 msgstr[0] ""
 msgstr[1] ""
 
-#: src\commands\deck.ts:290
+#: src\commands\deck.ts:251
 msgid "Main Deck (continued)"
 msgstr ""
 
-#: src\commands\deck.ts:304
+#: src\commands\deck.ts:265
 msgid "Extra Deck (continued)"
 msgstr ""
 
-#: src\commands\deck.ts:318
+#: src\commands\deck.ts:279
 msgid "Side Deck (continued)"
 msgstr ""
 
-#: src\commands\deck.ts:407
+#: src\commands\deck.ts:347
 msgid "Error: Your deck is empty."
 msgstr ""
 
@@ -211,11 +194,7 @@ msgstr ""
 msgid "Discord Community locale for this server: ${ interaction.guildLocale }"
 msgstr ""
 
-#: src\commands\locale.ts:89
-#, javascript-format
-msgid "Locale override for this direct message: ${ override }"
-msgstr ""
-
+#: src\commands\locale-user.ts:76
 #: src\commands\locale.ts:92
 #, javascript-format
 msgid "Your Discord locale: ${ interaction.locale }"
@@ -253,24 +232,14 @@ msgstr ""
 msgid "Sorry, you must have the Manage Server permission to do this. If you think this is an error, contact your server admin or report a bug."
 msgstr ""
 
-#: src\commands\locale.ts:146
-#, javascript-format
-msgid "Locale for this direct message overridden with ${ locale }. Your Discord setting is ${ interaction.locale }."
-msgstr ""
-
-#: src\commands\locale.ts:150
-#, javascript-format
-msgid "Locale for this direct message reset to Discord default. Your Discord setting is ${ interaction.locale }."
-msgstr ""
-
-#: src\commands\ping.ts:36
-#: src\events\message-ping.ts:47
+#: src\commands\ping.ts:38
+#: src\events\message-ping.ts:45
 #, javascript-format
 msgid "Average WebSocket ping (new instance): ${ ping } ms"
 msgstr ""
 
-#: src\commands\ping.ts:40
-#: src\events\message-ping.ts:112
+#: src\commands\ping.ts:42
+#: src\events\message-ping.ts:110
 #, javascript-format
 msgid "Total latency: ${ latency } ms"
 msgstr ""
@@ -280,86 +249,69 @@ msgstr ""
 msgid "Could not find a Yugipedia page named `${ page }`."
 msgstr ""
 
-#: src\events\message-ping.ts:49
+#: src\events\message-ping.ts:47
 msgid "Free and open source _Yu-Gi-Oh!_ bot"
 msgstr ""
 
-#: src\events\message-ping.ts:72
+#: src\events\message-ping.ts:70
 #, javascript-format
 msgid "Revision: ${ process.env.BOT_REVISION }."
 msgstr ""
 
-#: src\commands\deck.ts:328
+#: src\commands\deck.ts:289
 msgid ".ydk files must have the .ydk extension!"
 msgstr ""
 
-#: src\commands\deck.ts:331
+#: src\commands\deck.ts:292
 msgid ".ydk files should not be larger than 1 KB!"
 msgstr ""
 
-#: src\commands\deck.ts:321
+#: src\commands\deck.ts:282
 msgid "ydke URL"
 msgstr ""
 
 #: src\card.ts:455
-#: src\rush-duel.ts:61
+#: src\rush-duel.ts:75
 #. Forbidden/Limited Lists or Limit Regulations in the OCG
 #, javascript-format
 msgid "**Limit**: ${ limitRegulationDisplay }"
 msgstr ""
 
-#: src\commands\price.ts:69
+#: src\commands\price.ts:70
 msgid "TCGPlayer"
 msgstr ""
 
-#: src\commands\price.ts:70
+#: src\commands\price.ts:71
 msgid "Cardmarket"
 msgstr ""
 
-#: src\commands\price.ts:147
+#: src\commands\price.ts:148
 msgid "No market price"
 msgstr ""
 
-#: src\commands\price.ts:155
+#: src\commands\price.ts:156
 #, javascript-format
 msgid "Prices for ${ card.name[resultLanguage] } - ${ vendorName }"
 msgstr ""
 
-#: src\commands\price.ts:169
+#: src\commands\price.ts:170
 #, javascript-format
 msgid "Could not find prices for `${ name }`!"
 msgstr ""
 
-#: src\commands\deck.ts:425
-#. prepare interaction button for FTP upload
+#: src\commands\deck.ts:363
 msgid "Upload to YGOPRODECK"
 msgstr ""
 
-#: src\commands\deck.ts:483
-#. disable original button
-#. prepare row to disable button on original message
-msgid "Upload Complete"
-msgstr ""
-
-#: src\commands\deck.ts:470
-msgid "Deck upload failed!"
-msgstr ""
-
-#: src\commands\deck.ts:491
-#. reply in affirmation
-#, javascript-format
-msgid "Deck successfully uploaded to <${ url }>!"
-msgstr ""
-
-#: src\events\message-search.ts:264
+#: src\events\message-search.ts:271
 msgid "💬 Translations missing?"
 msgstr ""
 
-#: src\events\message-search.ts:265
+#: src\events\message-search.ts:272
 msgid "Help translate Bastion at the links above."
 msgstr ""
 
-#: src\events\message-ping.ts:50
+#: src\events\message-ping.ts:48
 msgid ""
 "❓ Help documentation on [GitHub](https://github.com/DawnbrandBots/bastion-bot), or use `.commands` and `.help`.\n"
 "🟢 Licence: [GNU AGPL 3.0+](https://choosealicense.com/licenses/agpl-3.0/).\n"
@@ -375,38 +327,38 @@ msgid ""
 "💬 Translations missing? Help translate Bastion on [GitHub](https://github.com/DawnbrandBots/bastion-bot)."
 msgstr ""
 
-#: src\events\message-search.ts:256
-#: src\events\message-search.ts:294
+#: src\events\message-search.ts:263
+#: src\events\message-search.ts:302
 #, javascript-format
 msgid "Search type: ${ localisedType }"
 msgstr ""
 
-#: src\events\message-search.ts:236
+#: src\events\message-search.ts:242
 #, javascript-format
 msgid "Search language: **${ localisedInputLanguage }** (${ inputLanguage }). Check defaults with </locale get:${ id }> and configure with </locale set:${ id }>"
 msgstr ""
 
-#: src\events\message-ping.ts:95
+#: src\events\message-ping.ts:93
 msgid "⚠️ You pinged me, but I am missing permissions in the channel!"
 msgstr ""
 
-#: src\events\message-ping.ts:98
-#: src\events\message-search.ts:332
+#: src\events\message-ping.ts:96
+#: src\events\message-search.ts:340
 msgid "Please have a server administrator [fix this](https://github.com/DawnbrandBots/bastion-bot#discord-permissions)."
 msgstr ""
 
-#: src\events\message-search.ts:329
+#: src\events\message-search.ts:337
 msgid "⚠️ I am missing permissions in the channel!"
 msgstr ""
 
-#: src\commands\deck.ts:297
+#: src\commands\deck.ts:258
 #, javascript-format
 msgid "Extra Deck (${ deck.extra.length } card — ${ countDetail })"
 msgid_plural "Extra Deck (${ deck.extra.length } cards — ${ countDetail })"
 msgstr[0] ""
 msgstr[1] ""
 
-#: src\commands\deck.ts:311
+#: src\commands\deck.ts:272
 #, javascript-format
 msgid "Side Deck (${ deck.side.length } card — ${ countDetail })"
 msgid_plural "Side Deck (${ deck.side.length } cards — ${ countDetail })"
@@ -428,48 +380,82 @@ msgstr ""
 msgid "Something went wrong searching Yugipedia for `${ page }`."
 msgstr ""
 
-#: src\rush-duel.ts:40
+#: src\rush-duel.ts:49
 #, javascript-format
 msgid "[Official Konami DB](${ official }) | [Rulings (Japanese)](${ rulings }) | [Yugipedia](${ yugipedia }) | [RushCard](${ rushcard })"
 msgstr ""
 
-#: src\rush-duel.ts:43
+#: src\rush-duel.ts:52
 #, javascript-format
 msgid "[Yugipedia](${ yugipedia }) | [RushCard](${ rushcard })"
 msgstr ""
 
-#: src\rush-duel.ts:57
+#: src\rush-duel.ts:71
 msgid "__**LEGEND**__"
 msgstr ""
 
-#: src\rush-duel.ts:99
+#: src\rush-duel.ts:110
 #, javascript-format
 msgid "**MAXIMUM ATK**: ${ card.maximum_atk }"
 msgstr ""
 
-#: src\rush-duel.ts:146
+#: src\rush-duel.ts:158
 #, javascript-format
 msgid "Konami ID #${ card.konami_id }"
 msgstr ""
 
 #: src\art.ts:129
-#: src\commands\deck.ts:451
 msgid "Buttons can only be used by the user who called Bastion."
 msgstr ""
 
-#: src\card.ts:462
-#, javascript-format
-msgid "**Master Duel rarity**: ${ rarity_icon } ${ localized_rarity }"
-msgstr ""
-
-#: src\rush-duel.ts:205
+#: src\rush-duel.ts:217
 #, javascript-format
 msgid "Using ${ searchTrigger }, you can search for Rush Duel cards directly in messages without autocomplete"
 msgstr ""
 
-#: src\events\message-search.ts:296
+#: src\events\message-search.ts:304
 #, javascript-format
 msgid "Could not find a Rush Duel card matching `${ input }`!"
+msgstr ""
+
+#: src\card.ts:462
+#, javascript-format
+msgid "**Master Duel rarity**: ${ rarityIcon } ${ localizedRarity }"
+msgstr ""
+
+#: src\card.ts:492
+#: src\rush-duel.ts:105
+#, javascript-format
+msgid "**Attribute**: ${ attributeIcon } ${ localizedAttribute }"
+msgstr ""
+
+#: src\card.ts:497
+#, javascript-format
+msgid "**Rank**: ${ rankIcon } ${ card.rank } **ATK**: ${ card.atk } **DEF**: ${ card.def }"
+msgstr ""
+
+#: src\card.ts:503
+#: src\rush-duel.ts:107
+#, javascript-format
+msgid "**Level**: ${ levelIcon } ${ card.level } **ATK**: ${ card.atk } **DEF**: ${ card.def }"
+msgstr ""
+
+#: src\commands\locale-user.ts:73
+#: src\commands\locale.ts:89
+#, javascript-format
+msgid "Locale override for your direct messages: ${ override }"
+msgstr ""
+
+#: src\commands\locale-user.ts:83
+#: src\commands\locale.ts:146
+#, javascript-format
+msgid "Locale for your direct messages overridden with ${ locale }. Your Discord setting is ${ interaction.locale }."
+msgstr ""
+
+#: src\commands\locale-user.ts:87
+#: src\commands\locale.ts:150
+#, javascript-format
+msgid "Locale for your direct messages reset to Discord default. Your Discord setting is ${ interaction.locale }."
 msgstr ""
 
 #: src\card.ts:40
@@ -836,65 +822,65 @@ msgctxt "master-duel-rarity"
 msgid "Ultra Rare (UR)"
 msgstr "Ultra Raro (UR)"
 
-#: src\card.ts:513
-#: src\card.ts:524
-#: src\rush-duel.ts:127
+#: src\card.ts:517
+#: src\card.ts:528
+#: src\rush-duel.ts:138
 msgctxt "card-embed"
 msgid "Card Text"
 msgstr "Testo carta"
 
-#: src\card.ts:518
+#: src\card.ts:522
 msgctxt "card-embed"
 msgid "Pendulum Effect"
 msgstr "Effetto Pendulum"
 
-#: src\card.ts:539
+#: src\card.ts:545
 msgctxt "card-embed"
 msgid "Card Effect"
 msgstr ""
 
-#: src\rush-duel.ts:118
-#: src\rush-duel.ts:139
+#: src\rush-duel.ts:129
+#: src\rush-duel.ts:151
 msgctxt "card-embed"
 msgid "[REQUIREMENT]"
 msgstr "[REQUISITO]"
 
-#: src\rush-duel.ts:119
-#: src\rush-duel.ts:140
+#: src\rush-duel.ts:130
+#: src\rush-duel.ts:152
 msgctxt "card-embed"
 msgid "[EFFECT]"
 msgstr "[EFFETTO]"
 
-#: src\rush-duel.ts:121
+#: src\rush-duel.ts:132
 msgctxt "card-embed"
 msgid "[CONTINUOUS EFFECT]"
 msgstr "[EFFETTO CONTINUO]"
 
-#: src\rush-duel.ts:123
+#: src\rush-duel.ts:134
 msgctxt "card-embed"
 msgid "[MULTI-CHOICE EFFECT]"
 msgstr ""
 
-#: src\locale.ts:71
+#: src\locale.ts:74
 msgctxt "command-option"
 msgid "result-language"
 msgstr ""
 
-#: src\locale.ts:131
+#: src\locale.ts:140
 msgctxt "command-option"
 msgid "input-language"
 msgstr ""
 
-#: src\commands\rush-duel.ts:68
-#: src\commands\rush-duel.ts:80
-#: src\locale.ts:147
-#: src\locale.ts:165
-#: src\locale.ts:181
+#: src\commands\rush-duel.ts:67
+#: src\commands\rush-duel.ts:79
+#: src\locale.ts:156
+#: src\locale.ts:174
+#: src\locale.ts:190
 msgctxt "command-option"
 msgid "input"
 msgstr ""
 
-#: src\commands\help.ts:52
+#: src\commands\help.ts:55
 msgctxt "command-option"
 msgid "command"
 msgstr ""
@@ -909,54 +895,56 @@ msgctxt "command-option"
 msgid "page"
 msgstr ""
 
-#: src\commands\deck.ts:126
+#: src\commands\deck.ts:87
 msgctxt "command-option"
 msgid "url"
 msgstr ""
 
-#: src\commands\deck.ts:132
+#: src\commands\deck.ts:93
 msgctxt "command-option"
 msgid "file"
 msgstr ""
 
-#: src\commands\deck.ts:138
-#: src\commands\deck.ts:144
+#: src\commands\deck.ts:99
+#: src\commands\deck.ts:105
 msgctxt "command-option"
 msgid "deck"
 msgstr ""
 
-#: src\commands\deck.ts:150
+#: src\commands\deck.ts:111
 msgctxt "command-option"
 msgid "public"
 msgstr ""
 
-#: src\commands\deck.ts:157
+#: src\commands\deck.ts:118
 msgctxt "command-option"
 msgid "stacked"
 msgstr ""
 
-#: src\locale.ts:142
+#: src\locale.ts:151
 msgctxt "command-option"
 msgid "name"
 msgstr ""
 
-#: src\locale.ts:160
+#: src\locale.ts:169
 msgctxt "command-option"
 msgid "password"
 msgstr ""
 
-#: src\commands\rush-duel.ts:73
-#: src\events\message-search.ts:293
-#: src\locale.ts:176
+#: src\commands\rush-duel.ts:72
+#: src\events\message-search.ts:301
+#: src\locale.ts:185
 msgctxt "command-option"
 msgid "konami-id"
 msgstr ""
 
+#: src\commands\locale-user.ts:36
 #: src\commands\locale.ts:30
 msgctxt "command-option"
 msgid "get"
 msgstr ""
 
+#: src\commands\locale-user.ts:41
 #: src\commands\locale.ts:35
 msgctxt "command-option"
 msgid "set"
@@ -967,47 +955,69 @@ msgctxt "command-option"
 msgid "scope"
 msgstr ""
 
+#: src\commands\locale-user.ts:46
 #: src\commands\locale.ts:48
 msgctxt "command-option"
 msgid "locale"
 msgstr ""
 
-#: src\commands\price.ts:94
+#: src\commands\price.ts:95
 msgctxt "command-option"
 msgid "vendor"
 msgstr ""
 
-#: src\commands\rush-duel.ts:63
+#: src\commands\rush-duel.ts:62
 msgctxt "command-option"
 msgid "search"
 msgstr ""
 
-#: src\commands\rush-duel.ts:85
+#: src\commands\rush-duel.ts:84
 msgctxt "command-option"
 msgid "random"
 msgstr ""
 
-#: src\commands\rush-duel.ts:90
+#: src\commands\rush-duel.ts:89
 msgctxt "command-option"
 msgid "art"
 msgstr ""
 
-#: src\commands\query.ts:36
+#: src\commands\query.ts:35
 msgctxt "command-option"
 msgid "lucene"
 msgstr ""
 
-#: src\locale.ts:74
+#: src\commands\metagame.ts:209
+msgctxt "command-option"
+msgid "strategies"
+msgstr ""
+
+#: src\commands\metagame.ts:234
+#: src\commands\metagame.ts:274
+msgctxt "command-option"
+msgid "format"
+msgstr ""
+
+#: src\commands\metagame.ts:240
+msgctxt "command-option"
+msgid "cards"
+msgstr ""
+
+#: src\commands\metagame.ts:310
+msgctxt "command-option"
+msgid "date-range"
+msgstr ""
+
+#: src\locale.ts:77
 msgctxt "command-option-description"
 msgid "The output language for the card embed, overriding other settings."
 msgstr ""
 
-#: src\locale.ts:132
+#: src\locale.ts:141
 msgctxt "command-option-description"
 msgid "The language to search in, defaulting to the result language."
 msgstr ""
 
-#: src\commands\help.ts:55
+#: src\commands\help.ts:58
 msgctxt "command-option-description"
 msgid "The name of a specific Slash Command."
 msgstr ""
@@ -1017,32 +1027,32 @@ msgctxt "command-option-description"
 msgid "The name of the Yugipedia page you want to search for."
 msgstr ""
 
-#: src\commands\deck.ts:129
+#: src\commands\deck.ts:90
 msgctxt "command-option-description"
 msgid "View a deck by entering a ydke:// URL."
 msgstr ""
 
-#: src\commands\deck.ts:135
+#: src\commands\deck.ts:96
 msgctxt "command-option-description"
 msgid "View a deck by uploading a .ydk file."
 msgstr ""
 
-#: src\commands\deck.ts:141
+#: src\commands\deck.ts:102
 msgctxt "command-option-description"
 msgid "The ydke:// URL of the deck you want to view."
 msgstr ""
 
-#: src\commands\deck.ts:147
+#: src\commands\deck.ts:108
 msgctxt "command-option-description"
 msgid "The .ydk file of the deck you want to view."
 msgstr ""
 
-#: src\commands\deck.ts:153
+#: src\commands\deck.ts:114
 msgctxt "command-option-description"
 msgid "Whether to display the deck details publicly in chat. This is false by default."
 msgstr ""
 
-#: src\commands\deck.ts:160
+#: src\commands\deck.ts:121
 msgctxt "command-option-description"
 msgid "Whether to display the deck sections as one stacked column. This is false (side-by-side) by default."
 msgstr ""
@@ -1052,8 +1062,8 @@ msgctxt "command-option-description"
 msgid "Display the art for the card with this name."
 msgstr ""
 
-#: src\commands\rush-duel.ts:69
-#: src\locale.ts:148
+#: src\commands\rush-duel.ts:68
+#: src\locale.ts:157
 msgctxt "command-option-description"
 msgid "Card name, fuzzy matching supported."
 msgstr ""
@@ -1063,7 +1073,7 @@ msgctxt "command-option-description"
 msgid "Display the art for the card with this password."
 msgstr ""
 
-#: src\locale.ts:167
+#: src\locale.ts:176
 msgctxt "command-option-description"
 msgid "Card password, the eight-digit number printed on the bottom left corner."
 msgstr ""
@@ -1073,8 +1083,8 @@ msgctxt "command-option-description"
 msgid "Display the art for the card with this official database ID."
 msgstr ""
 
-#: src\commands\rush-duel.ts:81
-#: src\locale.ts:182
+#: src\commands\rush-duel.ts:80
+#: src\locale.ts:191
 msgctxt "command-option-description"
 msgid "Konami's official card database identifier."
 msgstr ""
@@ -1114,22 +1124,22 @@ msgctxt "command-option-description"
 msgid "The new default language to use in this channel or server."
 msgstr ""
 
-#: src\commands\price.ts:98
+#: src\commands\price.ts:99
 msgctxt "command-option-description"
 msgid "Display the price for the card with this name."
 msgstr ""
 
-#: src\commands\price.ts:102
+#: src\commands\price.ts:103
 msgctxt "command-option-description"
 msgid "Display the price for the card with this password."
 msgstr ""
 
-#: src\commands\price.ts:105
+#: src\commands\price.ts:106
 msgctxt "command-option-description"
 msgid "Display the price for the card with this official database ID."
 msgstr ""
 
-#: src\commands\price.ts:95
+#: src\commands\price.ts:96
 msgctxt "command-option-description"
 msgid "The vendor to fetch the price data from."
 msgstr ""
@@ -1139,29 +1149,70 @@ msgctxt "command-option-description"
 msgid "The English name of the card you're looking for."
 msgstr ""
 
-#: src\commands\rush-duel.ts:64
+#: src\commands\rush-duel.ts:63
 msgctxt "command-option-description"
 msgid "Find all information for the Rush Duel card with this name."
 msgstr ""
 
-#: src\commands\rush-duel.ts:75
+#: src\commands\rush-duel.ts:74
 msgctxt "command-option-description"
 msgid "Find all information for the Rush Duel card with this official database ID."
 msgstr ""
 
-#: src\commands\rush-duel.ts:86
+#: src\commands\rush-duel.ts:85
 msgctxt "command-option-description"
 msgid "Get a random Rush Duel card."
 msgstr ""
 
-#: src\commands\rush-duel.ts:91
+#: src\commands\rush-duel.ts:90
 msgctxt "command-option-description"
 msgid "Display just the art for the Rush Duel card with this name."
 msgstr ""
 
-#: src\commands\query.ts:37
+#: src\commands\query.ts:36
 msgctxt "command-option-description"
 msgid "Lucene query on YAML Yugi"
+msgstr ""
+
+#: src\commands\locale-user.ts:37
+msgctxt "command-option-description"
+msgid "Check your user-installed Bastion's locale."
+msgstr ""
+
+#: src\commands\locale-user.ts:42
+msgctxt "command-option-description"
+msgid "Configure your user-installed Bastion's locale."
+msgstr ""
+
+#: src\commands\locale-user.ts:47
+msgctxt "command-option-description"
+msgid "The new default language to use for user-installed Bastion."
+msgstr ""
+
+#: src\commands\metagame.ts:212
+msgctxt "command-option-description"
+msgid "Show the top competitive strategies in tournaments and the Master Duel ranked ladder."
+msgstr ""
+
+#: src\commands\metagame.ts:214
+msgctxt "command-option-description"
+msgid "Show the top competitive strategies in tournaments."
+msgstr ""
+
+#: src\commands\metagame.ts:235
+#: src\commands\metagame.ts:275
+msgctxt "command-option-description"
+msgid "Game region."
+msgstr ""
+
+#: src\commands\metagame.ts:242
+msgctxt "command-option-description"
+msgid "Show the most popular cards in tournaments and the Master Duel ranked ladder."
+msgstr ""
+
+#: src\commands\metagame.ts:312
+msgctxt "command-option-description"
+msgid "Limit card usage statistics to this date range. Has no effect for Master Duel."
 msgstr ""
 
 #: src\commands\art.ts:36
@@ -1169,12 +1220,12 @@ msgctxt "command-name"
 msgid "art"
 msgstr ""
 
-#: src\commands\help.ts:49
+#: src\commands\help.ts:52
 msgctxt "command-name"
 msgid "help"
 msgstr ""
 
-#: src\commands\ping.ts:23
+#: src\commands\ping.ts:25
 msgctxt "command-name"
 msgid "ping"
 msgstr ""
@@ -1189,7 +1240,7 @@ msgctxt "command-name"
 msgid "yugipedia"
 msgstr ""
 
-#: src\commands\deck.ts:119
+#: src\commands\deck.ts:80
 msgctxt "command-name"
 msgid "deck"
 msgstr ""
@@ -1204,24 +1255,34 @@ msgctxt "command-name"
 msgid "locale"
 msgstr ""
 
-#: src\commands\random.ts:44
+#: src\commands\random.ts:43
 msgctxt "command-name"
 msgid "random"
 msgstr ""
 
-#: src\commands\price.ts:89
+#: src\commands\price.ts:90
 msgctxt "command-name"
 msgid "price"
 msgstr ""
 
-#: src\commands\rush-duel.ts:58
+#: src\commands\rush-duel.ts:57
 msgctxt "command-name"
 msgid "rush-duel"
 msgstr ""
 
-#: src\commands\query.ts:30
+#: src\commands\query.ts:29
 msgctxt "command-name"
 msgid "query"
+msgstr ""
+
+#: src\commands\locale-user.ts:31
+msgctxt "command-name"
+msgid "locale-user"
+msgstr ""
+
+#: src\commands\metagame.ts:204
+msgctxt "command-name"
+msgid "metagame"
 msgstr ""
 
 #: src\commands\art.ts:37
@@ -1229,12 +1290,12 @@ msgctxt "command-description"
 msgid "Display the art for a card!"
 msgstr ""
 
-#: src\commands\help.ts:50
+#: src\commands\help.ts:53
 msgctxt "command-description"
 msgid "Get help with a Slash Command."
 msgstr ""
 
-#: src\commands\ping.ts:24
+#: src\commands\ping.ts:26
 msgctxt "command-description"
 msgid "Test latency to the new bot instance."
 msgstr ""
@@ -1249,7 +1310,7 @@ msgctxt "command-description"
 msgid "Search the Yugipedia wiki for a page and link to it."
 msgstr ""
 
-#: src\commands\deck.ts:122
+#: src\commands\deck.ts:83
 msgctxt "command-description"
 msgid "Display a deck list from ydke:// or .ydk format, exported from a number of deck building programs."
 msgstr ""
@@ -1264,24 +1325,34 @@ msgctxt "command-description"
 msgid "Check or set Bastion's locale for this channel or server."
 msgstr ""
 
-#: src\commands\random.ts:45
+#: src\commands\random.ts:44
 msgctxt "command-description"
 msgid "Get a random Yu-Gi-Oh! card."
 msgstr ""
 
-#: src\commands\price.ts:90
+#: src\commands\price.ts:91
 msgctxt "command-description"
 msgid "Display the price for a card!"
 msgstr ""
 
-#: src\commands\rush-duel.ts:59
+#: src\commands\rush-duel.ts:58
 msgctxt "command-description"
 msgid "Find information on Rush Duel cards."
 msgstr ""
 
-#: src\commands\query.ts:31
+#: src\commands\query.ts:30
 msgctxt "command-description"
 msgid "Advanced search prototype"
+msgstr ""
+
+#: src\commands\locale-user.ts:32
+msgctxt "command-description"
+msgid "Check or set user-installed Bastion's locale."
+msgstr ""
+
+#: src\commands\metagame.ts:205
+msgctxt "command-description"
+msgid "Show statistics on the current competitive state of play."
 msgstr ""
 
 #: src\commands\locale.ts:43
@@ -1294,7 +1365,71 @@ msgctxt "command-option-choice"
 msgid "server"
 msgstr ""
 
+#: src\commands\locale-user.ts:49
 #: src\commands\locale.ts:51
 msgctxt "command-option-choice"
 msgid "Discord default"
+msgstr ""
+
+#: src\commands\metagame.ts:219
+#: src\commands\metagame.ts:251
+msgctxt "command-option-choice"
+msgid "TCG"
+msgstr ""
+
+#: src\commands\metagame.ts:220
+#: src\commands\metagame.ts:255
+msgctxt "command-option-choice"
+msgid "OCG"
+msgstr ""
+
+#: src\commands\metagame.ts:221
+#: src\commands\metagame.ts:259
+msgctxt "command-option-choice"
+msgid "OCG (Asian-English)"
+msgstr ""
+
+#: src\commands\metagame.ts:228
+msgctxt "command-option-choice"
+msgid "Master Duel Diamond+ tier list"
+msgstr ""
+
+#: src\commands\metagame.ts:261
+msgctxt "command-option-choice"
+msgid "Master Duel ranked ladder"
+msgstr ""
+
+#: src\commands\metagame.ts:283
+msgctxt "command-option-choice"
+msgid "Current format"
+msgstr ""
+
+#: src\commands\metagame.ts:287
+msgctxt "command-option-choice"
+msgid "Since last Forbidden/Limited List"
+msgstr ""
+
+#: src\commands\metagame.ts:291
+msgctxt "command-option-choice"
+msgid "Last 7 days"
+msgstr ""
+
+#: src\commands\metagame.ts:295
+msgctxt "command-option-choice"
+msgid "Last 14 days"
+msgstr ""
+
+#: src\commands\metagame.ts:299
+msgctxt "command-option-choice"
+msgid "Last 30 days"
+msgstr ""
+
+#: src\commands\metagame.ts:303
+msgctxt "command-option-choice"
+msgid "Last three months"
+msgstr ""
+
+#: src\commands\metagame.ts:307
+msgctxt "command-option-choice"
+msgid "Last six months"
 msgstr ""

--- a/translations/it.po
+++ b/translations/it.po
@@ -30,13 +30,13 @@ msgstr "**Tipo**: ${ raceIcon } ${ localizedMonsterTypeLine }"
 #: src\card.ts:491
 #: src\rush-duel.ts:94
 #, javascript-format
-msgid "**Attribute**: ${ AttributeIcon[card.attribute] } ${ localizedAttribute }"
-msgstr "**Attributo**: ${ AttributeIcon[card.attribute] } ${ localizedAttribute }"
+msgid "**Attribute**: ${ attributeIcon } ${ localizedAttribute }"
+msgstr "**Attributo**: ${ attributeIcon } ${ localizedAttribute }"
 
 #: src\card.ts:495
 #, javascript-format
-msgid "**Rank**: ${ Icon.Rank } ${ card.rank } **ATK**: ${ card.atk } **DEF**: ${ card.def }"
-msgstr "**Rango**: ${ Icon.Rank } ${ card.rank } **ATK**: ${ card.atk } **DEF**: ${ card.def }"
+msgid "**Rank**: ${ rankIcon } ${ card.rank } **ATK**: ${ card.atk } **DEF**: ${ card.def }"
+msgstr "**Rango**: ${ rankIcon } ${ card.rank } **ATK**: ${ card.atk } **DEF**: ${ card.def }"
 
 #: src\card.ts:498
 #, javascript-format
@@ -46,8 +46,8 @@ msgstr ""
 #: src\card.ts:500
 #: src\rush-duel.ts:96
 #, javascript-format
-msgid "**Level**: ${ Icon.Level } ${ card.level } **ATK**: ${ card.atk } **DEF**: ${ card.def }"
-msgstr "**Livello**: ${ Icon.Level } ${ card.level } **ATK**: ${ card.atk } **DEF**: ${ card.def }"
+msgid "**Level**: ${ levelIcon } ${ card.level } **ATK**: ${ card.atk } **DEF**: ${ card.def }"
+msgstr "**Livello**: ${ levelIcon } ${ card.level } **ATK**: ${ card.atk } **DEF**: ${ card.def }"
 
 #: src\card.ts:507
 #, javascript-format
@@ -459,7 +459,7 @@ msgstr ""
 
 #: src\card.ts:462
 #, javascript-format
-msgid "**Master Duel rarity**: ${ rarity_icon } ${ localized_rarity }"
+msgid "**Master Duel rarity**: ${ rarityIcon } ${ localizedRarity }"
 msgstr ""
 
 #: src\rush-duel.ts:205

--- a/translations/it.po
+++ b/translations/it.po
@@ -6,50 +6,50 @@ msgstr ""
 "MIME-Version: 1.0\n"
 "Content-Transfer-Encoding: 8bit\n"
 
-#: src\card.ts:416
-#: src\rush-duel.ts:39
+#: src\card.ts:412
+#: src\rush-duel.ts:48
 msgid "🔗 Links"
 msgstr ""
 
-#: src\card.ts:417
+#: src\card.ts:413
 #, javascript-format
 msgid "[Official Konami DB](${ official }) | [OCG Rulings](${ rulings }) | [Yugipedia](${ yugipedia }) | [YGOPRODECK](${ ygoprodeck })"
 msgstr ""
 
-#: src\card.ts:420
+#: src\card.ts:416
 #, javascript-format
 msgid "[Yugipedia](${ yugipedia }) | [YGOPRODECK](${ ygoprodeck })"
 msgstr ""
 
-#: src\card.ts:489
-#: src\rush-duel.ts:92
+#: src\card.ts:490
+#: src\rush-duel.ts:103
 #, javascript-format
 msgid "**Type**: ${ raceIcon } ${ localizedMonsterTypeLine }"
 msgstr "**Tipo**: ${ raceIcon } ${ localizedMonsterTypeLine }"
 
-#: src\card.ts:491
-#: src\rush-duel.ts:94
+#: src\card.ts:492
+#: src\rush-duel.ts:105
 #, javascript-format
 msgid "**Attribute**: ${ attributeIcon } ${ localizedAttribute }"
 msgstr "**Attributo**: ${ attributeIcon } ${ localizedAttribute }"
 
-#: src\card.ts:495
+#: src\card.ts:497
 #, javascript-format
 msgid "**Rank**: ${ rankIcon } ${ card.rank } **ATK**: ${ card.atk } **DEF**: ${ card.def }"
 msgstr "**Rango**: ${ rankIcon } ${ card.rank } **ATK**: ${ card.atk } **DEF**: ${ card.def }"
 
-#: src\card.ts:498
+#: src\card.ts:500
 #, javascript-format
 msgid "**Link Rating**: ${ card.link_arrows.length } **ATK**: ${ card.atk } **Link Arrows**: ${ arrows }"
 msgstr ""
 
-#: src\card.ts:500
-#: src\rush-duel.ts:96
+#: src\card.ts:503
+#: src\rush-duel.ts:107
 #, javascript-format
 msgid "**Level**: ${ levelIcon } ${ card.level } **ATK**: ${ card.atk } **DEF**: ${ card.def }"
 msgstr "**Livello**: ${ levelIcon } ${ card.level } **ATK**: ${ card.atk } **DEF**: ${ card.def }"
 
-#: src\card.ts:507
+#: src\card.ts:511
 #, javascript-format
 msgid "**Pendulum Scale**: ${ formattedScale }"
 msgstr "**Valore Pendulum**: ${ formattedScale }"
@@ -70,7 +70,7 @@ msgid "Password: ${ card.password } | Not yet released"
 msgstr ""
 
 #: src\card.ts:351
-#: src\rush-duel.ts:146
+#: src\rush-duel.ts:158
 msgid "Not yet released"
 msgstr ""
 
@@ -79,64 +79,64 @@ msgstr ""
 msgid "Placeholder ID: ${ card.fake_password }"
 msgstr ""
 
-#: src\utils.ts:41
+#: src\utils.ts:44
 msgid "🛠️ This command is in development."
 msgstr ""
 
-#: src\utils.ts:42
+#: src\utils.ts:45
 msgid "📨 Please send feedback to [our issue tracker](https://github.com/DawnbrandBots/bastion-bot) or the [support server](https://discord.gg/4aFuPyuE96)!"
 msgstr ""
 
-#: src\utils.ts:53
+#: src\utils.ts:56
 msgid "Please consider supporting us!"
 msgstr ""
 
-#: src\utils.ts:54
+#: src\utils.ts:57
 msgid "Help keep Bastion online!"
 msgstr ""
 
-#: src\utils.ts:55
+#: src\utils.ts:58
 msgid "Please help keep Bastion online!"
 msgstr ""
 
-#: src\utils.ts:56
+#: src\utils.ts:59
 msgid "Was Bastion helpful? Consider supporting us!"
 msgstr ""
 
-#: src\utils.ts:57
+#: src\utils.ts:60
 msgid "Was Bastion helpful? We need your support!"
 msgstr ""
 
-#: src\utils.ts:58
+#: src\utils.ts:61
 msgid "Did you find Bastion useful? Consider supporting us!"
 msgstr ""
 
-#: src\utils.ts:59
+#: src\utils.ts:62
 msgid "Did you find Bastion useful? Help keep it online!"
 msgstr ""
 
-#: src\utils.ts:60
+#: src\utils.ts:63
 msgid "Did you find Bastion useful? We need your support!"
 msgstr ""
 
-#: src\utils.ts:61
+#: src\utils.ts:64
 msgid "Enjoy Bastion? Help keep it online!"
 msgstr ""
 
-#: src\utils.ts:62
+#: src\utils.ts:65
 msgid "Enjoy Bastion? Consider supporting us!"
 msgstr ""
 
-#: src\utils.ts:63
+#: src\utils.ts:66
 msgid "Found what you were looking for? Consider supporting us!"
 msgstr ""
 
 #: src\commands\art.ts:63
-#: src\commands\price.ts:131
-#: src\commands\rush-duel.ts:172
-#: src\commands\rush-duel.ts:203
+#: src\commands\price.ts:132
+#: src\commands\rush-duel.ts:171
+#: src\commands\rush-duel.ts:202
 #: src\commands\search.ts:64
-#: src\events\message-search.ts:258
+#: src\events\message-search.ts:265
 #, javascript-format
 msgid "Could not find a card matching `${ input }`!"
 msgstr ""
@@ -147,51 +147,51 @@ msgstr ""
 msgid "Could not find art for `${ name }`!"
 msgstr ""
 
-#: src\commands\deck.ts:244
+#: src\commands\deck.ts:205
 #, javascript-format
 msgid "${ counts.Monster } Monster"
 msgid_plural "${ counts.Monster } Monsters"
 msgstr[0] ""
 msgstr[1] ""
 
-#: src\commands\deck.ts:247
+#: src\commands\deck.ts:208
 #, javascript-format
 msgid "${ counts.Spell } Spell"
 msgid_plural "${ counts.Spell } Spells"
 msgstr[0] ""
 msgstr[1] ""
 
-#: src\commands\deck.ts:250
+#: src\commands\deck.ts:211
 #, javascript-format
 msgid "${ counts.Trap } Trap"
 msgid_plural "${ counts.Trap } Traps"
 msgstr[0] ""
 msgstr[1] ""
 
-#: src\commands\deck.ts:278
+#: src\commands\deck.ts:239
 msgid "Your Deck"
 msgstr ""
 
-#: src\commands\deck.ts:283
+#: src\commands\deck.ts:244
 #, javascript-format
 msgid "Main Deck (${ deck.main.length } card — ${ countDetail })"
 msgid_plural "Main Deck (${ deck.main.length } cards — ${ countDetail })"
 msgstr[0] ""
 msgstr[1] ""
 
-#: src\commands\deck.ts:290
+#: src\commands\deck.ts:251
 msgid "Main Deck (continued)"
 msgstr ""
 
-#: src\commands\deck.ts:304
+#: src\commands\deck.ts:265
 msgid "Extra Deck (continued)"
 msgstr ""
 
-#: src\commands\deck.ts:318
+#: src\commands\deck.ts:279
 msgid "Side Deck (continued)"
 msgstr ""
 
-#: src\commands\deck.ts:407
+#: src\commands\deck.ts:347
 msgid "Error: Your deck is empty."
 msgstr ""
 
@@ -211,11 +211,7 @@ msgstr ""
 msgid "Discord Community locale for this server: ${ interaction.guildLocale }"
 msgstr ""
 
-#: src\commands\locale.ts:89
-#, javascript-format
-msgid "Locale override for this direct message: ${ override }"
-msgstr ""
-
+#: src\commands\locale-user.ts:76
 #: src\commands\locale.ts:92
 #, javascript-format
 msgid "Your Discord locale: ${ interaction.locale }"
@@ -253,24 +249,14 @@ msgstr ""
 msgid "Sorry, you must have the Manage Server permission to do this. If you think this is an error, contact your server admin or report a bug."
 msgstr ""
 
-#: src\commands\locale.ts:146
-#, javascript-format
-msgid "Locale for this direct message overridden with ${ locale }. Your Discord setting is ${ interaction.locale }."
-msgstr ""
-
-#: src\commands\locale.ts:150
-#, javascript-format
-msgid "Locale for this direct message reset to Discord default. Your Discord setting is ${ interaction.locale }."
-msgstr ""
-
-#: src\commands\ping.ts:36
-#: src\events\message-ping.ts:47
+#: src\commands\ping.ts:38
+#: src\events\message-ping.ts:45
 #, javascript-format
 msgid "Average WebSocket ping (new instance): ${ ping } ms"
 msgstr ""
 
-#: src\commands\ping.ts:40
-#: src\events\message-ping.ts:112
+#: src\commands\ping.ts:42
+#: src\events\message-ping.ts:110
 #, javascript-format
 msgid "Total latency: ${ latency } ms"
 msgstr ""
@@ -280,86 +266,69 @@ msgstr ""
 msgid "Could not find a Yugipedia page named `${ page }`."
 msgstr ""
 
-#: src\events\message-ping.ts:49
+#: src\events\message-ping.ts:47
 msgid "Free and open source _Yu-Gi-Oh!_ bot"
 msgstr ""
 
-#: src\events\message-ping.ts:72
+#: src\events\message-ping.ts:70
 #, javascript-format
 msgid "Revision: ${ process.env.BOT_REVISION }."
 msgstr ""
 
-#: src\commands\deck.ts:328
+#: src\commands\deck.ts:289
 msgid ".ydk files must have the .ydk extension!"
 msgstr ""
 
-#: src\commands\deck.ts:331
+#: src\commands\deck.ts:292
 msgid ".ydk files should not be larger than 1 KB!"
 msgstr ""
 
-#: src\commands\deck.ts:321
+#: src\commands\deck.ts:282
 msgid "ydke URL"
 msgstr ""
 
 #: src\card.ts:455
-#: src\rush-duel.ts:61
+#: src\rush-duel.ts:75
 #. Forbidden/Limited Lists or Limit Regulations in the OCG
 #, javascript-format
 msgid "**Limit**: ${ limitRegulationDisplay }"
 msgstr ""
 
-#: src\commands\price.ts:69
+#: src\commands\price.ts:70
 msgid "TCGPlayer"
 msgstr ""
 
-#: src\commands\price.ts:70
+#: src\commands\price.ts:71
 msgid "Cardmarket"
 msgstr ""
 
-#: src\commands\price.ts:147
+#: src\commands\price.ts:148
 msgid "No market price"
 msgstr ""
 
-#: src\commands\price.ts:155
+#: src\commands\price.ts:156
 #, javascript-format
 msgid "Prices for ${ card.name[resultLanguage] } - ${ vendorName }"
 msgstr ""
 
-#: src\commands\price.ts:169
+#: src\commands\price.ts:170
 #, javascript-format
 msgid "Could not find prices for `${ name }`!"
 msgstr ""
 
-#: src\commands\deck.ts:425
-#. prepare interaction button for FTP upload
+#: src\commands\deck.ts:363
 msgid "Upload to YGOPRODECK"
 msgstr ""
 
-#: src\commands\deck.ts:483
-#. disable original button
-#. prepare row to disable button on original message
-msgid "Upload Complete"
-msgstr ""
-
-#: src\commands\deck.ts:470
-msgid "Deck upload failed!"
-msgstr ""
-
-#: src\commands\deck.ts:491
-#. reply in affirmation
-#, javascript-format
-msgid "Deck successfully uploaded to <${ url }>!"
-msgstr ""
-
-#: src\events\message-search.ts:264
+#: src\events\message-search.ts:271
 msgid "💬 Translations missing?"
 msgstr ""
 
-#: src\events\message-search.ts:265
+#: src\events\message-search.ts:272
 msgid "Help translate Bastion at the links above."
 msgstr ""
 
-#: src\events\message-ping.ts:50
+#: src\events\message-ping.ts:48
 msgid ""
 "❓ Help documentation on [GitHub](https://github.com/DawnbrandBots/bastion-bot), or use `.commands` and `.help`.\n"
 "🟢 Licence: [GNU AGPL 3.0+](https://choosealicense.com/licenses/agpl-3.0/).\n"
@@ -375,38 +344,38 @@ msgid ""
 "💬 Translations missing? Help translate Bastion on [GitHub](https://github.com/DawnbrandBots/bastion-bot)."
 msgstr ""
 
-#: src\events\message-search.ts:256
-#: src\events\message-search.ts:294
+#: src\events\message-search.ts:263
+#: src\events\message-search.ts:302
 #, javascript-format
 msgid "Search type: ${ localisedType }"
 msgstr ""
 
-#: src\events\message-search.ts:236
+#: src\events\message-search.ts:242
 #, javascript-format
 msgid "Search language: **${ localisedInputLanguage }** (${ inputLanguage }). Check defaults with </locale get:${ id }> and configure with </locale set:${ id }>"
 msgstr ""
 
-#: src\events\message-ping.ts:95
+#: src\events\message-ping.ts:93
 msgid "⚠️ You pinged me, but I am missing permissions in the channel!"
 msgstr ""
 
-#: src\events\message-ping.ts:98
-#: src\events\message-search.ts:332
+#: src\events\message-ping.ts:96
+#: src\events\message-search.ts:340
 msgid "Please have a server administrator [fix this](https://github.com/DawnbrandBots/bastion-bot#discord-permissions)."
 msgstr ""
 
-#: src\events\message-search.ts:329
+#: src\events\message-search.ts:337
 msgid "⚠️ I am missing permissions in the channel!"
 msgstr ""
 
-#: src\commands\deck.ts:297
+#: src\commands\deck.ts:258
 #, javascript-format
 msgid "Extra Deck (${ deck.extra.length } card — ${ countDetail })"
 msgid_plural "Extra Deck (${ deck.extra.length } cards — ${ countDetail })"
 msgstr[0] ""
 msgstr[1] ""
 
-#: src\commands\deck.ts:311
+#: src\commands\deck.ts:272
 #, javascript-format
 msgid "Side Deck (${ deck.side.length } card — ${ countDetail })"
 msgid_plural "Side Deck (${ deck.side.length } cards — ${ countDetail })"
@@ -428,32 +397,31 @@ msgstr ""
 msgid "Something went wrong searching Yugipedia for `${ page }`."
 msgstr ""
 
-#: src\rush-duel.ts:40
+#: src\rush-duel.ts:49
 #, javascript-format
 msgid "[Official Konami DB](${ official }) | [Rulings (Japanese)](${ rulings }) | [Yugipedia](${ yugipedia }) | [RushCard](${ rushcard })"
 msgstr ""
 
-#: src\rush-duel.ts:43
+#: src\rush-duel.ts:52
 #, javascript-format
 msgid "[Yugipedia](${ yugipedia }) | [RushCard](${ rushcard })"
 msgstr ""
 
-#: src\rush-duel.ts:57
+#: src\rush-duel.ts:71
 msgid "__**LEGEND**__"
 msgstr ""
 
-#: src\rush-duel.ts:99
+#: src\rush-duel.ts:110
 #, javascript-format
 msgid "**MAXIMUM ATK**: ${ card.maximum_atk }"
 msgstr ""
 
-#: src\rush-duel.ts:146
+#: src\rush-duel.ts:158
 #, javascript-format
 msgid "Konami ID #${ card.konami_id }"
 msgstr ""
 
 #: src\art.ts:129
-#: src\commands\deck.ts:451
 msgid "Buttons can only be used by the user who called Bastion."
 msgstr ""
 
@@ -462,14 +430,32 @@ msgstr ""
 msgid "**Master Duel rarity**: ${ rarityIcon } ${ localizedRarity }"
 msgstr ""
 
-#: src\rush-duel.ts:205
+#: src\rush-duel.ts:217
 #, javascript-format
 msgid "Using ${ searchTrigger }, you can search for Rush Duel cards directly in messages without autocomplete"
 msgstr ""
 
-#: src\events\message-search.ts:296
+#: src\events\message-search.ts:304
 #, javascript-format
 msgid "Could not find a Rush Duel card matching `${ input }`!"
+msgstr ""
+
+#: src\commands\locale-user.ts:73
+#: src\commands\locale.ts:89
+#, javascript-format
+msgid "Locale override for your direct messages: ${ override }"
+msgstr ""
+
+#: src\commands\locale-user.ts:83
+#: src\commands\locale.ts:146
+#, javascript-format
+msgid "Locale for your direct messages overridden with ${ locale }. Your Discord setting is ${ interaction.locale }."
+msgstr ""
+
+#: src\commands\locale-user.ts:87
+#: src\commands\locale.ts:150
+#, javascript-format
+msgid "Locale for your direct messages reset to Discord default. Your Discord setting is ${ interaction.locale }."
 msgstr ""
 
 #: src\card.ts:40
@@ -836,65 +822,65 @@ msgctxt "master-duel-rarity"
 msgid "Ultra Rare (UR)"
 msgstr "Ultra Raro (UR)"
 
-#: src\card.ts:513
-#: src\card.ts:524
-#: src\rush-duel.ts:127
+#: src\card.ts:517
+#: src\card.ts:528
+#: src\rush-duel.ts:138
 msgctxt "card-embed"
 msgid "Card Text"
 msgstr "Testo carta"
 
-#: src\card.ts:518
+#: src\card.ts:522
 msgctxt "card-embed"
 msgid "Pendulum Effect"
 msgstr "Effetto Pendulum"
 
-#: src\card.ts:539
+#: src\card.ts:545
 msgctxt "card-embed"
 msgid "Card Effect"
 msgstr ""
 
-#: src\rush-duel.ts:118
-#: src\rush-duel.ts:139
+#: src\rush-duel.ts:129
+#: src\rush-duel.ts:151
 msgctxt "card-embed"
 msgid "[REQUIREMENT]"
 msgstr "[REQUISITO]"
 
-#: src\rush-duel.ts:119
-#: src\rush-duel.ts:140
+#: src\rush-duel.ts:130
+#: src\rush-duel.ts:152
 msgctxt "card-embed"
 msgid "[EFFECT]"
 msgstr "[EFFETTO]"
 
-#: src\rush-duel.ts:121
+#: src\rush-duel.ts:132
 msgctxt "card-embed"
 msgid "[CONTINUOUS EFFECT]"
 msgstr "[EFFETTO CONTINUO]"
 
-#: src\rush-duel.ts:123
+#: src\rush-duel.ts:134
 msgctxt "card-embed"
 msgid "[MULTI-CHOICE EFFECT]"
 msgstr ""
 
-#: src\locale.ts:71
+#: src\locale.ts:74
 msgctxt "command-option"
 msgid "result-language"
 msgstr ""
 
-#: src\locale.ts:131
+#: src\locale.ts:140
 msgctxt "command-option"
 msgid "input-language"
 msgstr ""
 
-#: src\commands\rush-duel.ts:68
-#: src\commands\rush-duel.ts:80
-#: src\locale.ts:147
-#: src\locale.ts:165
-#: src\locale.ts:181
+#: src\commands\rush-duel.ts:67
+#: src\commands\rush-duel.ts:79
+#: src\locale.ts:156
+#: src\locale.ts:174
+#: src\locale.ts:190
 msgctxt "command-option"
 msgid "input"
 msgstr ""
 
-#: src\commands\help.ts:52
+#: src\commands\help.ts:55
 msgctxt "command-option"
 msgid "command"
 msgstr ""
@@ -909,54 +895,56 @@ msgctxt "command-option"
 msgid "page"
 msgstr ""
 
-#: src\commands\deck.ts:126
+#: src\commands\deck.ts:87
 msgctxt "command-option"
 msgid "url"
 msgstr ""
 
-#: src\commands\deck.ts:132
+#: src\commands\deck.ts:93
 msgctxt "command-option"
 msgid "file"
 msgstr ""
 
-#: src\commands\deck.ts:138
-#: src\commands\deck.ts:144
+#: src\commands\deck.ts:99
+#: src\commands\deck.ts:105
 msgctxt "command-option"
 msgid "deck"
 msgstr ""
 
-#: src\commands\deck.ts:150
+#: src\commands\deck.ts:111
 msgctxt "command-option"
 msgid "public"
 msgstr ""
 
-#: src\commands\deck.ts:157
+#: src\commands\deck.ts:118
 msgctxt "command-option"
 msgid "stacked"
 msgstr ""
 
-#: src\locale.ts:142
+#: src\locale.ts:151
 msgctxt "command-option"
 msgid "name"
 msgstr ""
 
-#: src\locale.ts:160
+#: src\locale.ts:169
 msgctxt "command-option"
 msgid "password"
 msgstr ""
 
-#: src\commands\rush-duel.ts:73
-#: src\events\message-search.ts:293
-#: src\locale.ts:176
+#: src\commands\rush-duel.ts:72
+#: src\events\message-search.ts:301
+#: src\locale.ts:185
 msgctxt "command-option"
 msgid "konami-id"
 msgstr ""
 
+#: src\commands\locale-user.ts:36
 #: src\commands\locale.ts:30
 msgctxt "command-option"
 msgid "get"
 msgstr ""
 
+#: src\commands\locale-user.ts:41
 #: src\commands\locale.ts:35
 msgctxt "command-option"
 msgid "set"
@@ -967,47 +955,69 @@ msgctxt "command-option"
 msgid "scope"
 msgstr ""
 
+#: src\commands\locale-user.ts:46
 #: src\commands\locale.ts:48
 msgctxt "command-option"
 msgid "locale"
 msgstr ""
 
-#: src\commands\price.ts:94
+#: src\commands\price.ts:95
 msgctxt "command-option"
 msgid "vendor"
 msgstr ""
 
-#: src\commands\rush-duel.ts:63
+#: src\commands\rush-duel.ts:62
 msgctxt "command-option"
 msgid "search"
 msgstr ""
 
-#: src\commands\rush-duel.ts:85
+#: src\commands\rush-duel.ts:84
 msgctxt "command-option"
 msgid "random"
 msgstr ""
 
-#: src\commands\rush-duel.ts:90
+#: src\commands\rush-duel.ts:89
 msgctxt "command-option"
 msgid "art"
 msgstr ""
 
-#: src\commands\query.ts:36
+#: src\commands\query.ts:35
 msgctxt "command-option"
 msgid "lucene"
 msgstr ""
 
-#: src\locale.ts:74
+#: src\commands\metagame.ts:209
+msgctxt "command-option"
+msgid "strategies"
+msgstr ""
+
+#: src\commands\metagame.ts:234
+#: src\commands\metagame.ts:274
+msgctxt "command-option"
+msgid "format"
+msgstr ""
+
+#: src\commands\metagame.ts:240
+msgctxt "command-option"
+msgid "cards"
+msgstr ""
+
+#: src\commands\metagame.ts:310
+msgctxt "command-option"
+msgid "date-range"
+msgstr ""
+
+#: src\locale.ts:77
 msgctxt "command-option-description"
 msgid "The output language for the card embed, overriding other settings."
 msgstr ""
 
-#: src\locale.ts:132
+#: src\locale.ts:141
 msgctxt "command-option-description"
 msgid "The language to search in, defaulting to the result language."
 msgstr ""
 
-#: src\commands\help.ts:55
+#: src\commands\help.ts:58
 msgctxt "command-option-description"
 msgid "The name of a specific Slash Command."
 msgstr ""
@@ -1017,32 +1027,32 @@ msgctxt "command-option-description"
 msgid "The name of the Yugipedia page you want to search for."
 msgstr ""
 
-#: src\commands\deck.ts:129
+#: src\commands\deck.ts:90
 msgctxt "command-option-description"
 msgid "View a deck by entering a ydke:// URL."
 msgstr ""
 
-#: src\commands\deck.ts:135
+#: src\commands\deck.ts:96
 msgctxt "command-option-description"
 msgid "View a deck by uploading a .ydk file."
 msgstr ""
 
-#: src\commands\deck.ts:141
+#: src\commands\deck.ts:102
 msgctxt "command-option-description"
 msgid "The ydke:// URL of the deck you want to view."
 msgstr ""
 
-#: src\commands\deck.ts:147
+#: src\commands\deck.ts:108
 msgctxt "command-option-description"
 msgid "The .ydk file of the deck you want to view."
 msgstr ""
 
-#: src\commands\deck.ts:153
+#: src\commands\deck.ts:114
 msgctxt "command-option-description"
 msgid "Whether to display the deck details publicly in chat. This is false by default."
 msgstr ""
 
-#: src\commands\deck.ts:160
+#: src\commands\deck.ts:121
 msgctxt "command-option-description"
 msgid "Whether to display the deck sections as one stacked column. This is false (side-by-side) by default."
 msgstr ""
@@ -1052,8 +1062,8 @@ msgctxt "command-option-description"
 msgid "Display the art for the card with this name."
 msgstr ""
 
-#: src\commands\rush-duel.ts:69
-#: src\locale.ts:148
+#: src\commands\rush-duel.ts:68
+#: src\locale.ts:157
 msgctxt "command-option-description"
 msgid "Card name, fuzzy matching supported."
 msgstr ""
@@ -1063,7 +1073,7 @@ msgctxt "command-option-description"
 msgid "Display the art for the card with this password."
 msgstr ""
 
-#: src\locale.ts:167
+#: src\locale.ts:176
 msgctxt "command-option-description"
 msgid "Card password, the eight-digit number printed on the bottom left corner."
 msgstr ""
@@ -1073,8 +1083,8 @@ msgctxt "command-option-description"
 msgid "Display the art for the card with this official database ID."
 msgstr ""
 
-#: src\commands\rush-duel.ts:81
-#: src\locale.ts:182
+#: src\commands\rush-duel.ts:80
+#: src\locale.ts:191
 msgctxt "command-option-description"
 msgid "Konami's official card database identifier."
 msgstr ""
@@ -1114,22 +1124,22 @@ msgctxt "command-option-description"
 msgid "The new default language to use in this channel or server."
 msgstr ""
 
-#: src\commands\price.ts:98
+#: src\commands\price.ts:99
 msgctxt "command-option-description"
 msgid "Display the price for the card with this name."
 msgstr ""
 
-#: src\commands\price.ts:102
+#: src\commands\price.ts:103
 msgctxt "command-option-description"
 msgid "Display the price for the card with this password."
 msgstr ""
 
-#: src\commands\price.ts:105
+#: src\commands\price.ts:106
 msgctxt "command-option-description"
 msgid "Display the price for the card with this official database ID."
 msgstr ""
 
-#: src\commands\price.ts:95
+#: src\commands\price.ts:96
 msgctxt "command-option-description"
 msgid "The vendor to fetch the price data from."
 msgstr ""
@@ -1139,29 +1149,70 @@ msgctxt "command-option-description"
 msgid "The English name of the card you're looking for."
 msgstr ""
 
-#: src\commands\rush-duel.ts:64
+#: src\commands\rush-duel.ts:63
 msgctxt "command-option-description"
 msgid "Find all information for the Rush Duel card with this name."
 msgstr ""
 
-#: src\commands\rush-duel.ts:75
+#: src\commands\rush-duel.ts:74
 msgctxt "command-option-description"
 msgid "Find all information for the Rush Duel card with this official database ID."
 msgstr ""
 
-#: src\commands\rush-duel.ts:86
+#: src\commands\rush-duel.ts:85
 msgctxt "command-option-description"
 msgid "Get a random Rush Duel card."
 msgstr ""
 
-#: src\commands\rush-duel.ts:91
+#: src\commands\rush-duel.ts:90
 msgctxt "command-option-description"
 msgid "Display just the art for the Rush Duel card with this name."
 msgstr ""
 
-#: src\commands\query.ts:37
+#: src\commands\query.ts:36
 msgctxt "command-option-description"
 msgid "Lucene query on YAML Yugi"
+msgstr ""
+
+#: src\commands\locale-user.ts:37
+msgctxt "command-option-description"
+msgid "Check your user-installed Bastion's locale."
+msgstr ""
+
+#: src\commands\locale-user.ts:42
+msgctxt "command-option-description"
+msgid "Configure your user-installed Bastion's locale."
+msgstr ""
+
+#: src\commands\locale-user.ts:47
+msgctxt "command-option-description"
+msgid "The new default language to use for user-installed Bastion."
+msgstr ""
+
+#: src\commands\metagame.ts:212
+msgctxt "command-option-description"
+msgid "Show the top competitive strategies in tournaments and the Master Duel ranked ladder."
+msgstr ""
+
+#: src\commands\metagame.ts:214
+msgctxt "command-option-description"
+msgid "Show the top competitive strategies in tournaments."
+msgstr ""
+
+#: src\commands\metagame.ts:235
+#: src\commands\metagame.ts:275
+msgctxt "command-option-description"
+msgid "Game region."
+msgstr ""
+
+#: src\commands\metagame.ts:242
+msgctxt "command-option-description"
+msgid "Show the most popular cards in tournaments and the Master Duel ranked ladder."
+msgstr ""
+
+#: src\commands\metagame.ts:312
+msgctxt "command-option-description"
+msgid "Limit card usage statistics to this date range. Has no effect for Master Duel."
 msgstr ""
 
 #: src\commands\art.ts:36
@@ -1169,12 +1220,12 @@ msgctxt "command-name"
 msgid "art"
 msgstr ""
 
-#: src\commands\help.ts:49
+#: src\commands\help.ts:52
 msgctxt "command-name"
 msgid "help"
 msgstr ""
 
-#: src\commands\ping.ts:23
+#: src\commands\ping.ts:25
 msgctxt "command-name"
 msgid "ping"
 msgstr ""
@@ -1189,7 +1240,7 @@ msgctxt "command-name"
 msgid "yugipedia"
 msgstr ""
 
-#: src\commands\deck.ts:119
+#: src\commands\deck.ts:80
 msgctxt "command-name"
 msgid "deck"
 msgstr ""
@@ -1204,24 +1255,34 @@ msgctxt "command-name"
 msgid "locale"
 msgstr ""
 
-#: src\commands\random.ts:44
+#: src\commands\random.ts:43
 msgctxt "command-name"
 msgid "random"
 msgstr ""
 
-#: src\commands\price.ts:89
+#: src\commands\price.ts:90
 msgctxt "command-name"
 msgid "price"
 msgstr ""
 
-#: src\commands\rush-duel.ts:58
+#: src\commands\rush-duel.ts:57
 msgctxt "command-name"
 msgid "rush-duel"
 msgstr ""
 
-#: src\commands\query.ts:30
+#: src\commands\query.ts:29
 msgctxt "command-name"
 msgid "query"
+msgstr ""
+
+#: src\commands\locale-user.ts:31
+msgctxt "command-name"
+msgid "locale-user"
+msgstr ""
+
+#: src\commands\metagame.ts:204
+msgctxt "command-name"
+msgid "metagame"
 msgstr ""
 
 #: src\commands\art.ts:37
@@ -1229,12 +1290,12 @@ msgctxt "command-description"
 msgid "Display the art for a card!"
 msgstr ""
 
-#: src\commands\help.ts:50
+#: src\commands\help.ts:53
 msgctxt "command-description"
 msgid "Get help with a Slash Command."
 msgstr ""
 
-#: src\commands\ping.ts:24
+#: src\commands\ping.ts:26
 msgctxt "command-description"
 msgid "Test latency to the new bot instance."
 msgstr ""
@@ -1249,7 +1310,7 @@ msgctxt "command-description"
 msgid "Search the Yugipedia wiki for a page and link to it."
 msgstr ""
 
-#: src\commands\deck.ts:122
+#: src\commands\deck.ts:83
 msgctxt "command-description"
 msgid "Display a deck list from ydke:// or .ydk format, exported from a number of deck building programs."
 msgstr ""
@@ -1264,24 +1325,34 @@ msgctxt "command-description"
 msgid "Check or set Bastion's locale for this channel or server."
 msgstr ""
 
-#: src\commands\random.ts:45
+#: src\commands\random.ts:44
 msgctxt "command-description"
 msgid "Get a random Yu-Gi-Oh! card."
 msgstr ""
 
-#: src\commands\price.ts:90
+#: src\commands\price.ts:91
 msgctxt "command-description"
 msgid "Display the price for a card!"
 msgstr ""
 
-#: src\commands\rush-duel.ts:59
+#: src\commands\rush-duel.ts:58
 msgctxt "command-description"
 msgid "Find information on Rush Duel cards."
 msgstr ""
 
-#: src\commands\query.ts:31
+#: src\commands\query.ts:30
 msgctxt "command-description"
 msgid "Advanced search prototype"
+msgstr ""
+
+#: src\commands\locale-user.ts:32
+msgctxt "command-description"
+msgid "Check or set user-installed Bastion's locale."
+msgstr ""
+
+#: src\commands\metagame.ts:205
+msgctxt "command-description"
+msgid "Show statistics on the current competitive state of play."
 msgstr ""
 
 #: src\commands\locale.ts:43
@@ -1294,7 +1365,71 @@ msgctxt "command-option-choice"
 msgid "server"
 msgstr ""
 
+#: src\commands\locale-user.ts:49
 #: src\commands\locale.ts:51
 msgctxt "command-option-choice"
 msgid "Discord default"
+msgstr ""
+
+#: src\commands\metagame.ts:219
+#: src\commands\metagame.ts:251
+msgctxt "command-option-choice"
+msgid "TCG"
+msgstr ""
+
+#: src\commands\metagame.ts:220
+#: src\commands\metagame.ts:255
+msgctxt "command-option-choice"
+msgid "OCG"
+msgstr ""
+
+#: src\commands\metagame.ts:221
+#: src\commands\metagame.ts:259
+msgctxt "command-option-choice"
+msgid "OCG (Asian-English)"
+msgstr ""
+
+#: src\commands\metagame.ts:228
+msgctxt "command-option-choice"
+msgid "Master Duel Diamond+ tier list"
+msgstr ""
+
+#: src\commands\metagame.ts:261
+msgctxt "command-option-choice"
+msgid "Master Duel ranked ladder"
+msgstr ""
+
+#: src\commands\metagame.ts:283
+msgctxt "command-option-choice"
+msgid "Current format"
+msgstr ""
+
+#: src\commands\metagame.ts:287
+msgctxt "command-option-choice"
+msgid "Since last Forbidden/Limited List"
+msgstr ""
+
+#: src\commands\metagame.ts:291
+msgctxt "command-option-choice"
+msgid "Last 7 days"
+msgstr ""
+
+#: src\commands\metagame.ts:295
+msgctxt "command-option-choice"
+msgid "Last 14 days"
+msgstr ""
+
+#: src\commands\metagame.ts:299
+msgctxt "command-option-choice"
+msgid "Last 30 days"
+msgstr ""
+
+#: src\commands\metagame.ts:303
+msgctxt "command-option-choice"
+msgid "Last three months"
+msgstr ""
+
+#: src\commands\metagame.ts:307
+msgctxt "command-option-choice"
+msgid "Last six months"
 msgstr ""

--- a/translations/it.po
+++ b/translations/it.po
@@ -6,33 +6,50 @@ msgstr ""
 "MIME-Version: 1.0\n"
 "Content-Transfer-Encoding: 8bit\n"
 
-#: src\card.ts:412
-#: src\rush-duel.ts:48
+#: src\card.ts:416
+#: src\rush-duel.ts:39
 msgid "🔗 Links"
 msgstr ""
 
-#: src\card.ts:413
+#: src\card.ts:417
 #, javascript-format
 msgid "[Official Konami DB](${ official }) | [OCG Rulings](${ rulings }) | [Yugipedia](${ yugipedia }) | [YGOPRODECK](${ ygoprodeck })"
 msgstr ""
 
-#: src\card.ts:416
+#: src\card.ts:420
 #, javascript-format
 msgid "[Yugipedia](${ yugipedia }) | [YGOPRODECK](${ ygoprodeck })"
 msgstr ""
 
-#: src\card.ts:490
-#: src\rush-duel.ts:103
+#: src\card.ts:489
+#: src\rush-duel.ts:92
 #, javascript-format
 msgid "**Type**: ${ raceIcon } ${ localizedMonsterTypeLine }"
 msgstr "**Tipo**: ${ raceIcon } ${ localizedMonsterTypeLine }"
 
-#: src\card.ts:500
+#: src\card.ts:491
+#: src\rush-duel.ts:94
+#, javascript-format
+msgid "**Attribute**: ${ AttributeIcon[card.attribute] } ${ localizedAttribute }"
+msgstr "**Attributo**: ${ AttributeIcon[card.attribute] } ${ localizedAttribute }"
+
+#: src\card.ts:495
+#, javascript-format
+msgid "**Rank**: ${ Icon.Rank } ${ card.rank } **ATK**: ${ card.atk } **DEF**: ${ card.def }"
+msgstr "**Rango**: ${ Icon.Rank } ${ card.rank } **ATK**: ${ card.atk } **DEF**: ${ card.def }"
+
+#: src\card.ts:498
 #, javascript-format
 msgid "**Link Rating**: ${ card.link_arrows.length } **ATK**: ${ card.atk } **Link Arrows**: ${ arrows }"
 msgstr ""
 
-#: src\card.ts:511
+#: src\card.ts:500
+#: src\rush-duel.ts:96
+#, javascript-format
+msgid "**Level**: ${ Icon.Level } ${ card.level } **ATK**: ${ card.atk } **DEF**: ${ card.def }"
+msgstr "**Livello**: ${ Icon.Level } ${ card.level } **ATK**: ${ card.atk } **DEF**: ${ card.def }"
+
+#: src\card.ts:507
 #, javascript-format
 msgid "**Pendulum Scale**: ${ formattedScale }"
 msgstr "**Valore Pendulum**: ${ formattedScale }"
@@ -53,7 +70,7 @@ msgid "Password: ${ card.password } | Not yet released"
 msgstr ""
 
 #: src\card.ts:351
-#: src\rush-duel.ts:158
+#: src\rush-duel.ts:146
 msgid "Not yet released"
 msgstr ""
 
@@ -62,64 +79,64 @@ msgstr ""
 msgid "Placeholder ID: ${ card.fake_password }"
 msgstr ""
 
-#: src\utils.ts:44
+#: src\utils.ts:41
 msgid "🛠️ This command is in development."
 msgstr ""
 
-#: src\utils.ts:45
+#: src\utils.ts:42
 msgid "📨 Please send feedback to [our issue tracker](https://github.com/DawnbrandBots/bastion-bot) or the [support server](https://discord.gg/4aFuPyuE96)!"
 msgstr ""
 
-#: src\utils.ts:56
+#: src\utils.ts:53
 msgid "Please consider supporting us!"
 msgstr ""
 
-#: src\utils.ts:57
+#: src\utils.ts:54
 msgid "Help keep Bastion online!"
 msgstr ""
 
-#: src\utils.ts:58
+#: src\utils.ts:55
 msgid "Please help keep Bastion online!"
 msgstr ""
 
-#: src\utils.ts:59
+#: src\utils.ts:56
 msgid "Was Bastion helpful? Consider supporting us!"
 msgstr ""
 
-#: src\utils.ts:60
+#: src\utils.ts:57
 msgid "Was Bastion helpful? We need your support!"
 msgstr ""
 
-#: src\utils.ts:61
+#: src\utils.ts:58
 msgid "Did you find Bastion useful? Consider supporting us!"
 msgstr ""
 
-#: src\utils.ts:62
+#: src\utils.ts:59
 msgid "Did you find Bastion useful? Help keep it online!"
 msgstr ""
 
-#: src\utils.ts:63
+#: src\utils.ts:60
 msgid "Did you find Bastion useful? We need your support!"
 msgstr ""
 
-#: src\utils.ts:64
+#: src\utils.ts:61
 msgid "Enjoy Bastion? Help keep it online!"
 msgstr ""
 
-#: src\utils.ts:65
+#: src\utils.ts:62
 msgid "Enjoy Bastion? Consider supporting us!"
 msgstr ""
 
-#: src\utils.ts:66
+#: src\utils.ts:63
 msgid "Found what you were looking for? Consider supporting us!"
 msgstr ""
 
 #: src\commands\art.ts:63
-#: src\commands\price.ts:132
-#: src\commands\rush-duel.ts:171
-#: src\commands\rush-duel.ts:202
+#: src\commands\price.ts:131
+#: src\commands\rush-duel.ts:172
+#: src\commands\rush-duel.ts:203
 #: src\commands\search.ts:64
-#: src\events\message-search.ts:265
+#: src\events\message-search.ts:258
 #, javascript-format
 msgid "Could not find a card matching `${ input }`!"
 msgstr ""
@@ -130,51 +147,51 @@ msgstr ""
 msgid "Could not find art for `${ name }`!"
 msgstr ""
 
-#: src\commands\deck.ts:205
+#: src\commands\deck.ts:244
 #, javascript-format
 msgid "${ counts.Monster } Monster"
 msgid_plural "${ counts.Monster } Monsters"
 msgstr[0] ""
 msgstr[1] ""
 
-#: src\commands\deck.ts:208
+#: src\commands\deck.ts:247
 #, javascript-format
 msgid "${ counts.Spell } Spell"
 msgid_plural "${ counts.Spell } Spells"
 msgstr[0] ""
 msgstr[1] ""
 
-#: src\commands\deck.ts:211
+#: src\commands\deck.ts:250
 #, javascript-format
 msgid "${ counts.Trap } Trap"
 msgid_plural "${ counts.Trap } Traps"
 msgstr[0] ""
 msgstr[1] ""
 
-#: src\commands\deck.ts:239
+#: src\commands\deck.ts:278
 msgid "Your Deck"
 msgstr ""
 
-#: src\commands\deck.ts:244
+#: src\commands\deck.ts:283
 #, javascript-format
 msgid "Main Deck (${ deck.main.length } card — ${ countDetail })"
 msgid_plural "Main Deck (${ deck.main.length } cards — ${ countDetail })"
 msgstr[0] ""
 msgstr[1] ""
 
-#: src\commands\deck.ts:251
+#: src\commands\deck.ts:290
 msgid "Main Deck (continued)"
 msgstr ""
 
-#: src\commands\deck.ts:265
+#: src\commands\deck.ts:304
 msgid "Extra Deck (continued)"
 msgstr ""
 
-#: src\commands\deck.ts:279
+#: src\commands\deck.ts:318
 msgid "Side Deck (continued)"
 msgstr ""
 
-#: src\commands\deck.ts:347
+#: src\commands\deck.ts:407
 msgid "Error: Your deck is empty."
 msgstr ""
 
@@ -194,7 +211,11 @@ msgstr ""
 msgid "Discord Community locale for this server: ${ interaction.guildLocale }"
 msgstr ""
 
-#: src\commands\locale-user.ts:76
+#: src\commands\locale.ts:89
+#, javascript-format
+msgid "Locale override for this direct message: ${ override }"
+msgstr ""
+
 #: src\commands\locale.ts:92
 #, javascript-format
 msgid "Your Discord locale: ${ interaction.locale }"
@@ -232,14 +253,24 @@ msgstr ""
 msgid "Sorry, you must have the Manage Server permission to do this. If you think this is an error, contact your server admin or report a bug."
 msgstr ""
 
-#: src\commands\ping.ts:38
-#: src\events\message-ping.ts:45
+#: src\commands\locale.ts:146
+#, javascript-format
+msgid "Locale for this direct message overridden with ${ locale }. Your Discord setting is ${ interaction.locale }."
+msgstr ""
+
+#: src\commands\locale.ts:150
+#, javascript-format
+msgid "Locale for this direct message reset to Discord default. Your Discord setting is ${ interaction.locale }."
+msgstr ""
+
+#: src\commands\ping.ts:36
+#: src\events\message-ping.ts:47
 #, javascript-format
 msgid "Average WebSocket ping (new instance): ${ ping } ms"
 msgstr ""
 
-#: src\commands\ping.ts:42
-#: src\events\message-ping.ts:110
+#: src\commands\ping.ts:40
+#: src\events\message-ping.ts:112
 #, javascript-format
 msgid "Total latency: ${ latency } ms"
 msgstr ""
@@ -249,69 +280,86 @@ msgstr ""
 msgid "Could not find a Yugipedia page named `${ page }`."
 msgstr ""
 
-#: src\events\message-ping.ts:47
+#: src\events\message-ping.ts:49
 msgid "Free and open source _Yu-Gi-Oh!_ bot"
 msgstr ""
 
-#: src\events\message-ping.ts:70
+#: src\events\message-ping.ts:72
 #, javascript-format
 msgid "Revision: ${ process.env.BOT_REVISION }."
 msgstr ""
 
-#: src\commands\deck.ts:289
+#: src\commands\deck.ts:328
 msgid ".ydk files must have the .ydk extension!"
 msgstr ""
 
-#: src\commands\deck.ts:292
+#: src\commands\deck.ts:331
 msgid ".ydk files should not be larger than 1 KB!"
 msgstr ""
 
-#: src\commands\deck.ts:282
+#: src\commands\deck.ts:321
 msgid "ydke URL"
 msgstr ""
 
 #: src\card.ts:455
-#: src\rush-duel.ts:75
+#: src\rush-duel.ts:61
 #. Forbidden/Limited Lists or Limit Regulations in the OCG
 #, javascript-format
 msgid "**Limit**: ${ limitRegulationDisplay }"
 msgstr ""
 
-#: src\commands\price.ts:70
+#: src\commands\price.ts:69
 msgid "TCGPlayer"
 msgstr ""
 
-#: src\commands\price.ts:71
+#: src\commands\price.ts:70
 msgid "Cardmarket"
 msgstr ""
 
-#: src\commands\price.ts:148
+#: src\commands\price.ts:147
 msgid "No market price"
 msgstr ""
 
-#: src\commands\price.ts:156
+#: src\commands\price.ts:155
 #, javascript-format
 msgid "Prices for ${ card.name[resultLanguage] } - ${ vendorName }"
 msgstr ""
 
-#: src\commands\price.ts:170
+#: src\commands\price.ts:169
 #, javascript-format
 msgid "Could not find prices for `${ name }`!"
 msgstr ""
 
-#: src\commands\deck.ts:363
+#: src\commands\deck.ts:425
+#. prepare interaction button for FTP upload
 msgid "Upload to YGOPRODECK"
 msgstr ""
 
-#: src\events\message-search.ts:271
+#: src\commands\deck.ts:483
+#. disable original button
+#. prepare row to disable button on original message
+msgid "Upload Complete"
+msgstr ""
+
+#: src\commands\deck.ts:470
+msgid "Deck upload failed!"
+msgstr ""
+
+#: src\commands\deck.ts:491
+#. reply in affirmation
+#, javascript-format
+msgid "Deck successfully uploaded to <${ url }>!"
+msgstr ""
+
+#: src\events\message-search.ts:264
 msgid "💬 Translations missing?"
 msgstr ""
 
-#: src\events\message-search.ts:272
+#: src\events\message-search.ts:265
 msgid "Help translate Bastion at the links above."
 msgstr ""
 
-#: src\events\message-ping.ts:48
+#: src\events\message-ping.ts:50
 msgid ""
 "❓ Help documentation on [GitHub](https://github.com/DawnbrandBots/bastion-bot), or use `.commands` and `.help`.\n"
 "🟢 Licence: [GNU AGPL 3.0+](https://choosealicense.com/licenses/agpl-3.0/).\n"
@@ -327,38 +375,38 @@ msgid ""
 "💬 Translations missing? Help translate Bastion on [GitHub](https://github.com/DawnbrandBots/bastion-bot)."
 msgstr ""
 
-#: src\events\message-search.ts:263
-#: src\events\message-search.ts:302
+#: src\events\message-search.ts:256
+#: src\events\message-search.ts:294
 #, javascript-format
 msgid "Search type: ${ localisedType }"
 msgstr ""
 
-#: src\events\message-search.ts:242
+#: src\events\message-search.ts:236
 #, javascript-format
 msgid "Search language: **${ localisedInputLanguage }** (${ inputLanguage }). Check defaults with </locale get:${ id }> and configure with </locale set:${ id }>"
 msgstr ""
 
-#: src\events\message-ping.ts:93
+#: src\events\message-ping.ts:95
 msgid "⚠️ You pinged me, but I am missing permissions in the channel!"
 msgstr ""
 
-#: src\events\message-ping.ts:96
-#: src\events\message-search.ts:340
+#: src\events\message-ping.ts:98
+#: src\events\message-search.ts:332
 msgid "Please have a server administrator [fix this](https://github.com/DawnbrandBots/bastion-bot#discord-permissions)."
 msgstr ""
 
-#: src\events\message-search.ts:337
+#: src\events\message-search.ts:329
 msgid "⚠️ I am missing permissions in the channel!"
 msgstr ""
 
-#: src\commands\deck.ts:258
+#: src\commands\deck.ts:297
 #, javascript-format
 msgid "Extra Deck (${ deck.extra.length } card — ${ countDetail })"
 msgid_plural "Extra Deck (${ deck.extra.length } cards — ${ countDetail })"
 msgstr[0] ""
 msgstr[1] ""
 
-#: src\commands\deck.ts:272
+#: src\commands\deck.ts:311
 #, javascript-format
 msgid "Side Deck (${ deck.side.length } card — ${ countDetail })"
 msgid_plural "Side Deck (${ deck.side.length } cards — ${ countDetail })"
@@ -380,82 +428,48 @@ msgstr ""
 msgid "Something went wrong searching Yugipedia for `${ page }`."
 msgstr ""
 
-#: src\rush-duel.ts:49
+#: src\rush-duel.ts:40
 #, javascript-format
 msgid "[Official Konami DB](${ official }) | [Rulings (Japanese)](${ rulings }) | [Yugipedia](${ yugipedia }) | [RushCard](${ rushcard })"
 msgstr ""
 
-#: src\rush-duel.ts:52
+#: src\rush-duel.ts:43
 #, javascript-format
 msgid "[Yugipedia](${ yugipedia }) | [RushCard](${ rushcard })"
 msgstr ""
 
-#: src\rush-duel.ts:71
+#: src\rush-duel.ts:57
 msgid "__**LEGEND**__"
 msgstr ""
 
-#: src\rush-duel.ts:110
+#: src\rush-duel.ts:99
 #, javascript-format
 msgid "**MAXIMUM ATK**: ${ card.maximum_atk }"
 msgstr ""
 
-#: src\rush-duel.ts:158
+#: src\rush-duel.ts:146
 #, javascript-format
 msgid "Konami ID #${ card.konami_id }"
 msgstr ""
 
 #: src\art.ts:129
+#: src\commands\deck.ts:451
 msgid "Buttons can only be used by the user who called Bastion."
-msgstr ""
-
-#: src\rush-duel.ts:217
-#, javascript-format
-msgid "Using ${ searchTrigger }, you can search for Rush Duel cards directly in messages without autocomplete"
-msgstr ""
-
-#: src\events\message-search.ts:304
-#, javascript-format
-msgid "Could not find a Rush Duel card matching `${ input }`!"
 msgstr ""
 
 #: src\card.ts:462
 #, javascript-format
-msgid "**Master Duel rarity**: ${ rarityIcon } ${ localizedRarity }"
+msgid "**Master Duel rarity**: ${ rarity_icon } ${ localized_rarity }"
 msgstr ""
 
-#: src\card.ts:492
-#: src\rush-duel.ts:105
+#: src\rush-duel.ts:205
 #, javascript-format
-msgid "**Attribute**: ${ attributeIcon } ${ localizedAttribute }"
+msgid "Using ${ searchTrigger }, you can search for Rush Duel cards directly in messages without autocomplete"
 msgstr ""
 
-#: src\card.ts:497
+#: src\events\message-search.ts:296
 #, javascript-format
-msgid "**Rank**: ${ rankIcon } ${ card.rank } **ATK**: ${ card.atk } **DEF**: ${ card.def }"
-msgstr ""
-
-#: src\card.ts:503
-#: src\rush-duel.ts:107
-#, javascript-format
-msgid "**Level**: ${ levelIcon } ${ card.level } **ATK**: ${ card.atk } **DEF**: ${ card.def }"
-msgstr ""
-
-#: src\commands\locale-user.ts:73
-#: src\commands\locale.ts:89
-#, javascript-format
-msgid "Locale override for your direct messages: ${ override }"
-msgstr ""
-
-#: src\commands\locale-user.ts:83
-#: src\commands\locale.ts:146
-#, javascript-format
-msgid "Locale for your direct messages overridden with ${ locale }. Your Discord setting is ${ interaction.locale }."
-msgstr ""
-
-#: src\commands\locale-user.ts:87
-#: src\commands\locale.ts:150
-#, javascript-format
-msgid "Locale for your direct messages reset to Discord default. Your Discord setting is ${ interaction.locale }."
+msgid "Could not find a Rush Duel card matching `${ input }`!"
 msgstr ""
 
 #: src\card.ts:40
@@ -822,65 +836,65 @@ msgctxt "master-duel-rarity"
 msgid "Ultra Rare (UR)"
 msgstr "Ultra Raro (UR)"
 
-#: src\card.ts:517
-#: src\card.ts:528
-#: src\rush-duel.ts:138
+#: src\card.ts:513
+#: src\card.ts:524
+#: src\rush-duel.ts:127
 msgctxt "card-embed"
 msgid "Card Text"
 msgstr "Testo carta"
 
-#: src\card.ts:522
+#: src\card.ts:518
 msgctxt "card-embed"
 msgid "Pendulum Effect"
 msgstr "Effetto Pendulum"
 
-#: src\card.ts:545
+#: src\card.ts:539
 msgctxt "card-embed"
 msgid "Card Effect"
 msgstr ""
 
-#: src\rush-duel.ts:129
-#: src\rush-duel.ts:151
+#: src\rush-duel.ts:118
+#: src\rush-duel.ts:139
 msgctxt "card-embed"
 msgid "[REQUIREMENT]"
 msgstr "[REQUISITO]"
 
-#: src\rush-duel.ts:130
-#: src\rush-duel.ts:152
+#: src\rush-duel.ts:119
+#: src\rush-duel.ts:140
 msgctxt "card-embed"
 msgid "[EFFECT]"
 msgstr "[EFFETTO]"
 
-#: src\rush-duel.ts:132
+#: src\rush-duel.ts:121
 msgctxt "card-embed"
 msgid "[CONTINUOUS EFFECT]"
 msgstr "[EFFETTO CONTINUO]"
 
-#: src\rush-duel.ts:134
+#: src\rush-duel.ts:123
 msgctxt "card-embed"
 msgid "[MULTI-CHOICE EFFECT]"
 msgstr ""
 
-#: src\locale.ts:74
+#: src\locale.ts:71
 msgctxt "command-option"
 msgid "result-language"
 msgstr ""
 
-#: src\locale.ts:140
+#: src\locale.ts:131
 msgctxt "command-option"
 msgid "input-language"
 msgstr ""
 
-#: src\commands\rush-duel.ts:67
-#: src\commands\rush-duel.ts:79
-#: src\locale.ts:156
-#: src\locale.ts:174
-#: src\locale.ts:190
+#: src\commands\rush-duel.ts:68
+#: src\commands\rush-duel.ts:80
+#: src\locale.ts:147
+#: src\locale.ts:165
+#: src\locale.ts:181
 msgctxt "command-option"
 msgid "input"
 msgstr ""
 
-#: src\commands\help.ts:55
+#: src\commands\help.ts:52
 msgctxt "command-option"
 msgid "command"
 msgstr ""
@@ -895,56 +909,54 @@ msgctxt "command-option"
 msgid "page"
 msgstr ""
 
-#: src\commands\deck.ts:87
+#: src\commands\deck.ts:126
 msgctxt "command-option"
 msgid "url"
 msgstr ""
 
-#: src\commands\deck.ts:93
+#: src\commands\deck.ts:132
 msgctxt "command-option"
 msgid "file"
 msgstr ""
 
-#: src\commands\deck.ts:99
-#: src\commands\deck.ts:105
+#: src\commands\deck.ts:138
+#: src\commands\deck.ts:144
 msgctxt "command-option"
 msgid "deck"
 msgstr ""
 
-#: src\commands\deck.ts:111
+#: src\commands\deck.ts:150
 msgctxt "command-option"
 msgid "public"
 msgstr ""
 
-#: src\commands\deck.ts:118
+#: src\commands\deck.ts:157
 msgctxt "command-option"
 msgid "stacked"
 msgstr ""
 
-#: src\locale.ts:151
+#: src\locale.ts:142
 msgctxt "command-option"
 msgid "name"
 msgstr ""
 
-#: src\locale.ts:169
+#: src\locale.ts:160
 msgctxt "command-option"
 msgid "password"
 msgstr ""
 
-#: src\commands\rush-duel.ts:72
-#: src\events\message-search.ts:301
-#: src\locale.ts:185
+#: src\commands\rush-duel.ts:73
+#: src\events\message-search.ts:293
+#: src\locale.ts:176
 msgctxt "command-option"
 msgid "konami-id"
 msgstr ""
 
-#: src\commands\locale-user.ts:36
 #: src\commands\locale.ts:30
 msgctxt "command-option"
 msgid "get"
 msgstr ""
 
-#: src\commands\locale-user.ts:41
 #: src\commands\locale.ts:35
 msgctxt "command-option"
 msgid "set"
@@ -955,69 +967,47 @@ msgctxt "command-option"
 msgid "scope"
 msgstr ""
 
-#: src\commands\locale-user.ts:46
 #: src\commands\locale.ts:48
 msgctxt "command-option"
 msgid "locale"
 msgstr ""
 
-#: src\commands\price.ts:95
+#: src\commands\price.ts:94
 msgctxt "command-option"
 msgid "vendor"
 msgstr ""
 
-#: src\commands\rush-duel.ts:62
+#: src\commands\rush-duel.ts:63
 msgctxt "command-option"
 msgid "search"
 msgstr ""
 
-#: src\commands\rush-duel.ts:84
+#: src\commands\rush-duel.ts:85
 msgctxt "command-option"
 msgid "random"
 msgstr ""
 
-#: src\commands\rush-duel.ts:89
+#: src\commands\rush-duel.ts:90
 msgctxt "command-option"
 msgid "art"
 msgstr ""
 
-#: src\commands\query.ts:35
+#: src\commands\query.ts:36
 msgctxt "command-option"
 msgid "lucene"
 msgstr ""
 
-#: src\commands\metagame.ts:209
-msgctxt "command-option"
-msgid "strategies"
-msgstr ""
-
-#: src\commands\metagame.ts:234
-#: src\commands\metagame.ts:274
-msgctxt "command-option"
-msgid "format"
-msgstr ""
-
-#: src\commands\metagame.ts:240
-msgctxt "command-option"
-msgid "cards"
-msgstr ""
-
-#: src\commands\metagame.ts:310
-msgctxt "command-option"
-msgid "date-range"
-msgstr ""
-
-#: src\locale.ts:77
+#: src\locale.ts:74
 msgctxt "command-option-description"
 msgid "The output language for the card embed, overriding other settings."
 msgstr ""
 
-#: src\locale.ts:141
+#: src\locale.ts:132
 msgctxt "command-option-description"
 msgid "The language to search in, defaulting to the result language."
 msgstr ""
 
-#: src\commands\help.ts:58
+#: src\commands\help.ts:55
 msgctxt "command-option-description"
 msgid "The name of a specific Slash Command."
 msgstr ""
@@ -1027,32 +1017,32 @@ msgctxt "command-option-description"
 msgid "The name of the Yugipedia page you want to search for."
 msgstr ""
 
-#: src\commands\deck.ts:90
+#: src\commands\deck.ts:129
 msgctxt "command-option-description"
 msgid "View a deck by entering a ydke:// URL."
 msgstr ""
 
-#: src\commands\deck.ts:96
+#: src\commands\deck.ts:135
 msgctxt "command-option-description"
 msgid "View a deck by uploading a .ydk file."
 msgstr ""
 
-#: src\commands\deck.ts:102
+#: src\commands\deck.ts:141
 msgctxt "command-option-description"
 msgid "The ydke:// URL of the deck you want to view."
 msgstr ""
 
-#: src\commands\deck.ts:108
+#: src\commands\deck.ts:147
 msgctxt "command-option-description"
 msgid "The .ydk file of the deck you want to view."
 msgstr ""
 
-#: src\commands\deck.ts:114
+#: src\commands\deck.ts:153
 msgctxt "command-option-description"
 msgid "Whether to display the deck details publicly in chat. This is false by default."
 msgstr ""
 
-#: src\commands\deck.ts:121
+#: src\commands\deck.ts:160
 msgctxt "command-option-description"
 msgid "Whether to display the deck sections as one stacked column. This is false (side-by-side) by default."
 msgstr ""
@@ -1062,8 +1052,8 @@ msgctxt "command-option-description"
 msgid "Display the art for the card with this name."
 msgstr ""
 
-#: src\commands\rush-duel.ts:68
-#: src\locale.ts:157
+#: src\commands\rush-duel.ts:69
+#: src\locale.ts:148
 msgctxt "command-option-description"
 msgid "Card name, fuzzy matching supported."
 msgstr ""
@@ -1073,7 +1063,7 @@ msgctxt "command-option-description"
 msgid "Display the art for the card with this password."
 msgstr ""
 
-#: src\locale.ts:176
+#: src\locale.ts:167
 msgctxt "command-option-description"
 msgid "Card password, the eight-digit number printed on the bottom left corner."
 msgstr ""
@@ -1083,8 +1073,8 @@ msgctxt "command-option-description"
 msgid "Display the art for the card with this official database ID."
 msgstr ""
 
-#: src\commands\rush-duel.ts:80
-#: src\locale.ts:191
+#: src\commands\rush-duel.ts:81
+#: src\locale.ts:182
 msgctxt "command-option-description"
 msgid "Konami's official card database identifier."
 msgstr ""
@@ -1124,22 +1114,22 @@ msgctxt "command-option-description"
 msgid "The new default language to use in this channel or server."
 msgstr ""
 
-#: src\commands\price.ts:99
+#: src\commands\price.ts:98
 msgctxt "command-option-description"
 msgid "Display the price for the card with this name."
 msgstr ""
 
-#: src\commands\price.ts:103
+#: src\commands\price.ts:102
 msgctxt "command-option-description"
 msgid "Display the price for the card with this password."
 msgstr ""
 
-#: src\commands\price.ts:106
+#: src\commands\price.ts:105
 msgctxt "command-option-description"
 msgid "Display the price for the card with this official database ID."
 msgstr ""
 
-#: src\commands\price.ts:96
+#: src\commands\price.ts:95
 msgctxt "command-option-description"
 msgid "The vendor to fetch the price data from."
 msgstr ""
@@ -1149,70 +1139,29 @@ msgctxt "command-option-description"
 msgid "The English name of the card you're looking for."
 msgstr ""
 
-#: src\commands\rush-duel.ts:63
+#: src\commands\rush-duel.ts:64
 msgctxt "command-option-description"
 msgid "Find all information for the Rush Duel card with this name."
 msgstr ""
 
-#: src\commands\rush-duel.ts:74
+#: src\commands\rush-duel.ts:75
 msgctxt "command-option-description"
 msgid "Find all information for the Rush Duel card with this official database ID."
 msgstr ""
 
-#: src\commands\rush-duel.ts:85
+#: src\commands\rush-duel.ts:86
 msgctxt "command-option-description"
 msgid "Get a random Rush Duel card."
 msgstr ""
 
-#: src\commands\rush-duel.ts:90
+#: src\commands\rush-duel.ts:91
 msgctxt "command-option-description"
 msgid "Display just the art for the Rush Duel card with this name."
 msgstr ""
 
-#: src\commands\query.ts:36
+#: src\commands\query.ts:37
 msgctxt "command-option-description"
 msgid "Lucene query on YAML Yugi"
-msgstr ""
-
-#: src\commands\locale-user.ts:37
-msgctxt "command-option-description"
-msgid "Check your user-installed Bastion's locale."
-msgstr ""
-
-#: src\commands\locale-user.ts:42
-msgctxt "command-option-description"
-msgid "Configure your user-installed Bastion's locale."
-msgstr ""
-
-#: src\commands\locale-user.ts:47
-msgctxt "command-option-description"
-msgid "The new default language to use for user-installed Bastion."
-msgstr ""
-
-#: src\commands\metagame.ts:212
-msgctxt "command-option-description"
-msgid "Show the top competitive strategies in tournaments and the Master Duel ranked ladder."
-msgstr ""
-
-#: src\commands\metagame.ts:214
-msgctxt "command-option-description"
-msgid "Show the top competitive strategies in tournaments."
-msgstr ""
-
-#: src\commands\metagame.ts:235
-#: src\commands\metagame.ts:275
-msgctxt "command-option-description"
-msgid "Game region."
-msgstr ""
-
-#: src\commands\metagame.ts:242
-msgctxt "command-option-description"
-msgid "Show the most popular cards in tournaments and the Master Duel ranked ladder."
-msgstr ""
-
-#: src\commands\metagame.ts:312
-msgctxt "command-option-description"
-msgid "Limit card usage statistics to this date range. Has no effect for Master Duel."
 msgstr ""
 
 #: src\commands\art.ts:36
@@ -1220,12 +1169,12 @@ msgctxt "command-name"
 msgid "art"
 msgstr ""
 
-#: src\commands\help.ts:52
+#: src\commands\help.ts:49
 msgctxt "command-name"
 msgid "help"
 msgstr ""
 
-#: src\commands\ping.ts:25
+#: src\commands\ping.ts:23
 msgctxt "command-name"
 msgid "ping"
 msgstr ""
@@ -1240,7 +1189,7 @@ msgctxt "command-name"
 msgid "yugipedia"
 msgstr ""
 
-#: src\commands\deck.ts:80
+#: src\commands\deck.ts:119
 msgctxt "command-name"
 msgid "deck"
 msgstr ""
@@ -1255,34 +1204,24 @@ msgctxt "command-name"
 msgid "locale"
 msgstr ""
 
-#: src\commands\random.ts:43
+#: src\commands\random.ts:44
 msgctxt "command-name"
 msgid "random"
 msgstr ""
 
-#: src\commands\price.ts:90
+#: src\commands\price.ts:89
 msgctxt "command-name"
 msgid "price"
 msgstr ""
 
-#: src\commands\rush-duel.ts:57
+#: src\commands\rush-duel.ts:58
 msgctxt "command-name"
 msgid "rush-duel"
 msgstr ""
 
-#: src\commands\query.ts:29
+#: src\commands\query.ts:30
 msgctxt "command-name"
 msgid "query"
-msgstr ""
-
-#: src\commands\locale-user.ts:31
-msgctxt "command-name"
-msgid "locale-user"
-msgstr ""
-
-#: src\commands\metagame.ts:204
-msgctxt "command-name"
-msgid "metagame"
 msgstr ""
 
 #: src\commands\art.ts:37
@@ -1290,12 +1229,12 @@ msgctxt "command-description"
 msgid "Display the art for a card!"
 msgstr ""
 
-#: src\commands\help.ts:53
+#: src\commands\help.ts:50
 msgctxt "command-description"
 msgid "Get help with a Slash Command."
 msgstr ""
 
-#: src\commands\ping.ts:26
+#: src\commands\ping.ts:24
 msgctxt "command-description"
 msgid "Test latency to the new bot instance."
 msgstr ""
@@ -1310,7 +1249,7 @@ msgctxt "command-description"
 msgid "Search the Yugipedia wiki for a page and link to it."
 msgstr ""
 
-#: src\commands\deck.ts:83
+#: src\commands\deck.ts:122
 msgctxt "command-description"
 msgid "Display a deck list from ydke:// or .ydk format, exported from a number of deck building programs."
 msgstr ""
@@ -1325,34 +1264,24 @@ msgctxt "command-description"
 msgid "Check or set Bastion's locale for this channel or server."
 msgstr ""
 
-#: src\commands\random.ts:44
+#: src\commands\random.ts:45
 msgctxt "command-description"
 msgid "Get a random Yu-Gi-Oh! card."
 msgstr ""
 
-#: src\commands\price.ts:91
+#: src\commands\price.ts:90
 msgctxt "command-description"
 msgid "Display the price for a card!"
 msgstr ""
 
-#: src\commands\rush-duel.ts:58
+#: src\commands\rush-duel.ts:59
 msgctxt "command-description"
 msgid "Find information on Rush Duel cards."
 msgstr ""
 
-#: src\commands\query.ts:30
+#: src\commands\query.ts:31
 msgctxt "command-description"
 msgid "Advanced search prototype"
-msgstr ""
-
-#: src\commands\locale-user.ts:32
-msgctxt "command-description"
-msgid "Check or set user-installed Bastion's locale."
-msgstr ""
-
-#: src\commands\metagame.ts:205
-msgctxt "command-description"
-msgid "Show statistics on the current competitive state of play."
 msgstr ""
 
 #: src\commands\locale.ts:43
@@ -1365,71 +1294,7 @@ msgctxt "command-option-choice"
 msgid "server"
 msgstr ""
 
-#: src\commands\locale-user.ts:49
 #: src\commands\locale.ts:51
 msgctxt "command-option-choice"
 msgid "Discord default"
-msgstr ""
-
-#: src\commands\metagame.ts:219
-#: src\commands\metagame.ts:251
-msgctxt "command-option-choice"
-msgid "TCG"
-msgstr ""
-
-#: src\commands\metagame.ts:220
-#: src\commands\metagame.ts:255
-msgctxt "command-option-choice"
-msgid "OCG"
-msgstr ""
-
-#: src\commands\metagame.ts:221
-#: src\commands\metagame.ts:259
-msgctxt "command-option-choice"
-msgid "OCG (Asian-English)"
-msgstr ""
-
-#: src\commands\metagame.ts:228
-msgctxt "command-option-choice"
-msgid "Master Duel Diamond+ tier list"
-msgstr ""
-
-#: src\commands\metagame.ts:261
-msgctxt "command-option-choice"
-msgid "Master Duel ranked ladder"
-msgstr ""
-
-#: src\commands\metagame.ts:283
-msgctxt "command-option-choice"
-msgid "Current format"
-msgstr ""
-
-#: src\commands\metagame.ts:287
-msgctxt "command-option-choice"
-msgid "Since last Forbidden/Limited List"
-msgstr ""
-
-#: src\commands\metagame.ts:291
-msgctxt "command-option-choice"
-msgid "Last 7 days"
-msgstr ""
-
-#: src\commands\metagame.ts:295
-msgctxt "command-option-choice"
-msgid "Last 14 days"
-msgstr ""
-
-#: src\commands\metagame.ts:299
-msgctxt "command-option-choice"
-msgid "Last 30 days"
-msgstr ""
-
-#: src\commands\metagame.ts:303
-msgctxt "command-option-choice"
-msgid "Last three months"
-msgstr ""
-
-#: src\commands\metagame.ts:307
-msgctxt "command-option-choice"
-msgid "Last six months"
 msgstr ""

--- a/translations/ja.po
+++ b/translations/ja.po
@@ -6,33 +6,50 @@ msgstr ""
 "MIME-Version: 1.0\n"
 "Content-Transfer-Encoding: 8bit\n"
 
-#: src\card.ts:412
-#: src\rush-duel.ts:48
+#: src\card.ts:416
+#: src\rush-duel.ts:39
 msgid "🔗 Links"
 msgstr "🔗 リンク集"
 
-#: src\card.ts:413
+#: src\card.ts:417
 #, javascript-format
 msgid "[Official Konami DB](${ official }) | [OCG Rulings](${ rulings }) | [Yugipedia](${ yugipedia }) | [YGOPRODECK](${ ygoprodeck })"
 msgstr "[Konami公式カードDB](${ official }) | [OCG公式裁定](${ rulings }) | [Yugipedia](${ yugipedia }) | [YGOPRODECK](${ ygoprodeck })"
 
-#: src\card.ts:416
+#: src\card.ts:420
 #, javascript-format
 msgid "[Yugipedia](${ yugipedia }) | [YGOPRODECK](${ ygoprodeck })"
 msgstr ""
 
-#: src\card.ts:490
-#: src\rush-duel.ts:103
+#: src\card.ts:489
+#: src\rush-duel.ts:92
 #, javascript-format
 msgid "**Type**: ${ raceIcon } ${ localizedMonsterTypeLine }"
 msgstr "**種族**: ${ raceIcon } ${ localizedMonsterTypeLine }"
 
-#: src\card.ts:500
+#: src\card.ts:491
+#: src\rush-duel.ts:94
+#, javascript-format
+msgid "**Attribute**: ${ AttributeIcon[card.attribute] } ${ localizedAttribute }"
+msgstr "**属性**: ${ AttributeIcon[card.attribute] } ${ localizedAttribute }"
+
+#: src\card.ts:495
+#, javascript-format
+msgid "**Rank**: ${ Icon.Rank } ${ card.rank } **ATK**: ${ card.atk } **DEF**: ${ card.def }"
+msgstr "**ランク**: ${ Icon.Rank } ${ card.rank } **攻撃力**: ${ card.atk } **守備力**: ${ card.def }"
+
+#: src\card.ts:498
 #, javascript-format
 msgid "**Link Rating**: ${ card.link_arrows.length } **ATK**: ${ card.atk } **Link Arrows**: ${ arrows }"
 msgstr "**リンクの数字分**: ${ card.link_arrows.length } **攻撃力**: ${ card.atk } **リンクマーカー**: ${ arrows }"
 
-#: src\card.ts:511
+#: src\card.ts:500
+#: src\rush-duel.ts:96
+#, javascript-format
+msgid "**Level**: ${ Icon.Level } ${ card.level } **ATK**: ${ card.atk } **DEF**: ${ card.def }"
+msgstr "**レベル**: ${ Icon.Level } ${ card.level } **攻撃力**: ${ card.atk } **守備力**: ${ card.def }"
+
+#: src\card.ts:507
 #, javascript-format
 msgid "**Pendulum Scale**: ${ formattedScale }"
 msgstr "**ペンデュラムスケール**: ${ formattedScale }"
@@ -53,7 +70,7 @@ msgid "Password: ${ card.password } | Not yet released"
 msgstr "パスワード: ${ card.password } | 未発売"
 
 #: src\card.ts:351
-#: src\rush-duel.ts:158
+#: src\rush-duel.ts:146
 msgid "Not yet released"
 msgstr "未発売"
 
@@ -62,64 +79,64 @@ msgstr "未発売"
 msgid "Placeholder ID: ${ card.fake_password }"
 msgstr ""
 
-#: src\utils.ts:44
+#: src\utils.ts:41
 msgid "🛠️ This command is in development."
 msgstr "🛠️ このコマンドは作成中です。"
 
-#: src\utils.ts:45
+#: src\utils.ts:42
 msgid "📨 Please send feedback to [our issue tracker](https://github.com/DawnbrandBots/bastion-bot) or the [support server](https://discord.gg/4aFuPyuE96)!"
 msgstr "📨 このボットへのご意見を[イシュートラッカー](https://github.com/DawnbrandBots/bastion-bot) か [ディスコードサーバ](https://discord.gg/4aFuPyuE96) に届けてもらえると嬉しいです！"
 
-#: src\utils.ts:56
+#: src\utils.ts:53
 msgid "Please consider supporting us!"
 msgstr "このボットの開発をサポートしてくれると嬉しいです！"
 
-#: src\utils.ts:57
+#: src\utils.ts:54
 msgid "Help keep Bastion online!"
 msgstr "Bastionが稼働し続けられるようにしましょう！"
 
-#: src\utils.ts:58
+#: src\utils.ts:55
 msgid "Please help keep Bastion online!"
 msgstr "Bastionが稼働し続けられるのはみなさんのおかけです！"
 
-#: src\utils.ts:59
+#: src\utils.ts:56
 msgid "Was Bastion helpful? Consider supporting us!"
 msgstr "Bastionがお好き？一緒に開発すればもっと好きになりますよ！"
 
-#: src\utils.ts:60
+#: src\utils.ts:57
 msgid "Was Bastion helpful? We need your support!"
 msgstr "Bastionがお好き？一緒に開発しませんか？"
 
-#: src\utils.ts:61
+#: src\utils.ts:58
 msgid "Did you find Bastion useful? Consider supporting us!"
 msgstr "Bastionがお役に立ちましたか？このボットの開発をサポートしてくれると嬉しいです！"
 
-#: src\utils.ts:62
+#: src\utils.ts:59
 msgid "Did you find Bastion useful? Help keep it online!"
 msgstr "Bastionがお役に立ちましたか？Bastionが稼働し続けられるようにしましょう！"
 
-#: src\utils.ts:63
+#: src\utils.ts:60
 msgid "Did you find Bastion useful? We need your support!"
 msgstr "Bastionがお役に立ちましたか？一緒に開発しませんか？"
 
-#: src\utils.ts:64
+#: src\utils.ts:61
 msgid "Enjoy Bastion? Help keep it online!"
 msgstr "Bastionがお好き？Bastionが稼働し続けられるようにしましょう！"
 
-#: src\utils.ts:65
+#: src\utils.ts:62
 msgid "Enjoy Bastion? Consider supporting us!"
 msgstr "Bastionがお好き？このボットの開発をサポートしてくれると嬉しいです！"
 
-#: src\utils.ts:66
+#: src\utils.ts:63
 msgid "Found what you were looking for? Consider supporting us!"
 msgstr "お探しの情報は見つかりましたか？このボットの開発をサポートしてくれると嬉しいです！"
 
 #: src\commands\art.ts:63
-#: src\commands\price.ts:132
-#: src\commands\rush-duel.ts:171
-#: src\commands\rush-duel.ts:202
+#: src\commands\price.ts:131
+#: src\commands\rush-duel.ts:172
+#: src\commands\rush-duel.ts:203
 #: src\commands\search.ts:64
-#: src\events\message-search.ts:265
+#: src\events\message-search.ts:258
 #, javascript-format
 msgid "Could not find a card matching `${ input }`!"
 msgstr "`${ input }`に一致するカードは見つかりませんでした！"
@@ -130,47 +147,47 @@ msgstr "`${ input }`に一致するカードは見つかりませんでした！
 msgid "Could not find art for `${ name }`!"
 msgstr "`${ name }`のカード画像は見つかりませんでした！"
 
-#: src\commands\deck.ts:205
+#: src\commands\deck.ts:244
 #, javascript-format
 msgid "${ counts.Monster } Monster"
 msgid_plural "${ counts.Monster } Monsters"
 msgstr[0] "モンスター ${ counts.Monster } 体"
 
-#: src\commands\deck.ts:208
+#: src\commands\deck.ts:247
 #, javascript-format
 msgid "${ counts.Spell } Spell"
 msgid_plural "${ counts.Spell } Spells"
 msgstr[0] "魔法 ${ counts.Spell } 枚"
 
-#: src\commands\deck.ts:211
+#: src\commands\deck.ts:250
 #, javascript-format
 msgid "${ counts.Trap } Trap"
 msgid_plural "${ counts.Trap } Traps"
 msgstr[0] "罠 ${ counts.Trap } 枚"
 
-#: src\commands\deck.ts:239
+#: src\commands\deck.ts:278
 msgid "Your Deck"
 msgstr "あなたのデッキ"
 
-#: src\commands\deck.ts:244
+#: src\commands\deck.ts:283
 #, javascript-format
 msgid "Main Deck (${ deck.main.length } card — ${ countDetail })"
 msgid_plural "Main Deck (${ deck.main.length } cards — ${ countDetail })"
 msgstr[0] "メインデッキ (${ deck.main.length } 枚 — ${ countDetail })"
 
-#: src\commands\deck.ts:251
+#: src\commands\deck.ts:290
 msgid "Main Deck (continued)"
 msgstr "メインデッキ（続き）"
 
-#: src\commands\deck.ts:265
+#: src\commands\deck.ts:304
 msgid "Extra Deck (continued)"
 msgstr "エクストラデッキ（続き）"
 
-#: src\commands\deck.ts:279
+#: src\commands\deck.ts:318
 msgid "Side Deck (continued)"
 msgstr "サイドデッキ（続き）"
 
-#: src\commands\deck.ts:347
+#: src\commands\deck.ts:407
 msgid "Error: Your deck is empty."
 msgstr "エラー: デッキが空です。"
 
@@ -190,7 +207,11 @@ msgstr "このサーバへの上書き言語設定: ${ guildOverride }"
 msgid "Discord Community locale for this server: ${ interaction.guildLocale }"
 msgstr "このサーバのディスコードコミュニティの言語設定: ${ interaction.guildLocale }"
 
-#: src\commands\locale-user.ts:76
+#: src\commands\locale.ts:89
+#, javascript-format
+msgid "Locale override for this direct message: ${ override }"
+msgstr "このダイレクトメッセージへの上書き言語設定: ${ override }"
+
 #: src\commands\locale.ts:92
 #, javascript-format
 msgid "Your Discord locale: ${ interaction.locale }"
@@ -228,14 +249,24 @@ msgstr "コミュニティサーバのサーバーでのデフォルト設定は
 msgid "Sorry, you must have the Manage Server permission to do this. If you think this is an error, contact your server admin or report a bug."
 msgstr "申し訳ありませんが、「サーバ管理」の権限が必要です。これがバグと考えられる場合は、サーバの管理者へ報告頂くか、バグ報告をして頂ければと思います。"
 
-#: src\commands\ping.ts:38
-#: src\events\message-ping.ts:45
+#: src\commands\locale.ts:146
+#, javascript-format
+msgid "Locale for this direct message overridden with ${ locale }. Your Discord setting is ${ interaction.locale }."
+msgstr "このダイレクトメッセージの言語設定は ${ locale } にて上書きされました。あなたのディスコードの設定は ${ interaction.locale } です。"
+
+#: src\commands\locale.ts:150
+#, javascript-format
+msgid "Locale for this direct message reset to Discord default. Your Discord setting is ${ interaction.locale }."
+msgstr "このダイレクトメッセージの言語設定はあなたのディスコードのデフォルトへとリセットされました。あなたのディスコードの設定は ${ interaction.locale } です。"
+
+#: src\commands\ping.ts:36
+#: src\events\message-ping.ts:47
 #, javascript-format
 msgid "Average WebSocket ping (new instance): ${ ping } ms"
 msgstr "平均 WebSocket ping（新インスタンス）: ${ ping } ms"
 
-#: src\commands\ping.ts:42
-#: src\events\message-ping.ts:110
+#: src\commands\ping.ts:40
+#: src\events\message-ping.ts:112
 #, javascript-format
 msgid "Total latency: ${ latency } ms"
 msgstr "総レイテンシー: ${ latency } ms"
@@ -245,69 +276,86 @@ msgstr "総レイテンシー: ${ latency } ms"
 msgid "Could not find a Yugipedia page named `${ page }`."
 msgstr "`${ page }` という名前のYugipediaのページが見つかりませんでした。"
 
-#: src\events\message-ping.ts:47
+#: src\events\message-ping.ts:49
 msgid "Free and open source _Yu-Gi-Oh!_ bot"
 msgstr "自由でオープンソースな _Yu-Gi-Oh!_ ボット"
 
-#: src\events\message-ping.ts:70
+#: src\events\message-ping.ts:72
 #, javascript-format
 msgid "Revision: ${ process.env.BOT_REVISION }."
 msgstr "リビジョン: ${ process.env.BOT_REVISION }."
 
-#: src\commands\deck.ts:289
+#: src\commands\deck.ts:328
 msgid ".ydk files must have the .ydk extension!"
 msgstr ".ydkファイルには.ydkの拡張子が必要です！"
 
-#: src\commands\deck.ts:292
+#: src\commands\deck.ts:331
 msgid ".ydk files should not be larger than 1 KB!"
 msgstr ".ydkファイルを 1 KB よりも大きくしないでください！"
 
-#: src\commands\deck.ts:282
+#: src\commands\deck.ts:321
 msgid "ydke URL"
 msgstr "ydkeのURL"
 
 #: src\card.ts:455
-#: src\rush-duel.ts:75
+#: src\rush-duel.ts:61
 #. Forbidden/Limited Lists or Limit Regulations in the OCG
 #, javascript-format
 msgid "**Limit**: ${ limitRegulationDisplay }"
 msgstr "**リミットレギュレーション**: ${ limitRegulationDisplay }"
 
-#: src\commands\price.ts:70
+#: src\commands\price.ts:69
 msgid "TCGPlayer"
 msgstr ""
 
-#: src\commands\price.ts:71
+#: src\commands\price.ts:70
 msgid "Cardmarket"
 msgstr ""
 
-#: src\commands\price.ts:148
+#: src\commands\price.ts:147
 msgid "No market price"
 msgstr "市場価格不明"
 
-#: src\commands\price.ts:156
+#: src\commands\price.ts:155
 #, javascript-format
 msgid "Prices for ${ card.name[resultLanguage] } - ${ vendorName }"
 msgstr "${ vendorName } の ${ card.name[resultLanguage] } の値段"
 
-#: src\commands\price.ts:170
+#: src\commands\price.ts:169
 #, javascript-format
 msgid "Could not find prices for `${ name }`!"
 msgstr "`${ name }` の値段を見つけられませんでした！"
 
-#: src\commands\deck.ts:363
+#: src\commands\deck.ts:425
+#. prepare interaction button for FTP upload
 msgid "Upload to YGOPRODECK"
 msgstr "YGOPRODECKにアップロード"
 
-#: src\events\message-search.ts:271
+#: src\commands\deck.ts:483
+#. disable original button
+#. prepare row to disable button on original message
+msgid "Upload Complete"
+msgstr "アップロード完了"
+
+#: src\commands\deck.ts:470
+msgid "Deck upload failed!"
+msgstr "デッキのアップロードに失敗しました！"
+
+#: src\commands\deck.ts:491
+#. reply in affirmation
+#, javascript-format
+msgid "Deck successfully uploaded to <${ url }>!"
+msgstr "<${ url }>にデッキのアップロードを完了しました！"
+
+#: src\events\message-search.ts:264
 msgid "💬 Translations missing?"
 msgstr "💬 翻訳が存在しませんか？"
 
-#: src\events\message-search.ts:272
+#: src\events\message-search.ts:265
 msgid "Help translate Bastion at the links above."
 msgstr "このボットの翻訳プロジェクトへは上のリンクから。"
 
-#: src\events\message-ping.ts:48
+#: src\events\message-ping.ts:50
 msgid ""
 "❓ Help documentation on [GitHub](https://github.com/DawnbrandBots/bastion-bot), or use `.commands` and `.help`.\n"
 "🟢 Licence: [GNU AGPL 3.0+](https://choosealicense.com/licenses/agpl-3.0/).\n"
@@ -335,37 +383,37 @@ msgstr ""
 "\n"
 "💬 翻訳がされていない場所がありますか? [GitHub](https://github.com/DawnbrandBots/bastion-bot)で翻訳を手伝ってくれると嬉しいです！"
 
-#: src\events\message-search.ts:263
-#: src\events\message-search.ts:302
+#: src\events\message-search.ts:256
+#: src\events\message-search.ts:294
 #, javascript-format
 msgid "Search type: ${ localisedType }"
 msgstr "検索タイプ: ${ localisedType }"
 
-#: src\events\message-search.ts:242
+#: src\events\message-search.ts:236
 #, javascript-format
 msgid "Search language: **${ localisedInputLanguage }** (${ inputLanguage }). Check defaults with </locale get:${ id }> and configure with </locale set:${ id }>"
 msgstr "検索言語: **${ localisedInputLanguage }** (${ inputLanguage })。</locale get:${ id }>で言語設定のデフォルトを確認し、</locale set:${ id }>で設定できます。"
 
-#: src\events\message-ping.ts:93
+#: src\events\message-ping.ts:95
 msgid "⚠️ You pinged me, but I am missing permissions in the channel!"
 msgstr "⚠️ Pingをもらいましたが、そのチャンネルにはこのボットに権限がありません！"
 
-#: src\events\message-ping.ts:96
-#: src\events\message-search.ts:340
+#: src\events\message-ping.ts:98
+#: src\events\message-search.ts:332
 msgid "Please have a server administrator [fix this](https://github.com/DawnbrandBots/bastion-bot#discord-permissions)."
 msgstr "サーバ管理者の方に[この問題](https://github.com/DawnbrandBots/bastion-bot#discord-permissions)の対応をお願いいたします。"
 
-#: src\events\message-search.ts:337
+#: src\events\message-search.ts:329
 msgid "⚠️ I am missing permissions in the channel!"
 msgstr "⚠️ そのチャンネルではこのボットに権限がありません！"
 
-#: src\commands\deck.ts:258
+#: src\commands\deck.ts:297
 #, javascript-format
 msgid "Extra Deck (${ deck.extra.length } card — ${ countDetail })"
 msgid_plural "Extra Deck (${ deck.extra.length } cards — ${ countDetail })"
 msgstr[0] "エクストラデッキ (${ deck.extra.length } 枚 — ${ countDetail })"
 
-#: src\commands\deck.ts:272
+#: src\commands\deck.ts:311
 #, javascript-format
 msgid "Side Deck (${ deck.side.length } card — ${ countDetail })"
 msgid_plural "Side Deck (${ deck.side.length } cards — ${ countDetail })"
@@ -386,82 +434,48 @@ msgstr "`${ searchTerm }`でYGOPRODECKを検索中に何かエラーが起こっ
 msgid "Something went wrong searching Yugipedia for `${ page }`."
 msgstr "`${ page }`でYugipediaを検索中に何かエラーが起こったようです。"
 
-#: src\rush-duel.ts:49
+#: src\rush-duel.ts:40
 #, javascript-format
 msgid "[Official Konami DB](${ official }) | [Rulings (Japanese)](${ rulings }) | [Yugipedia](${ yugipedia }) | [RushCard](${ rushcard })"
 msgstr "[Konami公式カードDB](${ official }) | [公式裁定](${ rulings }) | [Yugipedia](${ yugipedia }) | [RushCard](${ rushcard })"
 
-#: src\rush-duel.ts:52
+#: src\rush-duel.ts:43
 #, javascript-format
 msgid "[Yugipedia](${ yugipedia }) | [RushCard](${ rushcard })"
 msgstr ""
 
-#: src\rush-duel.ts:71
+#: src\rush-duel.ts:57
 msgid "__**LEGEND**__"
 msgstr "__**レジェンド**__"
 
-#: src\rush-duel.ts:110
+#: src\rush-duel.ts:99
 #, javascript-format
 msgid "**MAXIMUM ATK**: ${ card.maximum_atk }"
 msgstr ""
 
-#: src\rush-duel.ts:158
+#: src\rush-duel.ts:146
 #, javascript-format
 msgid "Konami ID #${ card.konami_id }"
 msgstr ""
 
 #: src\art.ts:129
+#: src\commands\deck.ts:451
 msgid "Buttons can only be used by the user who called Bastion."
 msgstr "ボタンはBastionにコマンドを送ったユーザーのみに有効です。"
 
-#: src\rush-duel.ts:217
+#: src\card.ts:462
+#, javascript-format
+msgid "**Master Duel rarity**: ${ rarity_icon } ${ localized_rarity }"
+msgstr "**マスターデュエルレアリティ**: ${ rarity_icon } ${ localized_rarity }"
+
+#: src\rush-duel.ts:205
 #, javascript-format
 msgid "Using ${ searchTrigger }, you can search for Rush Duel cards directly in messages without autocomplete"
 msgstr ""
 
-#: src\events\message-search.ts:304
+#: src\events\message-search.ts:296
 #, javascript-format
 msgid "Could not find a Rush Duel card matching `${ input }`!"
-msgstr ""
-
-#: src\card.ts:462
-#, javascript-format
-msgid "**Master Duel rarity**: ${ rarityIcon } ${ localizedRarity }"
-msgstr ""
-
-#: src\card.ts:492
-#: src\rush-duel.ts:105
-#, javascript-format
-msgid "**Attribute**: ${ attributeIcon } ${ localizedAttribute }"
-msgstr ""
-
-#: src\card.ts:497
-#, javascript-format
-msgid "**Rank**: ${ rankIcon } ${ card.rank } **ATK**: ${ card.atk } **DEF**: ${ card.def }"
-msgstr ""
-
-#: src\card.ts:503
-#: src\rush-duel.ts:107
-#, javascript-format
-msgid "**Level**: ${ levelIcon } ${ card.level } **ATK**: ${ card.atk } **DEF**: ${ card.def }"
-msgstr ""
-
-#: src\commands\locale-user.ts:73
-#: src\commands\locale.ts:89
-#, javascript-format
-msgid "Locale override for your direct messages: ${ override }"
-msgstr ""
-
-#: src\commands\locale-user.ts:83
-#: src\commands\locale.ts:146
-#, javascript-format
-msgid "Locale for your direct messages overridden with ${ locale }. Your Discord setting is ${ interaction.locale }."
-msgstr ""
-
-#: src\commands\locale-user.ts:87
-#: src\commands\locale.ts:150
-#, javascript-format
-msgid "Locale for your direct messages reset to Discord default. Your Discord setting is ${ interaction.locale }."
 msgstr ""
 
 #: src\card.ts:40
@@ -828,65 +842,65 @@ msgctxt "master-duel-rarity"
 msgid "Ultra Rare (UR)"
 msgstr "ウルトラレア（ＵＲ）"
 
-#: src\card.ts:517
-#: src\card.ts:528
-#: src\rush-duel.ts:138
+#: src\card.ts:513
+#: src\card.ts:524
+#: src\rush-duel.ts:127
 msgctxt "card-embed"
 msgid "Card Text"
 msgstr "カードテキスト"
 
-#: src\card.ts:522
+#: src\card.ts:518
 msgctxt "card-embed"
 msgid "Pendulum Effect"
 msgstr "ペンデュラム効果"
 
-#: src\card.ts:545
+#: src\card.ts:539
 msgctxt "card-embed"
 msgid "Card Effect"
 msgstr "カード効果"
 
-#: src\rush-duel.ts:129
-#: src\rush-duel.ts:151
+#: src\rush-duel.ts:118
+#: src\rush-duel.ts:139
 msgctxt "card-embed"
 msgid "[REQUIREMENT]"
 msgstr "【条件】"
 
-#: src\rush-duel.ts:130
-#: src\rush-duel.ts:152
+#: src\rush-duel.ts:119
+#: src\rush-duel.ts:140
 msgctxt "card-embed"
 msgid "[EFFECT]"
 msgstr "【効果】"
 
-#: src\rush-duel.ts:132
+#: src\rush-duel.ts:121
 msgctxt "card-embed"
 msgid "[CONTINUOUS EFFECT]"
 msgstr "【永続効果】"
 
-#: src\rush-duel.ts:134
+#: src\rush-duel.ts:123
 msgctxt "card-embed"
 msgid "[MULTI-CHOICE EFFECT]"
 msgstr "【選択効果】"
 
-#: src\locale.ts:74
+#: src\locale.ts:71
 msgctxt "command-option"
 msgid "result-language"
 msgstr "出力用言語"
 
-#: src\locale.ts:140
+#: src\locale.ts:131
 msgctxt "command-option"
 msgid "input-language"
 msgstr "入力用言語"
 
-#: src\commands\rush-duel.ts:67
-#: src\commands\rush-duel.ts:79
-#: src\locale.ts:156
-#: src\locale.ts:174
-#: src\locale.ts:190
+#: src\commands\rush-duel.ts:68
+#: src\commands\rush-duel.ts:80
+#: src\locale.ts:147
+#: src\locale.ts:165
+#: src\locale.ts:181
 msgctxt "command-option"
 msgid "input"
 msgstr "入力"
 
-#: src\commands\help.ts:55
+#: src\commands\help.ts:52
 msgctxt "command-option"
 msgid "command"
 msgstr "コマンド"
@@ -901,56 +915,54 @@ msgctxt "command-option"
 msgid "page"
 msgstr "ページ"
 
-#: src\commands\deck.ts:87
+#: src\commands\deck.ts:126
 msgctxt "command-option"
 msgid "url"
 msgstr ""
 
-#: src\commands\deck.ts:93
+#: src\commands\deck.ts:132
 msgctxt "command-option"
 msgid "file"
 msgstr "ファイル"
 
-#: src\commands\deck.ts:99
-#: src\commands\deck.ts:105
+#: src\commands\deck.ts:138
+#: src\commands\deck.ts:144
 msgctxt "command-option"
 msgid "deck"
 msgstr "デッキ"
 
-#: src\commands\deck.ts:111
+#: src\commands\deck.ts:150
 msgctxt "command-option"
 msgid "public"
 msgstr "チャンネルに公開"
 
-#: src\commands\deck.ts:118
+#: src\commands\deck.ts:157
 msgctxt "command-option"
 msgid "stacked"
 msgstr "一行表示"
 
-#: src\locale.ts:151
+#: src\locale.ts:142
 msgctxt "command-option"
 msgid "name"
 msgstr "カード名"
 
-#: src\locale.ts:169
+#: src\locale.ts:160
 msgctxt "command-option"
 msgid "password"
 msgstr "パスワード"
 
-#: src\commands\rush-duel.ts:72
-#: src\events\message-search.ts:301
-#: src\locale.ts:185
+#: src\commands\rush-duel.ts:73
+#: src\events\message-search.ts:293
+#: src\locale.ts:176
 msgctxt "command-option"
 msgid "konami-id"
 msgstr "コナミid"
 
-#: src\commands\locale-user.ts:36
 #: src\commands\locale.ts:30
 msgctxt "command-option"
 msgid "get"
 msgstr "確認する"
 
-#: src\commands\locale-user.ts:41
 #: src\commands\locale.ts:35
 msgctxt "command-option"
 msgid "set"
@@ -961,69 +973,47 @@ msgctxt "command-option"
 msgid "scope"
 msgstr "適用範囲"
 
-#: src\commands\locale-user.ts:46
 #: src\commands\locale.ts:48
 msgctxt "command-option"
 msgid "locale"
 msgstr "使用言語"
 
-#: src\commands\price.ts:95
+#: src\commands\price.ts:94
 msgctxt "command-option"
 msgid "vendor"
 msgstr "販売店"
 
-#: src\commands\rush-duel.ts:62
+#: src\commands\rush-duel.ts:63
 msgctxt "command-option"
 msgid "search"
 msgstr "検索"
 
-#: src\commands\rush-duel.ts:84
+#: src\commands\rush-duel.ts:85
 msgctxt "command-option"
 msgid "random"
 msgstr "おみくじ"
 
-#: src\commands\rush-duel.ts:89
+#: src\commands\rush-duel.ts:90
 msgctxt "command-option"
 msgid "art"
 msgstr "イラスト"
 
-#: src\commands\query.ts:35
+#: src\commands\query.ts:36
 msgctxt "command-option"
 msgid "lucene"
 msgstr ""
 
-#: src\commands\metagame.ts:209
-msgctxt "command-option"
-msgid "strategies"
-msgstr ""
-
-#: src\commands\metagame.ts:234
-#: src\commands\metagame.ts:274
-msgctxt "command-option"
-msgid "format"
-msgstr ""
-
-#: src\commands\metagame.ts:240
-msgctxt "command-option"
-msgid "cards"
-msgstr ""
-
-#: src\commands\metagame.ts:310
-msgctxt "command-option"
-msgid "date-range"
-msgstr ""
-
-#: src\locale.ts:77
+#: src\locale.ts:74
 msgctxt "command-option-description"
 msgid "The output language for the card embed, overriding other settings."
 msgstr "カード情報の表示言語を設定します。デフォルトの設定より優先されます。"
 
-#: src\locale.ts:141
+#: src\locale.ts:132
 msgctxt "command-option-description"
 msgid "The language to search in, defaulting to the result language."
 msgstr "検索ワードが何語かを指定できます。デフォルトの設定は出力言語と同じです。"
 
-#: src\commands\help.ts:58
+#: src\commands\help.ts:55
 msgctxt "command-option-description"
 msgid "The name of a specific Slash Command."
 msgstr "使い方を表示したいスラッシュコマンドの名前"
@@ -1033,32 +1023,32 @@ msgctxt "command-option-description"
 msgid "The name of the Yugipedia page you want to search for."
 msgstr "検索したいYugipediaのページの名前"
 
-#: src\commands\deck.ts:90
+#: src\commands\deck.ts:129
 msgctxt "command-option-description"
 msgid "View a deck by entering a ydke:// URL."
 msgstr "ydke://形式のURLを入力すると、そのデッキ内容を表示します。"
 
-#: src\commands\deck.ts:96
+#: src\commands\deck.ts:135
 msgctxt "command-option-description"
 msgid "View a deck by uploading a .ydk file."
 msgstr ".ydk形式のファイルをアップロードすると、そのデッキ内容を表示します。"
 
-#: src\commands\deck.ts:102
+#: src\commands\deck.ts:141
 msgctxt "command-option-description"
 msgid "The ydke:// URL of the deck you want to view."
 msgstr "デッキ内容を表示したいydke://形式のURL"
 
-#: src\commands\deck.ts:108
+#: src\commands\deck.ts:147
 msgctxt "command-option-description"
 msgid "The .ydk file of the deck you want to view."
 msgstr "デッキ内容を表示したい.ydk形式のファイル"
 
-#: src\commands\deck.ts:114
+#: src\commands\deck.ts:153
 msgctxt "command-option-description"
 msgid "Whether to display the deck details publicly in chat. This is false by default."
 msgstr "デッキ内容を自分以外の人にも見せるか否かを設定できます。デフォルトでは他の人には非表示になっています。"
 
-#: src\commands\deck.ts:121
+#: src\commands\deck.ts:160
 msgctxt "command-option-description"
 msgid "Whether to display the deck sections as one stacked column. This is false (side-by-side) by default."
 msgstr "デッキ内容を一行で表示するか否かを設定できます。デフォルトでは左右の二行に分けて表示します。"
@@ -1068,8 +1058,8 @@ msgctxt "command-option-description"
 msgid "Display the art for the card with this name."
 msgstr "この名称のカードのイラストを表示します"
 
-#: src\commands\rush-duel.ts:68
-#: src\locale.ts:157
+#: src\commands\rush-duel.ts:69
+#: src\locale.ts:148
 msgctxt "command-option-description"
 msgid "Card name, fuzzy matching supported."
 msgstr "カード名（あいまい検索に対応しています）"
@@ -1079,7 +1069,7 @@ msgctxt "command-option-description"
 msgid "Display the art for the card with this password."
 msgstr "このパスワードのカードのイラストを表示します"
 
-#: src\locale.ts:176
+#: src\locale.ts:167
 msgctxt "command-option-description"
 msgid "Card password, the eight-digit number printed on the bottom left corner."
 msgstr "カードパスワード（カード左下の8桁の数字）"
@@ -1089,8 +1079,8 @@ msgctxt "command-option-description"
 msgid "Display the art for the card with this official database ID."
 msgstr "このパスワードのカードのイラストを表示します"
 
-#: src\commands\rush-duel.ts:80
-#: src\locale.ts:191
+#: src\commands\rush-duel.ts:81
+#: src\locale.ts:182
 msgctxt "command-option-description"
 msgid "Konami's official card database identifier."
 msgstr "Konami公式カードDBでのカードID"
@@ -1130,22 +1120,22 @@ msgctxt "command-option-description"
 msgid "The new default language to use in this channel or server."
 msgstr "このチャンネルあるいはサーバ全体で使う新しい言語設定"
 
-#: src\commands\price.ts:99
+#: src\commands\price.ts:98
 msgctxt "command-option-description"
 msgid "Display the price for the card with this name."
 msgstr "この名称のカードの価格を表示します"
 
-#: src\commands\price.ts:103
+#: src\commands\price.ts:102
 msgctxt "command-option-description"
 msgid "Display the price for the card with this password."
 msgstr "このパスワードのカードの価格を表示します"
 
-#: src\commands\price.ts:106
+#: src\commands\price.ts:105
 msgctxt "command-option-description"
 msgid "Display the price for the card with this official database ID."
 msgstr "この公式カードDBのIDを持つカードの価格を表示します"
 
-#: src\commands\price.ts:96
+#: src\commands\price.ts:95
 msgctxt "command-option-description"
 msgid "The vendor to fetch the price data from."
 msgstr "価格情報の参照先"
@@ -1155,70 +1145,29 @@ msgctxt "command-option-description"
 msgid "The English name of the card you're looking for."
 msgstr "カード名称の英語名"
 
-#: src\commands\rush-duel.ts:63
+#: src\commands\rush-duel.ts:64
 msgctxt "command-option-description"
 msgid "Find all information for the Rush Duel card with this name."
 msgstr "この名称のラッシュデュエルカードの情報を表示します"
 
-#: src\commands\rush-duel.ts:74
+#: src\commands\rush-duel.ts:75
 msgctxt "command-option-description"
 msgid "Find all information for the Rush Duel card with this official database ID."
 msgstr "この公式カードDBのIDを持つラッシュデュエルカードの情報を表示します"
 
-#: src\commands\rush-duel.ts:85
+#: src\commands\rush-duel.ts:86
 msgctxt "command-option-description"
 msgid "Get a random Rush Duel card."
 msgstr "ラッシュデュエル用カードのおみくじ"
 
-#: src\commands\rush-duel.ts:90
+#: src\commands\rush-duel.ts:91
 msgctxt "command-option-description"
 msgid "Display just the art for the Rush Duel card with this name."
 msgstr "ラッシュデュエル用カードのイラストを表示します"
 
-#: src\commands\query.ts:36
+#: src\commands\query.ts:37
 msgctxt "command-option-description"
 msgid "Lucene query on YAML Yugi"
-msgstr ""
-
-#: src\commands\locale-user.ts:37
-msgctxt "command-option-description"
-msgid "Check your user-installed Bastion's locale."
-msgstr ""
-
-#: src\commands\locale-user.ts:42
-msgctxt "command-option-description"
-msgid "Configure your user-installed Bastion's locale."
-msgstr ""
-
-#: src\commands\locale-user.ts:47
-msgctxt "command-option-description"
-msgid "The new default language to use for user-installed Bastion."
-msgstr ""
-
-#: src\commands\metagame.ts:212
-msgctxt "command-option-description"
-msgid "Show the top competitive strategies in tournaments and the Master Duel ranked ladder."
-msgstr ""
-
-#: src\commands\metagame.ts:214
-msgctxt "command-option-description"
-msgid "Show the top competitive strategies in tournaments."
-msgstr ""
-
-#: src\commands\metagame.ts:235
-#: src\commands\metagame.ts:275
-msgctxt "command-option-description"
-msgid "Game region."
-msgstr ""
-
-#: src\commands\metagame.ts:242
-msgctxt "command-option-description"
-msgid "Show the most popular cards in tournaments and the Master Duel ranked ladder."
-msgstr ""
-
-#: src\commands\metagame.ts:312
-msgctxt "command-option-description"
-msgid "Limit card usage statistics to this date range. Has no effect for Master Duel."
 msgstr ""
 
 #: src\commands\art.ts:36
@@ -1226,12 +1175,12 @@ msgctxt "command-name"
 msgid "art"
 msgstr "いらすと"
 
-#: src\commands\help.ts:52
+#: src\commands\help.ts:49
 msgctxt "command-name"
 msgid "help"
 msgstr "つかいかた"
 
-#: src\commands\ping.ts:25
+#: src\commands\ping.ts:23
 msgctxt "command-name"
 msgid "ping"
 msgstr ""
@@ -1246,7 +1195,7 @@ msgctxt "command-name"
 msgid "yugipedia"
 msgstr ""
 
-#: src\commands\deck.ts:80
+#: src\commands\deck.ts:119
 msgctxt "command-name"
 msgid "deck"
 msgstr "でっき"
@@ -1261,34 +1210,24 @@ msgctxt "command-name"
 msgid "locale"
 msgstr "げんごせってい"
 
-#: src\commands\random.ts:43
+#: src\commands\random.ts:44
 msgctxt "command-name"
 msgid "random"
 msgstr "おみくじ"
 
-#: src\commands\price.ts:90
+#: src\commands\price.ts:89
 msgctxt "command-name"
 msgid "price"
 msgstr "かかく"
 
-#: src\commands\rush-duel.ts:57
+#: src\commands\rush-duel.ts:58
 msgctxt "command-name"
 msgid "rush-duel"
 msgstr "らっしゅ"
 
-#: src\commands\query.ts:29
+#: src\commands\query.ts:30
 msgctxt "command-name"
 msgid "query"
-msgstr ""
-
-#: src\commands\locale-user.ts:31
-msgctxt "command-name"
-msgid "locale-user"
-msgstr ""
-
-#: src\commands\metagame.ts:204
-msgctxt "command-name"
-msgid "metagame"
 msgstr ""
 
 #: src\commands\art.ts:37
@@ -1296,12 +1235,12 @@ msgctxt "command-description"
 msgid "Display the art for a card!"
 msgstr "カードの画像（イラスト）を表示します。"
 
-#: src\commands\help.ts:53
+#: src\commands\help.ts:50
 msgctxt "command-description"
 msgid "Get help with a Slash Command."
 msgstr "コマンドの使い方を表示します。"
 
-#: src\commands\ping.ts:26
+#: src\commands\ping.ts:24
 msgctxt "command-description"
 msgid "Test latency to the new bot instance."
 msgstr "ボットが落ちていないかを確認できます（pingの反応を表示します。）"
@@ -1316,7 +1255,7 @@ msgctxt "command-description"
 msgid "Search the Yugipedia wiki for a page and link to it."
 msgstr "Yugipediaを検索します。"
 
-#: src\commands\deck.ts:83
+#: src\commands\deck.ts:122
 msgctxt "command-description"
 msgid "Display a deck list from ydke:// or .ydk format, exported from a number of deck building programs."
 msgstr "ydke:// か .ydk 形式のデッキ情報を表示します。（多くのデッキ構築アプリで使われている形式です。）"
@@ -1331,34 +1270,24 @@ msgctxt "command-description"
 msgid "Check or set Bastion's locale for this channel or server."
 msgstr "このチャンネル（あるいはサーバー）のBastionのロケールを確認（あるいは変更）します。"
 
-#: src\commands\random.ts:44
+#: src\commands\random.ts:45
 msgctxt "command-description"
 msgid "Get a random Yu-Gi-Oh! card."
 msgstr "遊戯王カードをランダムに表示します。"
 
-#: src\commands\price.ts:91
+#: src\commands\price.ts:90
 msgctxt "command-description"
 msgid "Display the price for a card!"
 msgstr "カードの値段を表示します！"
 
-#: src\commands\rush-duel.ts:58
+#: src\commands\rush-duel.ts:59
 msgctxt "command-description"
 msgid "Find information on Rush Duel cards."
 msgstr "ラッシュデュエルのカード情報を探します。"
 
-#: src\commands\query.ts:30
+#: src\commands\query.ts:31
 msgctxt "command-description"
 msgid "Advanced search prototype"
-msgstr ""
-
-#: src\commands\locale-user.ts:32
-msgctxt "command-description"
-msgid "Check or set user-installed Bastion's locale."
-msgstr ""
-
-#: src\commands\metagame.ts:205
-msgctxt "command-description"
-msgid "Show statistics on the current competitive state of play."
 msgstr ""
 
 #: src\commands\locale.ts:43
@@ -1371,71 +1300,7 @@ msgctxt "command-option-choice"
 msgid "server"
 msgstr "サーバー"
 
-#: src\commands\locale-user.ts:49
 #: src\commands\locale.ts:51
 msgctxt "command-option-choice"
 msgid "Discord default"
 msgstr "ディスコードのデフォルト"
-
-#: src\commands\metagame.ts:219
-#: src\commands\metagame.ts:251
-msgctxt "command-option-choice"
-msgid "TCG"
-msgstr ""
-
-#: src\commands\metagame.ts:220
-#: src\commands\metagame.ts:255
-msgctxt "command-option-choice"
-msgid "OCG"
-msgstr ""
-
-#: src\commands\metagame.ts:221
-#: src\commands\metagame.ts:259
-msgctxt "command-option-choice"
-msgid "OCG (Asian-English)"
-msgstr ""
-
-#: src\commands\metagame.ts:228
-msgctxt "command-option-choice"
-msgid "Master Duel Diamond+ tier list"
-msgstr ""
-
-#: src\commands\metagame.ts:261
-msgctxt "command-option-choice"
-msgid "Master Duel ranked ladder"
-msgstr ""
-
-#: src\commands\metagame.ts:283
-msgctxt "command-option-choice"
-msgid "Current format"
-msgstr ""
-
-#: src\commands\metagame.ts:287
-msgctxt "command-option-choice"
-msgid "Since last Forbidden/Limited List"
-msgstr ""
-
-#: src\commands\metagame.ts:291
-msgctxt "command-option-choice"
-msgid "Last 7 days"
-msgstr ""
-
-#: src\commands\metagame.ts:295
-msgctxt "command-option-choice"
-msgid "Last 14 days"
-msgstr ""
-
-#: src\commands\metagame.ts:299
-msgctxt "command-option-choice"
-msgid "Last 30 days"
-msgstr ""
-
-#: src\commands\metagame.ts:303
-msgctxt "command-option-choice"
-msgid "Last three months"
-msgstr ""
-
-#: src\commands\metagame.ts:307
-msgctxt "command-option-choice"
-msgid "Last six months"
-msgstr ""

--- a/translations/ja.po
+++ b/translations/ja.po
@@ -6,50 +6,33 @@ msgstr ""
 "MIME-Version: 1.0\n"
 "Content-Transfer-Encoding: 8bit\n"
 
-#: src\card.ts:416
-#: src\rush-duel.ts:39
+#: src\card.ts:412
+#: src\rush-duel.ts:48
 msgid "🔗 Links"
 msgstr "🔗 リンク集"
 
-#: src\card.ts:417
+#: src\card.ts:413
 #, javascript-format
 msgid "[Official Konami DB](${ official }) | [OCG Rulings](${ rulings }) | [Yugipedia](${ yugipedia }) | [YGOPRODECK](${ ygoprodeck })"
 msgstr "[Konami公式カードDB](${ official }) | [OCG公式裁定](${ rulings }) | [Yugipedia](${ yugipedia }) | [YGOPRODECK](${ ygoprodeck })"
 
-#: src\card.ts:420
+#: src\card.ts:416
 #, javascript-format
 msgid "[Yugipedia](${ yugipedia }) | [YGOPRODECK](${ ygoprodeck })"
 msgstr ""
 
-#: src\card.ts:489
-#: src\rush-duel.ts:92
+#: src\card.ts:490
+#: src\rush-duel.ts:103
 #, javascript-format
 msgid "**Type**: ${ raceIcon } ${ localizedMonsterTypeLine }"
 msgstr "**種族**: ${ raceIcon } ${ localizedMonsterTypeLine }"
 
-#: src\card.ts:491
-#: src\rush-duel.ts:94
-#, javascript-format
-msgid "**Attribute**: ${ AttributeIcon[card.attribute] } ${ localizedAttribute }"
-msgstr "**属性**: ${ AttributeIcon[card.attribute] } ${ localizedAttribute }"
-
-#: src\card.ts:495
-#, javascript-format
-msgid "**Rank**: ${ Icon.Rank } ${ card.rank } **ATK**: ${ card.atk } **DEF**: ${ card.def }"
-msgstr "**ランク**: ${ Icon.Rank } ${ card.rank } **攻撃力**: ${ card.atk } **守備力**: ${ card.def }"
-
-#: src\card.ts:498
+#: src\card.ts:500
 #, javascript-format
 msgid "**Link Rating**: ${ card.link_arrows.length } **ATK**: ${ card.atk } **Link Arrows**: ${ arrows }"
 msgstr "**リンクの数字分**: ${ card.link_arrows.length } **攻撃力**: ${ card.atk } **リンクマーカー**: ${ arrows }"
 
-#: src\card.ts:500
-#: src\rush-duel.ts:96
-#, javascript-format
-msgid "**Level**: ${ Icon.Level } ${ card.level } **ATK**: ${ card.atk } **DEF**: ${ card.def }"
-msgstr "**レベル**: ${ Icon.Level } ${ card.level } **攻撃力**: ${ card.atk } **守備力**: ${ card.def }"
-
-#: src\card.ts:507
+#: src\card.ts:511
 #, javascript-format
 msgid "**Pendulum Scale**: ${ formattedScale }"
 msgstr "**ペンデュラムスケール**: ${ formattedScale }"
@@ -70,7 +53,7 @@ msgid "Password: ${ card.password } | Not yet released"
 msgstr "パスワード: ${ card.password } | 未発売"
 
 #: src\card.ts:351
-#: src\rush-duel.ts:146
+#: src\rush-duel.ts:158
 msgid "Not yet released"
 msgstr "未発売"
 
@@ -79,64 +62,64 @@ msgstr "未発売"
 msgid "Placeholder ID: ${ card.fake_password }"
 msgstr ""
 
-#: src\utils.ts:41
+#: src\utils.ts:44
 msgid "🛠️ This command is in development."
 msgstr "🛠️ このコマンドは作成中です。"
 
-#: src\utils.ts:42
+#: src\utils.ts:45
 msgid "📨 Please send feedback to [our issue tracker](https://github.com/DawnbrandBots/bastion-bot) or the [support server](https://discord.gg/4aFuPyuE96)!"
 msgstr "📨 このボットへのご意見を[イシュートラッカー](https://github.com/DawnbrandBots/bastion-bot) か [ディスコードサーバ](https://discord.gg/4aFuPyuE96) に届けてもらえると嬉しいです！"
 
-#: src\utils.ts:53
+#: src\utils.ts:56
 msgid "Please consider supporting us!"
 msgstr "このボットの開発をサポートしてくれると嬉しいです！"
 
-#: src\utils.ts:54
+#: src\utils.ts:57
 msgid "Help keep Bastion online!"
 msgstr "Bastionが稼働し続けられるようにしましょう！"
 
-#: src\utils.ts:55
+#: src\utils.ts:58
 msgid "Please help keep Bastion online!"
 msgstr "Bastionが稼働し続けられるのはみなさんのおかけです！"
 
-#: src\utils.ts:56
+#: src\utils.ts:59
 msgid "Was Bastion helpful? Consider supporting us!"
 msgstr "Bastionがお好き？一緒に開発すればもっと好きになりますよ！"
 
-#: src\utils.ts:57
+#: src\utils.ts:60
 msgid "Was Bastion helpful? We need your support!"
 msgstr "Bastionがお好き？一緒に開発しませんか？"
 
-#: src\utils.ts:58
+#: src\utils.ts:61
 msgid "Did you find Bastion useful? Consider supporting us!"
 msgstr "Bastionがお役に立ちましたか？このボットの開発をサポートしてくれると嬉しいです！"
 
-#: src\utils.ts:59
+#: src\utils.ts:62
 msgid "Did you find Bastion useful? Help keep it online!"
 msgstr "Bastionがお役に立ちましたか？Bastionが稼働し続けられるようにしましょう！"
 
-#: src\utils.ts:60
+#: src\utils.ts:63
 msgid "Did you find Bastion useful? We need your support!"
 msgstr "Bastionがお役に立ちましたか？一緒に開発しませんか？"
 
-#: src\utils.ts:61
+#: src\utils.ts:64
 msgid "Enjoy Bastion? Help keep it online!"
 msgstr "Bastionがお好き？Bastionが稼働し続けられるようにしましょう！"
 
-#: src\utils.ts:62
+#: src\utils.ts:65
 msgid "Enjoy Bastion? Consider supporting us!"
 msgstr "Bastionがお好き？このボットの開発をサポートしてくれると嬉しいです！"
 
-#: src\utils.ts:63
+#: src\utils.ts:66
 msgid "Found what you were looking for? Consider supporting us!"
 msgstr "お探しの情報は見つかりましたか？このボットの開発をサポートしてくれると嬉しいです！"
 
 #: src\commands\art.ts:63
-#: src\commands\price.ts:131
-#: src\commands\rush-duel.ts:172
-#: src\commands\rush-duel.ts:203
+#: src\commands\price.ts:132
+#: src\commands\rush-duel.ts:171
+#: src\commands\rush-duel.ts:202
 #: src\commands\search.ts:64
-#: src\events\message-search.ts:258
+#: src\events\message-search.ts:265
 #, javascript-format
 msgid "Could not find a card matching `${ input }`!"
 msgstr "`${ input }`に一致するカードは見つかりませんでした！"
@@ -147,47 +130,47 @@ msgstr "`${ input }`に一致するカードは見つかりませんでした！
 msgid "Could not find art for `${ name }`!"
 msgstr "`${ name }`のカード画像は見つかりませんでした！"
 
-#: src\commands\deck.ts:244
+#: src\commands\deck.ts:205
 #, javascript-format
 msgid "${ counts.Monster } Monster"
 msgid_plural "${ counts.Monster } Monsters"
 msgstr[0] "モンスター ${ counts.Monster } 体"
 
-#: src\commands\deck.ts:247
+#: src\commands\deck.ts:208
 #, javascript-format
 msgid "${ counts.Spell } Spell"
 msgid_plural "${ counts.Spell } Spells"
 msgstr[0] "魔法 ${ counts.Spell } 枚"
 
-#: src\commands\deck.ts:250
+#: src\commands\deck.ts:211
 #, javascript-format
 msgid "${ counts.Trap } Trap"
 msgid_plural "${ counts.Trap } Traps"
 msgstr[0] "罠 ${ counts.Trap } 枚"
 
-#: src\commands\deck.ts:278
+#: src\commands\deck.ts:239
 msgid "Your Deck"
 msgstr "あなたのデッキ"
 
-#: src\commands\deck.ts:283
+#: src\commands\deck.ts:244
 #, javascript-format
 msgid "Main Deck (${ deck.main.length } card — ${ countDetail })"
 msgid_plural "Main Deck (${ deck.main.length } cards — ${ countDetail })"
 msgstr[0] "メインデッキ (${ deck.main.length } 枚 — ${ countDetail })"
 
-#: src\commands\deck.ts:290
+#: src\commands\deck.ts:251
 msgid "Main Deck (continued)"
 msgstr "メインデッキ（続き）"
 
-#: src\commands\deck.ts:304
+#: src\commands\deck.ts:265
 msgid "Extra Deck (continued)"
 msgstr "エクストラデッキ（続き）"
 
-#: src\commands\deck.ts:318
+#: src\commands\deck.ts:279
 msgid "Side Deck (continued)"
 msgstr "サイドデッキ（続き）"
 
-#: src\commands\deck.ts:407
+#: src\commands\deck.ts:347
 msgid "Error: Your deck is empty."
 msgstr "エラー: デッキが空です。"
 
@@ -207,11 +190,7 @@ msgstr "このサーバへの上書き言語設定: ${ guildOverride }"
 msgid "Discord Community locale for this server: ${ interaction.guildLocale }"
 msgstr "このサーバのディスコードコミュニティの言語設定: ${ interaction.guildLocale }"
 
-#: src\commands\locale.ts:89
-#, javascript-format
-msgid "Locale override for this direct message: ${ override }"
-msgstr "このダイレクトメッセージへの上書き言語設定: ${ override }"
-
+#: src\commands\locale-user.ts:76
 #: src\commands\locale.ts:92
 #, javascript-format
 msgid "Your Discord locale: ${ interaction.locale }"
@@ -249,24 +228,14 @@ msgstr "コミュニティサーバのサーバーでのデフォルト設定は
 msgid "Sorry, you must have the Manage Server permission to do this. If you think this is an error, contact your server admin or report a bug."
 msgstr "申し訳ありませんが、「サーバ管理」の権限が必要です。これがバグと考えられる場合は、サーバの管理者へ報告頂くか、バグ報告をして頂ければと思います。"
 
-#: src\commands\locale.ts:146
-#, javascript-format
-msgid "Locale for this direct message overridden with ${ locale }. Your Discord setting is ${ interaction.locale }."
-msgstr "このダイレクトメッセージの言語設定は ${ locale } にて上書きされました。あなたのディスコードの設定は ${ interaction.locale } です。"
-
-#: src\commands\locale.ts:150
-#, javascript-format
-msgid "Locale for this direct message reset to Discord default. Your Discord setting is ${ interaction.locale }."
-msgstr "このダイレクトメッセージの言語設定はあなたのディスコードのデフォルトへとリセットされました。あなたのディスコードの設定は ${ interaction.locale } です。"
-
-#: src\commands\ping.ts:36
-#: src\events\message-ping.ts:47
+#: src\commands\ping.ts:38
+#: src\events\message-ping.ts:45
 #, javascript-format
 msgid "Average WebSocket ping (new instance): ${ ping } ms"
 msgstr "平均 WebSocket ping（新インスタンス）: ${ ping } ms"
 
-#: src\commands\ping.ts:40
-#: src\events\message-ping.ts:112
+#: src\commands\ping.ts:42
+#: src\events\message-ping.ts:110
 #, javascript-format
 msgid "Total latency: ${ latency } ms"
 msgstr "総レイテンシー: ${ latency } ms"
@@ -276,86 +245,69 @@ msgstr "総レイテンシー: ${ latency } ms"
 msgid "Could not find a Yugipedia page named `${ page }`."
 msgstr "`${ page }` という名前のYugipediaのページが見つかりませんでした。"
 
-#: src\events\message-ping.ts:49
+#: src\events\message-ping.ts:47
 msgid "Free and open source _Yu-Gi-Oh!_ bot"
 msgstr "自由でオープンソースな _Yu-Gi-Oh!_ ボット"
 
-#: src\events\message-ping.ts:72
+#: src\events\message-ping.ts:70
 #, javascript-format
 msgid "Revision: ${ process.env.BOT_REVISION }."
 msgstr "リビジョン: ${ process.env.BOT_REVISION }."
 
-#: src\commands\deck.ts:328
+#: src\commands\deck.ts:289
 msgid ".ydk files must have the .ydk extension!"
 msgstr ".ydkファイルには.ydkの拡張子が必要です！"
 
-#: src\commands\deck.ts:331
+#: src\commands\deck.ts:292
 msgid ".ydk files should not be larger than 1 KB!"
 msgstr ".ydkファイルを 1 KB よりも大きくしないでください！"
 
-#: src\commands\deck.ts:321
+#: src\commands\deck.ts:282
 msgid "ydke URL"
 msgstr "ydkeのURL"
 
 #: src\card.ts:455
-#: src\rush-duel.ts:61
+#: src\rush-duel.ts:75
 #. Forbidden/Limited Lists or Limit Regulations in the OCG
 #, javascript-format
 msgid "**Limit**: ${ limitRegulationDisplay }"
 msgstr "**リミットレギュレーション**: ${ limitRegulationDisplay }"
 
-#: src\commands\price.ts:69
+#: src\commands\price.ts:70
 msgid "TCGPlayer"
 msgstr ""
 
-#: src\commands\price.ts:70
+#: src\commands\price.ts:71
 msgid "Cardmarket"
 msgstr ""
 
-#: src\commands\price.ts:147
+#: src\commands\price.ts:148
 msgid "No market price"
 msgstr "市場価格不明"
 
-#: src\commands\price.ts:155
+#: src\commands\price.ts:156
 #, javascript-format
 msgid "Prices for ${ card.name[resultLanguage] } - ${ vendorName }"
 msgstr "${ vendorName } の ${ card.name[resultLanguage] } の値段"
 
-#: src\commands\price.ts:169
+#: src\commands\price.ts:170
 #, javascript-format
 msgid "Could not find prices for `${ name }`!"
 msgstr "`${ name }` の値段を見つけられませんでした！"
 
-#: src\commands\deck.ts:425
-#. prepare interaction button for FTP upload
+#: src\commands\deck.ts:363
 msgid "Upload to YGOPRODECK"
 msgstr "YGOPRODECKにアップロード"
 
-#: src\commands\deck.ts:483
-#. disable original button
-#. prepare row to disable button on original message
-msgid "Upload Complete"
-msgstr "アップロード完了"
-
-#: src\commands\deck.ts:470
-msgid "Deck upload failed!"
-msgstr "デッキのアップロードに失敗しました！"
-
-#: src\commands\deck.ts:491
-#. reply in affirmation
-#, javascript-format
-msgid "Deck successfully uploaded to <${ url }>!"
-msgstr "<${ url }>にデッキのアップロードを完了しました！"
-
-#: src\events\message-search.ts:264
+#: src\events\message-search.ts:271
 msgid "💬 Translations missing?"
 msgstr "💬 翻訳が存在しませんか？"
 
-#: src\events\message-search.ts:265
+#: src\events\message-search.ts:272
 msgid "Help translate Bastion at the links above."
 msgstr "このボットの翻訳プロジェクトへは上のリンクから。"
 
-#: src\events\message-ping.ts:50
+#: src\events\message-ping.ts:48
 msgid ""
 "❓ Help documentation on [GitHub](https://github.com/DawnbrandBots/bastion-bot), or use `.commands` and `.help`.\n"
 "🟢 Licence: [GNU AGPL 3.0+](https://choosealicense.com/licenses/agpl-3.0/).\n"
@@ -383,37 +335,37 @@ msgstr ""
 "\n"
 "💬 翻訳がされていない場所がありますか? [GitHub](https://github.com/DawnbrandBots/bastion-bot)で翻訳を手伝ってくれると嬉しいです！"
 
-#: src\events\message-search.ts:256
-#: src\events\message-search.ts:294
+#: src\events\message-search.ts:263
+#: src\events\message-search.ts:302
 #, javascript-format
 msgid "Search type: ${ localisedType }"
 msgstr "検索タイプ: ${ localisedType }"
 
-#: src\events\message-search.ts:236
+#: src\events\message-search.ts:242
 #, javascript-format
 msgid "Search language: **${ localisedInputLanguage }** (${ inputLanguage }). Check defaults with </locale get:${ id }> and configure with </locale set:${ id }>"
 msgstr "検索言語: **${ localisedInputLanguage }** (${ inputLanguage })。</locale get:${ id }>で言語設定のデフォルトを確認し、</locale set:${ id }>で設定できます。"
 
-#: src\events\message-ping.ts:95
+#: src\events\message-ping.ts:93
 msgid "⚠️ You pinged me, but I am missing permissions in the channel!"
 msgstr "⚠️ Pingをもらいましたが、そのチャンネルにはこのボットに権限がありません！"
 
-#: src\events\message-ping.ts:98
-#: src\events\message-search.ts:332
+#: src\events\message-ping.ts:96
+#: src\events\message-search.ts:340
 msgid "Please have a server administrator [fix this](https://github.com/DawnbrandBots/bastion-bot#discord-permissions)."
 msgstr "サーバ管理者の方に[この問題](https://github.com/DawnbrandBots/bastion-bot#discord-permissions)の対応をお願いいたします。"
 
-#: src\events\message-search.ts:329
+#: src\events\message-search.ts:337
 msgid "⚠️ I am missing permissions in the channel!"
 msgstr "⚠️ そのチャンネルではこのボットに権限がありません！"
 
-#: src\commands\deck.ts:297
+#: src\commands\deck.ts:258
 #, javascript-format
 msgid "Extra Deck (${ deck.extra.length } card — ${ countDetail })"
 msgid_plural "Extra Deck (${ deck.extra.length } cards — ${ countDetail })"
 msgstr[0] "エクストラデッキ (${ deck.extra.length } 枚 — ${ countDetail })"
 
-#: src\commands\deck.ts:311
+#: src\commands\deck.ts:272
 #, javascript-format
 msgid "Side Deck (${ deck.side.length } card — ${ countDetail })"
 msgid_plural "Side Deck (${ deck.side.length } cards — ${ countDetail })"
@@ -434,48 +386,82 @@ msgstr "`${ searchTerm }`でYGOPRODECKを検索中に何かエラーが起こっ
 msgid "Something went wrong searching Yugipedia for `${ page }`."
 msgstr "`${ page }`でYugipediaを検索中に何かエラーが起こったようです。"
 
-#: src\rush-duel.ts:40
+#: src\rush-duel.ts:49
 #, javascript-format
 msgid "[Official Konami DB](${ official }) | [Rulings (Japanese)](${ rulings }) | [Yugipedia](${ yugipedia }) | [RushCard](${ rushcard })"
 msgstr "[Konami公式カードDB](${ official }) | [公式裁定](${ rulings }) | [Yugipedia](${ yugipedia }) | [RushCard](${ rushcard })"
 
-#: src\rush-duel.ts:43
+#: src\rush-duel.ts:52
 #, javascript-format
 msgid "[Yugipedia](${ yugipedia }) | [RushCard](${ rushcard })"
 msgstr ""
 
-#: src\rush-duel.ts:57
+#: src\rush-duel.ts:71
 msgid "__**LEGEND**__"
 msgstr "__**レジェンド**__"
 
-#: src\rush-duel.ts:99
+#: src\rush-duel.ts:110
 #, javascript-format
 msgid "**MAXIMUM ATK**: ${ card.maximum_atk }"
 msgstr ""
 
-#: src\rush-duel.ts:146
+#: src\rush-duel.ts:158
 #, javascript-format
 msgid "Konami ID #${ card.konami_id }"
 msgstr ""
 
 #: src\art.ts:129
-#: src\commands\deck.ts:451
 msgid "Buttons can only be used by the user who called Bastion."
 msgstr "ボタンはBastionにコマンドを送ったユーザーのみに有効です。"
 
-#: src\card.ts:462
-#, javascript-format
-msgid "**Master Duel rarity**: ${ rarity_icon } ${ localized_rarity }"
-msgstr "**マスターデュエルレアリティ**: ${ rarity_icon } ${ localized_rarity }"
-
-#: src\rush-duel.ts:205
+#: src\rush-duel.ts:217
 #, javascript-format
 msgid "Using ${ searchTrigger }, you can search for Rush Duel cards directly in messages without autocomplete"
 msgstr ""
 
-#: src\events\message-search.ts:296
+#: src\events\message-search.ts:304
 #, javascript-format
 msgid "Could not find a Rush Duel card matching `${ input }`!"
+msgstr ""
+
+#: src\card.ts:462
+#, javascript-format
+msgid "**Master Duel rarity**: ${ rarityIcon } ${ localizedRarity }"
+msgstr ""
+
+#: src\card.ts:492
+#: src\rush-duel.ts:105
+#, javascript-format
+msgid "**Attribute**: ${ attributeIcon } ${ localizedAttribute }"
+msgstr ""
+
+#: src\card.ts:497
+#, javascript-format
+msgid "**Rank**: ${ rankIcon } ${ card.rank } **ATK**: ${ card.atk } **DEF**: ${ card.def }"
+msgstr ""
+
+#: src\card.ts:503
+#: src\rush-duel.ts:107
+#, javascript-format
+msgid "**Level**: ${ levelIcon } ${ card.level } **ATK**: ${ card.atk } **DEF**: ${ card.def }"
+msgstr ""
+
+#: src\commands\locale-user.ts:73
+#: src\commands\locale.ts:89
+#, javascript-format
+msgid "Locale override for your direct messages: ${ override }"
+msgstr ""
+
+#: src\commands\locale-user.ts:83
+#: src\commands\locale.ts:146
+#, javascript-format
+msgid "Locale for your direct messages overridden with ${ locale }. Your Discord setting is ${ interaction.locale }."
+msgstr ""
+
+#: src\commands\locale-user.ts:87
+#: src\commands\locale.ts:150
+#, javascript-format
+msgid "Locale for your direct messages reset to Discord default. Your Discord setting is ${ interaction.locale }."
 msgstr ""
 
 #: src\card.ts:40
@@ -842,65 +828,65 @@ msgctxt "master-duel-rarity"
 msgid "Ultra Rare (UR)"
 msgstr "ウルトラレア（ＵＲ）"
 
-#: src\card.ts:513
-#: src\card.ts:524
-#: src\rush-duel.ts:127
+#: src\card.ts:517
+#: src\card.ts:528
+#: src\rush-duel.ts:138
 msgctxt "card-embed"
 msgid "Card Text"
 msgstr "カードテキスト"
 
-#: src\card.ts:518
+#: src\card.ts:522
 msgctxt "card-embed"
 msgid "Pendulum Effect"
 msgstr "ペンデュラム効果"
 
-#: src\card.ts:539
+#: src\card.ts:545
 msgctxt "card-embed"
 msgid "Card Effect"
 msgstr "カード効果"
 
-#: src\rush-duel.ts:118
-#: src\rush-duel.ts:139
+#: src\rush-duel.ts:129
+#: src\rush-duel.ts:151
 msgctxt "card-embed"
 msgid "[REQUIREMENT]"
 msgstr "【条件】"
 
-#: src\rush-duel.ts:119
-#: src\rush-duel.ts:140
+#: src\rush-duel.ts:130
+#: src\rush-duel.ts:152
 msgctxt "card-embed"
 msgid "[EFFECT]"
 msgstr "【効果】"
 
-#: src\rush-duel.ts:121
+#: src\rush-duel.ts:132
 msgctxt "card-embed"
 msgid "[CONTINUOUS EFFECT]"
 msgstr "【永続効果】"
 
-#: src\rush-duel.ts:123
+#: src\rush-duel.ts:134
 msgctxt "card-embed"
 msgid "[MULTI-CHOICE EFFECT]"
 msgstr "【選択効果】"
 
-#: src\locale.ts:71
+#: src\locale.ts:74
 msgctxt "command-option"
 msgid "result-language"
 msgstr "出力用言語"
 
-#: src\locale.ts:131
+#: src\locale.ts:140
 msgctxt "command-option"
 msgid "input-language"
 msgstr "入力用言語"
 
-#: src\commands\rush-duel.ts:68
-#: src\commands\rush-duel.ts:80
-#: src\locale.ts:147
-#: src\locale.ts:165
-#: src\locale.ts:181
+#: src\commands\rush-duel.ts:67
+#: src\commands\rush-duel.ts:79
+#: src\locale.ts:156
+#: src\locale.ts:174
+#: src\locale.ts:190
 msgctxt "command-option"
 msgid "input"
 msgstr "入力"
 
-#: src\commands\help.ts:52
+#: src\commands\help.ts:55
 msgctxt "command-option"
 msgid "command"
 msgstr "コマンド"
@@ -915,54 +901,56 @@ msgctxt "command-option"
 msgid "page"
 msgstr "ページ"
 
-#: src\commands\deck.ts:126
+#: src\commands\deck.ts:87
 msgctxt "command-option"
 msgid "url"
 msgstr ""
 
-#: src\commands\deck.ts:132
+#: src\commands\deck.ts:93
 msgctxt "command-option"
 msgid "file"
 msgstr "ファイル"
 
-#: src\commands\deck.ts:138
-#: src\commands\deck.ts:144
+#: src\commands\deck.ts:99
+#: src\commands\deck.ts:105
 msgctxt "command-option"
 msgid "deck"
 msgstr "デッキ"
 
-#: src\commands\deck.ts:150
+#: src\commands\deck.ts:111
 msgctxt "command-option"
 msgid "public"
 msgstr "チャンネルに公開"
 
-#: src\commands\deck.ts:157
+#: src\commands\deck.ts:118
 msgctxt "command-option"
 msgid "stacked"
 msgstr "一行表示"
 
-#: src\locale.ts:142
+#: src\locale.ts:151
 msgctxt "command-option"
 msgid "name"
 msgstr "カード名"
 
-#: src\locale.ts:160
+#: src\locale.ts:169
 msgctxt "command-option"
 msgid "password"
 msgstr "パスワード"
 
-#: src\commands\rush-duel.ts:73
-#: src\events\message-search.ts:293
-#: src\locale.ts:176
+#: src\commands\rush-duel.ts:72
+#: src\events\message-search.ts:301
+#: src\locale.ts:185
 msgctxt "command-option"
 msgid "konami-id"
 msgstr "コナミid"
 
+#: src\commands\locale-user.ts:36
 #: src\commands\locale.ts:30
 msgctxt "command-option"
 msgid "get"
 msgstr "確認する"
 
+#: src\commands\locale-user.ts:41
 #: src\commands\locale.ts:35
 msgctxt "command-option"
 msgid "set"
@@ -973,47 +961,69 @@ msgctxt "command-option"
 msgid "scope"
 msgstr "適用範囲"
 
+#: src\commands\locale-user.ts:46
 #: src\commands\locale.ts:48
 msgctxt "command-option"
 msgid "locale"
 msgstr "使用言語"
 
-#: src\commands\price.ts:94
+#: src\commands\price.ts:95
 msgctxt "command-option"
 msgid "vendor"
 msgstr "販売店"
 
-#: src\commands\rush-duel.ts:63
+#: src\commands\rush-duel.ts:62
 msgctxt "command-option"
 msgid "search"
 msgstr "検索"
 
-#: src\commands\rush-duel.ts:85
+#: src\commands\rush-duel.ts:84
 msgctxt "command-option"
 msgid "random"
 msgstr "おみくじ"
 
-#: src\commands\rush-duel.ts:90
+#: src\commands\rush-duel.ts:89
 msgctxt "command-option"
 msgid "art"
 msgstr "イラスト"
 
-#: src\commands\query.ts:36
+#: src\commands\query.ts:35
 msgctxt "command-option"
 msgid "lucene"
 msgstr ""
 
-#: src\locale.ts:74
+#: src\commands\metagame.ts:209
+msgctxt "command-option"
+msgid "strategies"
+msgstr ""
+
+#: src\commands\metagame.ts:234
+#: src\commands\metagame.ts:274
+msgctxt "command-option"
+msgid "format"
+msgstr ""
+
+#: src\commands\metagame.ts:240
+msgctxt "command-option"
+msgid "cards"
+msgstr ""
+
+#: src\commands\metagame.ts:310
+msgctxt "command-option"
+msgid "date-range"
+msgstr ""
+
+#: src\locale.ts:77
 msgctxt "command-option-description"
 msgid "The output language for the card embed, overriding other settings."
 msgstr "カード情報の表示言語を設定します。デフォルトの設定より優先されます。"
 
-#: src\locale.ts:132
+#: src\locale.ts:141
 msgctxt "command-option-description"
 msgid "The language to search in, defaulting to the result language."
 msgstr "検索ワードが何語かを指定できます。デフォルトの設定は出力言語と同じです。"
 
-#: src\commands\help.ts:55
+#: src\commands\help.ts:58
 msgctxt "command-option-description"
 msgid "The name of a specific Slash Command."
 msgstr "使い方を表示したいスラッシュコマンドの名前"
@@ -1023,32 +1033,32 @@ msgctxt "command-option-description"
 msgid "The name of the Yugipedia page you want to search for."
 msgstr "検索したいYugipediaのページの名前"
 
-#: src\commands\deck.ts:129
+#: src\commands\deck.ts:90
 msgctxt "command-option-description"
 msgid "View a deck by entering a ydke:// URL."
 msgstr "ydke://形式のURLを入力すると、そのデッキ内容を表示します。"
 
-#: src\commands\deck.ts:135
+#: src\commands\deck.ts:96
 msgctxt "command-option-description"
 msgid "View a deck by uploading a .ydk file."
 msgstr ".ydk形式のファイルをアップロードすると、そのデッキ内容を表示します。"
 
-#: src\commands\deck.ts:141
+#: src\commands\deck.ts:102
 msgctxt "command-option-description"
 msgid "The ydke:// URL of the deck you want to view."
 msgstr "デッキ内容を表示したいydke://形式のURL"
 
-#: src\commands\deck.ts:147
+#: src\commands\deck.ts:108
 msgctxt "command-option-description"
 msgid "The .ydk file of the deck you want to view."
 msgstr "デッキ内容を表示したい.ydk形式のファイル"
 
-#: src\commands\deck.ts:153
+#: src\commands\deck.ts:114
 msgctxt "command-option-description"
 msgid "Whether to display the deck details publicly in chat. This is false by default."
 msgstr "デッキ内容を自分以外の人にも見せるか否かを設定できます。デフォルトでは他の人には非表示になっています。"
 
-#: src\commands\deck.ts:160
+#: src\commands\deck.ts:121
 msgctxt "command-option-description"
 msgid "Whether to display the deck sections as one stacked column. This is false (side-by-side) by default."
 msgstr "デッキ内容を一行で表示するか否かを設定できます。デフォルトでは左右の二行に分けて表示します。"
@@ -1058,8 +1068,8 @@ msgctxt "command-option-description"
 msgid "Display the art for the card with this name."
 msgstr "この名称のカードのイラストを表示します"
 
-#: src\commands\rush-duel.ts:69
-#: src\locale.ts:148
+#: src\commands\rush-duel.ts:68
+#: src\locale.ts:157
 msgctxt "command-option-description"
 msgid "Card name, fuzzy matching supported."
 msgstr "カード名（あいまい検索に対応しています）"
@@ -1069,7 +1079,7 @@ msgctxt "command-option-description"
 msgid "Display the art for the card with this password."
 msgstr "このパスワードのカードのイラストを表示します"
 
-#: src\locale.ts:167
+#: src\locale.ts:176
 msgctxt "command-option-description"
 msgid "Card password, the eight-digit number printed on the bottom left corner."
 msgstr "カードパスワード（カード左下の8桁の数字）"
@@ -1079,8 +1089,8 @@ msgctxt "command-option-description"
 msgid "Display the art for the card with this official database ID."
 msgstr "このパスワードのカードのイラストを表示します"
 
-#: src\commands\rush-duel.ts:81
-#: src\locale.ts:182
+#: src\commands\rush-duel.ts:80
+#: src\locale.ts:191
 msgctxt "command-option-description"
 msgid "Konami's official card database identifier."
 msgstr "Konami公式カードDBでのカードID"
@@ -1120,22 +1130,22 @@ msgctxt "command-option-description"
 msgid "The new default language to use in this channel or server."
 msgstr "このチャンネルあるいはサーバ全体で使う新しい言語設定"
 
-#: src\commands\price.ts:98
+#: src\commands\price.ts:99
 msgctxt "command-option-description"
 msgid "Display the price for the card with this name."
 msgstr "この名称のカードの価格を表示します"
 
-#: src\commands\price.ts:102
+#: src\commands\price.ts:103
 msgctxt "command-option-description"
 msgid "Display the price for the card with this password."
 msgstr "このパスワードのカードの価格を表示します"
 
-#: src\commands\price.ts:105
+#: src\commands\price.ts:106
 msgctxt "command-option-description"
 msgid "Display the price for the card with this official database ID."
 msgstr "この公式カードDBのIDを持つカードの価格を表示します"
 
-#: src\commands\price.ts:95
+#: src\commands\price.ts:96
 msgctxt "command-option-description"
 msgid "The vendor to fetch the price data from."
 msgstr "価格情報の参照先"
@@ -1145,29 +1155,70 @@ msgctxt "command-option-description"
 msgid "The English name of the card you're looking for."
 msgstr "カード名称の英語名"
 
-#: src\commands\rush-duel.ts:64
+#: src\commands\rush-duel.ts:63
 msgctxt "command-option-description"
 msgid "Find all information for the Rush Duel card with this name."
 msgstr "この名称のラッシュデュエルカードの情報を表示します"
 
-#: src\commands\rush-duel.ts:75
+#: src\commands\rush-duel.ts:74
 msgctxt "command-option-description"
 msgid "Find all information for the Rush Duel card with this official database ID."
 msgstr "この公式カードDBのIDを持つラッシュデュエルカードの情報を表示します"
 
-#: src\commands\rush-duel.ts:86
+#: src\commands\rush-duel.ts:85
 msgctxt "command-option-description"
 msgid "Get a random Rush Duel card."
 msgstr "ラッシュデュエル用カードのおみくじ"
 
-#: src\commands\rush-duel.ts:91
+#: src\commands\rush-duel.ts:90
 msgctxt "command-option-description"
 msgid "Display just the art for the Rush Duel card with this name."
 msgstr "ラッシュデュエル用カードのイラストを表示します"
 
-#: src\commands\query.ts:37
+#: src\commands\query.ts:36
 msgctxt "command-option-description"
 msgid "Lucene query on YAML Yugi"
+msgstr ""
+
+#: src\commands\locale-user.ts:37
+msgctxt "command-option-description"
+msgid "Check your user-installed Bastion's locale."
+msgstr ""
+
+#: src\commands\locale-user.ts:42
+msgctxt "command-option-description"
+msgid "Configure your user-installed Bastion's locale."
+msgstr ""
+
+#: src\commands\locale-user.ts:47
+msgctxt "command-option-description"
+msgid "The new default language to use for user-installed Bastion."
+msgstr ""
+
+#: src\commands\metagame.ts:212
+msgctxt "command-option-description"
+msgid "Show the top competitive strategies in tournaments and the Master Duel ranked ladder."
+msgstr ""
+
+#: src\commands\metagame.ts:214
+msgctxt "command-option-description"
+msgid "Show the top competitive strategies in tournaments."
+msgstr ""
+
+#: src\commands\metagame.ts:235
+#: src\commands\metagame.ts:275
+msgctxt "command-option-description"
+msgid "Game region."
+msgstr ""
+
+#: src\commands\metagame.ts:242
+msgctxt "command-option-description"
+msgid "Show the most popular cards in tournaments and the Master Duel ranked ladder."
+msgstr ""
+
+#: src\commands\metagame.ts:312
+msgctxt "command-option-description"
+msgid "Limit card usage statistics to this date range. Has no effect for Master Duel."
 msgstr ""
 
 #: src\commands\art.ts:36
@@ -1175,12 +1226,12 @@ msgctxt "command-name"
 msgid "art"
 msgstr "いらすと"
 
-#: src\commands\help.ts:49
+#: src\commands\help.ts:52
 msgctxt "command-name"
 msgid "help"
 msgstr "つかいかた"
 
-#: src\commands\ping.ts:23
+#: src\commands\ping.ts:25
 msgctxt "command-name"
 msgid "ping"
 msgstr ""
@@ -1195,7 +1246,7 @@ msgctxt "command-name"
 msgid "yugipedia"
 msgstr ""
 
-#: src\commands\deck.ts:119
+#: src\commands\deck.ts:80
 msgctxt "command-name"
 msgid "deck"
 msgstr "でっき"
@@ -1210,24 +1261,34 @@ msgctxt "command-name"
 msgid "locale"
 msgstr "げんごせってい"
 
-#: src\commands\random.ts:44
+#: src\commands\random.ts:43
 msgctxt "command-name"
 msgid "random"
 msgstr "おみくじ"
 
-#: src\commands\price.ts:89
+#: src\commands\price.ts:90
 msgctxt "command-name"
 msgid "price"
 msgstr "かかく"
 
-#: src\commands\rush-duel.ts:58
+#: src\commands\rush-duel.ts:57
 msgctxt "command-name"
 msgid "rush-duel"
 msgstr "らっしゅ"
 
-#: src\commands\query.ts:30
+#: src\commands\query.ts:29
 msgctxt "command-name"
 msgid "query"
+msgstr ""
+
+#: src\commands\locale-user.ts:31
+msgctxt "command-name"
+msgid "locale-user"
+msgstr ""
+
+#: src\commands\metagame.ts:204
+msgctxt "command-name"
+msgid "metagame"
 msgstr ""
 
 #: src\commands\art.ts:37
@@ -1235,12 +1296,12 @@ msgctxt "command-description"
 msgid "Display the art for a card!"
 msgstr "カードの画像（イラスト）を表示します。"
 
-#: src\commands\help.ts:50
+#: src\commands\help.ts:53
 msgctxt "command-description"
 msgid "Get help with a Slash Command."
 msgstr "コマンドの使い方を表示します。"
 
-#: src\commands\ping.ts:24
+#: src\commands\ping.ts:26
 msgctxt "command-description"
 msgid "Test latency to the new bot instance."
 msgstr "ボットが落ちていないかを確認できます（pingの反応を表示します。）"
@@ -1255,7 +1316,7 @@ msgctxt "command-description"
 msgid "Search the Yugipedia wiki for a page and link to it."
 msgstr "Yugipediaを検索します。"
 
-#: src\commands\deck.ts:122
+#: src\commands\deck.ts:83
 msgctxt "command-description"
 msgid "Display a deck list from ydke:// or .ydk format, exported from a number of deck building programs."
 msgstr "ydke:// か .ydk 形式のデッキ情報を表示します。（多くのデッキ構築アプリで使われている形式です。）"
@@ -1270,24 +1331,34 @@ msgctxt "command-description"
 msgid "Check or set Bastion's locale for this channel or server."
 msgstr "このチャンネル（あるいはサーバー）のBastionのロケールを確認（あるいは変更）します。"
 
-#: src\commands\random.ts:45
+#: src\commands\random.ts:44
 msgctxt "command-description"
 msgid "Get a random Yu-Gi-Oh! card."
 msgstr "遊戯王カードをランダムに表示します。"
 
-#: src\commands\price.ts:90
+#: src\commands\price.ts:91
 msgctxt "command-description"
 msgid "Display the price for a card!"
 msgstr "カードの値段を表示します！"
 
-#: src\commands\rush-duel.ts:59
+#: src\commands\rush-duel.ts:58
 msgctxt "command-description"
 msgid "Find information on Rush Duel cards."
 msgstr "ラッシュデュエルのカード情報を探します。"
 
-#: src\commands\query.ts:31
+#: src\commands\query.ts:30
 msgctxt "command-description"
 msgid "Advanced search prototype"
+msgstr ""
+
+#: src\commands\locale-user.ts:32
+msgctxt "command-description"
+msgid "Check or set user-installed Bastion's locale."
+msgstr ""
+
+#: src\commands\metagame.ts:205
+msgctxt "command-description"
+msgid "Show statistics on the current competitive state of play."
 msgstr ""
 
 #: src\commands\locale.ts:43
@@ -1300,7 +1371,71 @@ msgctxt "command-option-choice"
 msgid "server"
 msgstr "サーバー"
 
+#: src\commands\locale-user.ts:49
 #: src\commands\locale.ts:51
 msgctxt "command-option-choice"
 msgid "Discord default"
 msgstr "ディスコードのデフォルト"
+
+#: src\commands\metagame.ts:219
+#: src\commands\metagame.ts:251
+msgctxt "command-option-choice"
+msgid "TCG"
+msgstr ""
+
+#: src\commands\metagame.ts:220
+#: src\commands\metagame.ts:255
+msgctxt "command-option-choice"
+msgid "OCG"
+msgstr ""
+
+#: src\commands\metagame.ts:221
+#: src\commands\metagame.ts:259
+msgctxt "command-option-choice"
+msgid "OCG (Asian-English)"
+msgstr ""
+
+#: src\commands\metagame.ts:228
+msgctxt "command-option-choice"
+msgid "Master Duel Diamond+ tier list"
+msgstr ""
+
+#: src\commands\metagame.ts:261
+msgctxt "command-option-choice"
+msgid "Master Duel ranked ladder"
+msgstr ""
+
+#: src\commands\metagame.ts:283
+msgctxt "command-option-choice"
+msgid "Current format"
+msgstr ""
+
+#: src\commands\metagame.ts:287
+msgctxt "command-option-choice"
+msgid "Since last Forbidden/Limited List"
+msgstr ""
+
+#: src\commands\metagame.ts:291
+msgctxt "command-option-choice"
+msgid "Last 7 days"
+msgstr ""
+
+#: src\commands\metagame.ts:295
+msgctxt "command-option-choice"
+msgid "Last 14 days"
+msgstr ""
+
+#: src\commands\metagame.ts:299
+msgctxt "command-option-choice"
+msgid "Last 30 days"
+msgstr ""
+
+#: src\commands\metagame.ts:303
+msgctxt "command-option-choice"
+msgid "Last three months"
+msgstr ""
+
+#: src\commands\metagame.ts:307
+msgctxt "command-option-choice"
+msgid "Last six months"
+msgstr ""

--- a/translations/ja.po
+++ b/translations/ja.po
@@ -30,13 +30,13 @@ msgstr "**種族**: ${ raceIcon } ${ localizedMonsterTypeLine }"
 #: src\card.ts:491
 #: src\rush-duel.ts:94
 #, javascript-format
-msgid "**Attribute**: ${ AttributeIcon[card.attribute] } ${ localizedAttribute }"
-msgstr "**属性**: ${ AttributeIcon[card.attribute] } ${ localizedAttribute }"
+msgid "**Attribute**: ${ attributeIcon } ${ localizedAttribute }"
+msgstr "**属性**: ${ attributeIcon } ${ localizedAttribute }"
 
 #: src\card.ts:495
 #, javascript-format
-msgid "**Rank**: ${ Icon.Rank } ${ card.rank } **ATK**: ${ card.atk } **DEF**: ${ card.def }"
-msgstr "**ランク**: ${ Icon.Rank } ${ card.rank } **攻撃力**: ${ card.atk } **守備力**: ${ card.def }"
+msgid "**Rank**: ${ rankIcon } ${ card.rank } **ATK**: ${ card.atk } **DEF**: ${ card.def }"
+msgstr "**ランク**: ${ rankIcon } ${ card.rank } **攻撃力**: ${ card.atk } **守備力**: ${ card.def }"
 
 #: src\card.ts:498
 #, javascript-format
@@ -46,8 +46,8 @@ msgstr "**リンクの数字分**: ${ card.link_arrows.length } **攻撃力**: $
 #: src\card.ts:500
 #: src\rush-duel.ts:96
 #, javascript-format
-msgid "**Level**: ${ Icon.Level } ${ card.level } **ATK**: ${ card.atk } **DEF**: ${ card.def }"
-msgstr "**レベル**: ${ Icon.Level } ${ card.level } **攻撃力**: ${ card.atk } **守備力**: ${ card.def }"
+msgid "**Level**: ${ levelIcon } ${ card.level } **ATK**: ${ card.atk } **DEF**: ${ card.def }"
+msgstr "**レベル**: ${ levelIcon } ${ card.level } **攻撃力**: ${ card.atk } **守備力**: ${ card.def }"
 
 #: src\card.ts:507
 #, javascript-format
@@ -465,8 +465,8 @@ msgstr "ボタンはBastionにコマンドを送ったユーザーのみに有�
 
 #: src\card.ts:462
 #, javascript-format
-msgid "**Master Duel rarity**: ${ rarity_icon } ${ localized_rarity }"
-msgstr "**マスターデュエルレアリティ**: ${ rarity_icon } ${ localized_rarity }"
+msgid "**Master Duel rarity**: ${ rarityIcon } ${ localizedRarity }"
+msgstr "**マスターデュエルレアリティ**: ${ rarityIcon } ${ localizedRarity }"
 
 #: src\rush-duel.ts:205
 #, javascript-format

--- a/translations/ja.po
+++ b/translations/ja.po
@@ -6,50 +6,50 @@ msgstr ""
 "MIME-Version: 1.0\n"
 "Content-Transfer-Encoding: 8bit\n"
 
-#: src\card.ts:416
-#: src\rush-duel.ts:39
+#: src\card.ts:412
+#: src\rush-duel.ts:48
 msgid "🔗 Links"
 msgstr "🔗 リンク集"
 
-#: src\card.ts:417
+#: src\card.ts:413
 #, javascript-format
 msgid "[Official Konami DB](${ official }) | [OCG Rulings](${ rulings }) | [Yugipedia](${ yugipedia }) | [YGOPRODECK](${ ygoprodeck })"
 msgstr "[Konami公式カードDB](${ official }) | [OCG公式裁定](${ rulings }) | [Yugipedia](${ yugipedia }) | [YGOPRODECK](${ ygoprodeck })"
 
-#: src\card.ts:420
+#: src\card.ts:416
 #, javascript-format
 msgid "[Yugipedia](${ yugipedia }) | [YGOPRODECK](${ ygoprodeck })"
 msgstr ""
 
-#: src\card.ts:489
-#: src\rush-duel.ts:92
+#: src\card.ts:490
+#: src\rush-duel.ts:103
 #, javascript-format
 msgid "**Type**: ${ raceIcon } ${ localizedMonsterTypeLine }"
 msgstr "**種族**: ${ raceIcon } ${ localizedMonsterTypeLine }"
 
-#: src\card.ts:491
-#: src\rush-duel.ts:94
+#: src\card.ts:492
+#: src\rush-duel.ts:105
 #, javascript-format
 msgid "**Attribute**: ${ attributeIcon } ${ localizedAttribute }"
 msgstr "**属性**: ${ attributeIcon } ${ localizedAttribute }"
 
-#: src\card.ts:495
+#: src\card.ts:497
 #, javascript-format
 msgid "**Rank**: ${ rankIcon } ${ card.rank } **ATK**: ${ card.atk } **DEF**: ${ card.def }"
 msgstr "**ランク**: ${ rankIcon } ${ card.rank } **攻撃力**: ${ card.atk } **守備力**: ${ card.def }"
 
-#: src\card.ts:498
+#: src\card.ts:500
 #, javascript-format
 msgid "**Link Rating**: ${ card.link_arrows.length } **ATK**: ${ card.atk } **Link Arrows**: ${ arrows }"
 msgstr "**リンクの数字分**: ${ card.link_arrows.length } **攻撃力**: ${ card.atk } **リンクマーカー**: ${ arrows }"
 
-#: src\card.ts:500
-#: src\rush-duel.ts:96
+#: src\card.ts:503
+#: src\rush-duel.ts:107
 #, javascript-format
 msgid "**Level**: ${ levelIcon } ${ card.level } **ATK**: ${ card.atk } **DEF**: ${ card.def }"
 msgstr "**レベル**: ${ levelIcon } ${ card.level } **攻撃力**: ${ card.atk } **守備力**: ${ card.def }"
 
-#: src\card.ts:507
+#: src\card.ts:511
 #, javascript-format
 msgid "**Pendulum Scale**: ${ formattedScale }"
 msgstr "**ペンデュラムスケール**: ${ formattedScale }"
@@ -70,7 +70,7 @@ msgid "Password: ${ card.password } | Not yet released"
 msgstr "パスワード: ${ card.password } | 未発売"
 
 #: src\card.ts:351
-#: src\rush-duel.ts:146
+#: src\rush-duel.ts:158
 msgid "Not yet released"
 msgstr "未発売"
 
@@ -79,64 +79,64 @@ msgstr "未発売"
 msgid "Placeholder ID: ${ card.fake_password }"
 msgstr ""
 
-#: src\utils.ts:41
+#: src\utils.ts:44
 msgid "🛠️ This command is in development."
 msgstr "🛠️ このコマンドは作成中です。"
 
-#: src\utils.ts:42
+#: src\utils.ts:45
 msgid "📨 Please send feedback to [our issue tracker](https://github.com/DawnbrandBots/bastion-bot) or the [support server](https://discord.gg/4aFuPyuE96)!"
 msgstr "📨 このボットへのご意見を[イシュートラッカー](https://github.com/DawnbrandBots/bastion-bot) か [ディスコードサーバ](https://discord.gg/4aFuPyuE96) に届けてもらえると嬉しいです！"
 
-#: src\utils.ts:53
+#: src\utils.ts:56
 msgid "Please consider supporting us!"
 msgstr "このボットの開発をサポートしてくれると嬉しいです！"
 
-#: src\utils.ts:54
+#: src\utils.ts:57
 msgid "Help keep Bastion online!"
 msgstr "Bastionが稼働し続けられるようにしましょう！"
 
-#: src\utils.ts:55
+#: src\utils.ts:58
 msgid "Please help keep Bastion online!"
 msgstr "Bastionが稼働し続けられるのはみなさんのおかけです！"
 
-#: src\utils.ts:56
+#: src\utils.ts:59
 msgid "Was Bastion helpful? Consider supporting us!"
 msgstr "Bastionがお好き？一緒に開発すればもっと好きになりますよ！"
 
-#: src\utils.ts:57
+#: src\utils.ts:60
 msgid "Was Bastion helpful? We need your support!"
 msgstr "Bastionがお好き？一緒に開発しませんか？"
 
-#: src\utils.ts:58
+#: src\utils.ts:61
 msgid "Did you find Bastion useful? Consider supporting us!"
 msgstr "Bastionがお役に立ちましたか？このボットの開発をサポートしてくれると嬉しいです！"
 
-#: src\utils.ts:59
+#: src\utils.ts:62
 msgid "Did you find Bastion useful? Help keep it online!"
 msgstr "Bastionがお役に立ちましたか？Bastionが稼働し続けられるようにしましょう！"
 
-#: src\utils.ts:60
+#: src\utils.ts:63
 msgid "Did you find Bastion useful? We need your support!"
 msgstr "Bastionがお役に立ちましたか？一緒に開発しませんか？"
 
-#: src\utils.ts:61
+#: src\utils.ts:64
 msgid "Enjoy Bastion? Help keep it online!"
 msgstr "Bastionがお好き？Bastionが稼働し続けられるようにしましょう！"
 
-#: src\utils.ts:62
+#: src\utils.ts:65
 msgid "Enjoy Bastion? Consider supporting us!"
 msgstr "Bastionがお好き？このボットの開発をサポートしてくれると嬉しいです！"
 
-#: src\utils.ts:63
+#: src\utils.ts:66
 msgid "Found what you were looking for? Consider supporting us!"
 msgstr "お探しの情報は見つかりましたか？このボットの開発をサポートしてくれると嬉しいです！"
 
 #: src\commands\art.ts:63
-#: src\commands\price.ts:131
-#: src\commands\rush-duel.ts:172
-#: src\commands\rush-duel.ts:203
+#: src\commands\price.ts:132
+#: src\commands\rush-duel.ts:171
+#: src\commands\rush-duel.ts:202
 #: src\commands\search.ts:64
-#: src\events\message-search.ts:258
+#: src\events\message-search.ts:265
 #, javascript-format
 msgid "Could not find a card matching `${ input }`!"
 msgstr "`${ input }`に一致するカードは見つかりませんでした！"
@@ -147,47 +147,47 @@ msgstr "`${ input }`に一致するカードは見つかりませんでした！
 msgid "Could not find art for `${ name }`!"
 msgstr "`${ name }`のカード画像は見つかりませんでした！"
 
-#: src\commands\deck.ts:244
+#: src\commands\deck.ts:205
 #, javascript-format
 msgid "${ counts.Monster } Monster"
 msgid_plural "${ counts.Monster } Monsters"
 msgstr[0] "モンスター ${ counts.Monster } 体"
 
-#: src\commands\deck.ts:247
+#: src\commands\deck.ts:208
 #, javascript-format
 msgid "${ counts.Spell } Spell"
 msgid_plural "${ counts.Spell } Spells"
 msgstr[0] "魔法 ${ counts.Spell } 枚"
 
-#: src\commands\deck.ts:250
+#: src\commands\deck.ts:211
 #, javascript-format
 msgid "${ counts.Trap } Trap"
 msgid_plural "${ counts.Trap } Traps"
 msgstr[0] "罠 ${ counts.Trap } 枚"
 
-#: src\commands\deck.ts:278
+#: src\commands\deck.ts:239
 msgid "Your Deck"
 msgstr "あなたのデッキ"
 
-#: src\commands\deck.ts:283
+#: src\commands\deck.ts:244
 #, javascript-format
 msgid "Main Deck (${ deck.main.length } card — ${ countDetail })"
 msgid_plural "Main Deck (${ deck.main.length } cards — ${ countDetail })"
 msgstr[0] "メインデッキ (${ deck.main.length } 枚 — ${ countDetail })"
 
-#: src\commands\deck.ts:290
+#: src\commands\deck.ts:251
 msgid "Main Deck (continued)"
 msgstr "メインデッキ（続き）"
 
-#: src\commands\deck.ts:304
+#: src\commands\deck.ts:265
 msgid "Extra Deck (continued)"
 msgstr "エクストラデッキ（続き）"
 
-#: src\commands\deck.ts:318
+#: src\commands\deck.ts:279
 msgid "Side Deck (continued)"
 msgstr "サイドデッキ（続き）"
 
-#: src\commands\deck.ts:407
+#: src\commands\deck.ts:347
 msgid "Error: Your deck is empty."
 msgstr "エラー: デッキが空です。"
 
@@ -207,11 +207,7 @@ msgstr "このサーバへの上書き言語設定: ${ guildOverride }"
 msgid "Discord Community locale for this server: ${ interaction.guildLocale }"
 msgstr "このサーバのディスコードコミュニティの言語設定: ${ interaction.guildLocale }"
 
-#: src\commands\locale.ts:89
-#, javascript-format
-msgid "Locale override for this direct message: ${ override }"
-msgstr "このダイレクトメッセージへの上書き言語設定: ${ override }"
-
+#: src\commands\locale-user.ts:76
 #: src\commands\locale.ts:92
 #, javascript-format
 msgid "Your Discord locale: ${ interaction.locale }"
@@ -249,24 +245,14 @@ msgstr "コミュニティサーバのサーバーでのデフォルト設定は
 msgid "Sorry, you must have the Manage Server permission to do this. If you think this is an error, contact your server admin or report a bug."
 msgstr "申し訳ありませんが、「サーバ管理」の権限が必要です。これがバグと考えられる場合は、サーバの管理者へ報告頂くか、バグ報告をして頂ければと思います。"
 
-#: src\commands\locale.ts:146
-#, javascript-format
-msgid "Locale for this direct message overridden with ${ locale }. Your Discord setting is ${ interaction.locale }."
-msgstr "このダイレクトメッセージの言語設定は ${ locale } にて上書きされました。あなたのディスコードの設定は ${ interaction.locale } です。"
-
-#: src\commands\locale.ts:150
-#, javascript-format
-msgid "Locale for this direct message reset to Discord default. Your Discord setting is ${ interaction.locale }."
-msgstr "このダイレクトメッセージの言語設定はあなたのディスコードのデフォルトへとリセットされました。あなたのディスコードの設定は ${ interaction.locale } です。"
-
-#: src\commands\ping.ts:36
-#: src\events\message-ping.ts:47
+#: src\commands\ping.ts:38
+#: src\events\message-ping.ts:45
 #, javascript-format
 msgid "Average WebSocket ping (new instance): ${ ping } ms"
 msgstr "平均 WebSocket ping（新インスタンス）: ${ ping } ms"
 
-#: src\commands\ping.ts:40
-#: src\events\message-ping.ts:112
+#: src\commands\ping.ts:42
+#: src\events\message-ping.ts:110
 #, javascript-format
 msgid "Total latency: ${ latency } ms"
 msgstr "総レイテンシー: ${ latency } ms"
@@ -276,86 +262,69 @@ msgstr "総レイテンシー: ${ latency } ms"
 msgid "Could not find a Yugipedia page named `${ page }`."
 msgstr "`${ page }` という名前のYugipediaのページが見つかりませんでした。"
 
-#: src\events\message-ping.ts:49
+#: src\events\message-ping.ts:47
 msgid "Free and open source _Yu-Gi-Oh!_ bot"
 msgstr "自由でオープンソースな _Yu-Gi-Oh!_ ボット"
 
-#: src\events\message-ping.ts:72
+#: src\events\message-ping.ts:70
 #, javascript-format
 msgid "Revision: ${ process.env.BOT_REVISION }."
 msgstr "リビジョン: ${ process.env.BOT_REVISION }."
 
-#: src\commands\deck.ts:328
+#: src\commands\deck.ts:289
 msgid ".ydk files must have the .ydk extension!"
 msgstr ".ydkファイルには.ydkの拡張子が必要です！"
 
-#: src\commands\deck.ts:331
+#: src\commands\deck.ts:292
 msgid ".ydk files should not be larger than 1 KB!"
 msgstr ".ydkファイルを 1 KB よりも大きくしないでください！"
 
-#: src\commands\deck.ts:321
+#: src\commands\deck.ts:282
 msgid "ydke URL"
 msgstr "ydkeのURL"
 
 #: src\card.ts:455
-#: src\rush-duel.ts:61
+#: src\rush-duel.ts:75
 #. Forbidden/Limited Lists or Limit Regulations in the OCG
 #, javascript-format
 msgid "**Limit**: ${ limitRegulationDisplay }"
 msgstr "**リミットレギュレーション**: ${ limitRegulationDisplay }"
 
-#: src\commands\price.ts:69
+#: src\commands\price.ts:70
 msgid "TCGPlayer"
 msgstr ""
 
-#: src\commands\price.ts:70
+#: src\commands\price.ts:71
 msgid "Cardmarket"
 msgstr ""
 
-#: src\commands\price.ts:147
+#: src\commands\price.ts:148
 msgid "No market price"
 msgstr "市場価格不明"
 
-#: src\commands\price.ts:155
+#: src\commands\price.ts:156
 #, javascript-format
 msgid "Prices for ${ card.name[resultLanguage] } - ${ vendorName }"
 msgstr "${ vendorName } の ${ card.name[resultLanguage] } の値段"
 
-#: src\commands\price.ts:169
+#: src\commands\price.ts:170
 #, javascript-format
 msgid "Could not find prices for `${ name }`!"
 msgstr "`${ name }` の値段を見つけられませんでした！"
 
-#: src\commands\deck.ts:425
-#. prepare interaction button for FTP upload
+#: src\commands\deck.ts:363
 msgid "Upload to YGOPRODECK"
 msgstr "YGOPRODECKにアップロード"
 
-#: src\commands\deck.ts:483
-#. disable original button
-#. prepare row to disable button on original message
-msgid "Upload Complete"
-msgstr "アップロード完了"
-
-#: src\commands\deck.ts:470
-msgid "Deck upload failed!"
-msgstr "デッキのアップロードに失敗しました！"
-
-#: src\commands\deck.ts:491
-#. reply in affirmation
-#, javascript-format
-msgid "Deck successfully uploaded to <${ url }>!"
-msgstr "<${ url }>にデッキのアップロードを完了しました！"
-
-#: src\events\message-search.ts:264
+#: src\events\message-search.ts:271
 msgid "💬 Translations missing?"
 msgstr "💬 翻訳が存在しませんか？"
 
-#: src\events\message-search.ts:265
+#: src\events\message-search.ts:272
 msgid "Help translate Bastion at the links above."
 msgstr "このボットの翻訳プロジェクトへは上のリンクから。"
 
-#: src\events\message-ping.ts:50
+#: src\events\message-ping.ts:48
 msgid ""
 "❓ Help documentation on [GitHub](https://github.com/DawnbrandBots/bastion-bot), or use `.commands` and `.help`.\n"
 "🟢 Licence: [GNU AGPL 3.0+](https://choosealicense.com/licenses/agpl-3.0/).\n"
@@ -383,37 +352,37 @@ msgstr ""
 "\n"
 "💬 翻訳がされていない場所がありますか? [GitHub](https://github.com/DawnbrandBots/bastion-bot)で翻訳を手伝ってくれると嬉しいです！"
 
-#: src\events\message-search.ts:256
-#: src\events\message-search.ts:294
+#: src\events\message-search.ts:263
+#: src\events\message-search.ts:302
 #, javascript-format
 msgid "Search type: ${ localisedType }"
 msgstr "検索タイプ: ${ localisedType }"
 
-#: src\events\message-search.ts:236
+#: src\events\message-search.ts:242
 #, javascript-format
 msgid "Search language: **${ localisedInputLanguage }** (${ inputLanguage }). Check defaults with </locale get:${ id }> and configure with </locale set:${ id }>"
 msgstr "検索言語: **${ localisedInputLanguage }** (${ inputLanguage })。</locale get:${ id }>で言語設定のデフォルトを確認し、</locale set:${ id }>で設定できます。"
 
-#: src\events\message-ping.ts:95
+#: src\events\message-ping.ts:93
 msgid "⚠️ You pinged me, but I am missing permissions in the channel!"
 msgstr "⚠️ Pingをもらいましたが、そのチャンネルにはこのボットに権限がありません！"
 
-#: src\events\message-ping.ts:98
-#: src\events\message-search.ts:332
+#: src\events\message-ping.ts:96
+#: src\events\message-search.ts:340
 msgid "Please have a server administrator [fix this](https://github.com/DawnbrandBots/bastion-bot#discord-permissions)."
 msgstr "サーバ管理者の方に[この問題](https://github.com/DawnbrandBots/bastion-bot#discord-permissions)の対応をお願いいたします。"
 
-#: src\events\message-search.ts:329
+#: src\events\message-search.ts:337
 msgid "⚠️ I am missing permissions in the channel!"
 msgstr "⚠️ そのチャンネルではこのボットに権限がありません！"
 
-#: src\commands\deck.ts:297
+#: src\commands\deck.ts:258
 #, javascript-format
 msgid "Extra Deck (${ deck.extra.length } card — ${ countDetail })"
 msgid_plural "Extra Deck (${ deck.extra.length } cards — ${ countDetail })"
 msgstr[0] "エクストラデッキ (${ deck.extra.length } 枚 — ${ countDetail })"
 
-#: src\commands\deck.ts:311
+#: src\commands\deck.ts:272
 #, javascript-format
 msgid "Side Deck (${ deck.side.length } card — ${ countDetail })"
 msgid_plural "Side Deck (${ deck.side.length } cards — ${ countDetail })"
@@ -434,32 +403,31 @@ msgstr "`${ searchTerm }`でYGOPRODECKを検索中に何かエラーが起こっ
 msgid "Something went wrong searching Yugipedia for `${ page }`."
 msgstr "`${ page }`でYugipediaを検索中に何かエラーが起こったようです。"
 
-#: src\rush-duel.ts:40
+#: src\rush-duel.ts:49
 #, javascript-format
 msgid "[Official Konami DB](${ official }) | [Rulings (Japanese)](${ rulings }) | [Yugipedia](${ yugipedia }) | [RushCard](${ rushcard })"
 msgstr "[Konami公式カードDB](${ official }) | [公式裁定](${ rulings }) | [Yugipedia](${ yugipedia }) | [RushCard](${ rushcard })"
 
-#: src\rush-duel.ts:43
+#: src\rush-duel.ts:52
 #, javascript-format
 msgid "[Yugipedia](${ yugipedia }) | [RushCard](${ rushcard })"
 msgstr ""
 
-#: src\rush-duel.ts:57
+#: src\rush-duel.ts:71
 msgid "__**LEGEND**__"
 msgstr "__**レジェンド**__"
 
-#: src\rush-duel.ts:99
+#: src\rush-duel.ts:110
 #, javascript-format
 msgid "**MAXIMUM ATK**: ${ card.maximum_atk }"
 msgstr ""
 
-#: src\rush-duel.ts:146
+#: src\rush-duel.ts:158
 #, javascript-format
 msgid "Konami ID #${ card.konami_id }"
 msgstr ""
 
 #: src\art.ts:129
-#: src\commands\deck.ts:451
 msgid "Buttons can only be used by the user who called Bastion."
 msgstr "ボタンはBastionにコマンドを送ったユーザーのみに有効です。"
 
@@ -468,14 +436,32 @@ msgstr "ボタンはBastionにコマンドを送ったユーザーのみに有�
 msgid "**Master Duel rarity**: ${ rarityIcon } ${ localizedRarity }"
 msgstr "**マスターデュエルレアリティ**: ${ rarityIcon } ${ localizedRarity }"
 
-#: src\rush-duel.ts:205
+#: src\rush-duel.ts:217
 #, javascript-format
 msgid "Using ${ searchTrigger }, you can search for Rush Duel cards directly in messages without autocomplete"
 msgstr ""
 
-#: src\events\message-search.ts:296
+#: src\events\message-search.ts:304
 #, javascript-format
 msgid "Could not find a Rush Duel card matching `${ input }`!"
+msgstr ""
+
+#: src\commands\locale-user.ts:73
+#: src\commands\locale.ts:89
+#, javascript-format
+msgid "Locale override for your direct messages: ${ override }"
+msgstr ""
+
+#: src\commands\locale-user.ts:83
+#: src\commands\locale.ts:146
+#, javascript-format
+msgid "Locale for your direct messages overridden with ${ locale }. Your Discord setting is ${ interaction.locale }."
+msgstr ""
+
+#: src\commands\locale-user.ts:87
+#: src\commands\locale.ts:150
+#, javascript-format
+msgid "Locale for your direct messages reset to Discord default. Your Discord setting is ${ interaction.locale }."
 msgstr ""
 
 #: src\card.ts:40
@@ -842,65 +828,65 @@ msgctxt "master-duel-rarity"
 msgid "Ultra Rare (UR)"
 msgstr "ウルトラレア（ＵＲ）"
 
-#: src\card.ts:513
-#: src\card.ts:524
-#: src\rush-duel.ts:127
+#: src\card.ts:517
+#: src\card.ts:528
+#: src\rush-duel.ts:138
 msgctxt "card-embed"
 msgid "Card Text"
 msgstr "カードテキスト"
 
-#: src\card.ts:518
+#: src\card.ts:522
 msgctxt "card-embed"
 msgid "Pendulum Effect"
 msgstr "ペンデュラム効果"
 
-#: src\card.ts:539
+#: src\card.ts:545
 msgctxt "card-embed"
 msgid "Card Effect"
 msgstr "カード効果"
 
-#: src\rush-duel.ts:118
-#: src\rush-duel.ts:139
+#: src\rush-duel.ts:129
+#: src\rush-duel.ts:151
 msgctxt "card-embed"
 msgid "[REQUIREMENT]"
 msgstr "【条件】"
 
-#: src\rush-duel.ts:119
-#: src\rush-duel.ts:140
+#: src\rush-duel.ts:130
+#: src\rush-duel.ts:152
 msgctxt "card-embed"
 msgid "[EFFECT]"
 msgstr "【効果】"
 
-#: src\rush-duel.ts:121
+#: src\rush-duel.ts:132
 msgctxt "card-embed"
 msgid "[CONTINUOUS EFFECT]"
 msgstr "【永続効果】"
 
-#: src\rush-duel.ts:123
+#: src\rush-duel.ts:134
 msgctxt "card-embed"
 msgid "[MULTI-CHOICE EFFECT]"
 msgstr "【選択効果】"
 
-#: src\locale.ts:71
+#: src\locale.ts:74
 msgctxt "command-option"
 msgid "result-language"
 msgstr "出力用言語"
 
-#: src\locale.ts:131
+#: src\locale.ts:140
 msgctxt "command-option"
 msgid "input-language"
 msgstr "入力用言語"
 
-#: src\commands\rush-duel.ts:68
-#: src\commands\rush-duel.ts:80
-#: src\locale.ts:147
-#: src\locale.ts:165
-#: src\locale.ts:181
+#: src\commands\rush-duel.ts:67
+#: src\commands\rush-duel.ts:79
+#: src\locale.ts:156
+#: src\locale.ts:174
+#: src\locale.ts:190
 msgctxt "command-option"
 msgid "input"
 msgstr "入力"
 
-#: src\commands\help.ts:52
+#: src\commands\help.ts:55
 msgctxt "command-option"
 msgid "command"
 msgstr "コマンド"
@@ -915,54 +901,56 @@ msgctxt "command-option"
 msgid "page"
 msgstr "ページ"
 
-#: src\commands\deck.ts:126
+#: src\commands\deck.ts:87
 msgctxt "command-option"
 msgid "url"
 msgstr ""
 
-#: src\commands\deck.ts:132
+#: src\commands\deck.ts:93
 msgctxt "command-option"
 msgid "file"
 msgstr "ファイル"
 
-#: src\commands\deck.ts:138
-#: src\commands\deck.ts:144
+#: src\commands\deck.ts:99
+#: src\commands\deck.ts:105
 msgctxt "command-option"
 msgid "deck"
 msgstr "デッキ"
 
-#: src\commands\deck.ts:150
+#: src\commands\deck.ts:111
 msgctxt "command-option"
 msgid "public"
 msgstr "チャンネルに公開"
 
-#: src\commands\deck.ts:157
+#: src\commands\deck.ts:118
 msgctxt "command-option"
 msgid "stacked"
 msgstr "一行表示"
 
-#: src\locale.ts:142
+#: src\locale.ts:151
 msgctxt "command-option"
 msgid "name"
 msgstr "カード名"
 
-#: src\locale.ts:160
+#: src\locale.ts:169
 msgctxt "command-option"
 msgid "password"
 msgstr "パスワード"
 
-#: src\commands\rush-duel.ts:73
-#: src\events\message-search.ts:293
-#: src\locale.ts:176
+#: src\commands\rush-duel.ts:72
+#: src\events\message-search.ts:301
+#: src\locale.ts:185
 msgctxt "command-option"
 msgid "konami-id"
 msgstr "コナミid"
 
+#: src\commands\locale-user.ts:36
 #: src\commands\locale.ts:30
 msgctxt "command-option"
 msgid "get"
 msgstr "確認する"
 
+#: src\commands\locale-user.ts:41
 #: src\commands\locale.ts:35
 msgctxt "command-option"
 msgid "set"
@@ -973,47 +961,69 @@ msgctxt "command-option"
 msgid "scope"
 msgstr "適用範囲"
 
+#: src\commands\locale-user.ts:46
 #: src\commands\locale.ts:48
 msgctxt "command-option"
 msgid "locale"
 msgstr "使用言語"
 
-#: src\commands\price.ts:94
+#: src\commands\price.ts:95
 msgctxt "command-option"
 msgid "vendor"
 msgstr "販売店"
 
-#: src\commands\rush-duel.ts:63
+#: src\commands\rush-duel.ts:62
 msgctxt "command-option"
 msgid "search"
 msgstr "検索"
 
-#: src\commands\rush-duel.ts:85
+#: src\commands\rush-duel.ts:84
 msgctxt "command-option"
 msgid "random"
 msgstr "おみくじ"
 
-#: src\commands\rush-duel.ts:90
+#: src\commands\rush-duel.ts:89
 msgctxt "command-option"
 msgid "art"
 msgstr "イラスト"
 
-#: src\commands\query.ts:36
+#: src\commands\query.ts:35
 msgctxt "command-option"
 msgid "lucene"
 msgstr ""
 
-#: src\locale.ts:74
+#: src\commands\metagame.ts:209
+msgctxt "command-option"
+msgid "strategies"
+msgstr ""
+
+#: src\commands\metagame.ts:234
+#: src\commands\metagame.ts:274
+msgctxt "command-option"
+msgid "format"
+msgstr ""
+
+#: src\commands\metagame.ts:240
+msgctxt "command-option"
+msgid "cards"
+msgstr ""
+
+#: src\commands\metagame.ts:310
+msgctxt "command-option"
+msgid "date-range"
+msgstr ""
+
+#: src\locale.ts:77
 msgctxt "command-option-description"
 msgid "The output language for the card embed, overriding other settings."
 msgstr "カード情報の表示言語を設定します。デフォルトの設定より優先されます。"
 
-#: src\locale.ts:132
+#: src\locale.ts:141
 msgctxt "command-option-description"
 msgid "The language to search in, defaulting to the result language."
 msgstr "検索ワードが何語かを指定できます。デフォルトの設定は出力言語と同じです。"
 
-#: src\commands\help.ts:55
+#: src\commands\help.ts:58
 msgctxt "command-option-description"
 msgid "The name of a specific Slash Command."
 msgstr "使い方を表示したいスラッシュコマンドの名前"
@@ -1023,32 +1033,32 @@ msgctxt "command-option-description"
 msgid "The name of the Yugipedia page you want to search for."
 msgstr "検索したいYugipediaのページの名前"
 
-#: src\commands\deck.ts:129
+#: src\commands\deck.ts:90
 msgctxt "command-option-description"
 msgid "View a deck by entering a ydke:// URL."
 msgstr "ydke://形式のURLを入力すると、そのデッキ内容を表示します。"
 
-#: src\commands\deck.ts:135
+#: src\commands\deck.ts:96
 msgctxt "command-option-description"
 msgid "View a deck by uploading a .ydk file."
 msgstr ".ydk形式のファイルをアップロードすると、そのデッキ内容を表示します。"
 
-#: src\commands\deck.ts:141
+#: src\commands\deck.ts:102
 msgctxt "command-option-description"
 msgid "The ydke:// URL of the deck you want to view."
 msgstr "デッキ内容を表示したいydke://形式のURL"
 
-#: src\commands\deck.ts:147
+#: src\commands\deck.ts:108
 msgctxt "command-option-description"
 msgid "The .ydk file of the deck you want to view."
 msgstr "デッキ内容を表示したい.ydk形式のファイル"
 
-#: src\commands\deck.ts:153
+#: src\commands\deck.ts:114
 msgctxt "command-option-description"
 msgid "Whether to display the deck details publicly in chat. This is false by default."
 msgstr "デッキ内容を自分以外の人にも見せるか否かを設定できます。デフォルトでは他の人には非表示になっています。"
 
-#: src\commands\deck.ts:160
+#: src\commands\deck.ts:121
 msgctxt "command-option-description"
 msgid "Whether to display the deck sections as one stacked column. This is false (side-by-side) by default."
 msgstr "デッキ内容を一行で表示するか否かを設定できます。デフォルトでは左右の二行に分けて表示します。"
@@ -1058,8 +1068,8 @@ msgctxt "command-option-description"
 msgid "Display the art for the card with this name."
 msgstr "この名称のカードのイラストを表示します"
 
-#: src\commands\rush-duel.ts:69
-#: src\locale.ts:148
+#: src\commands\rush-duel.ts:68
+#: src\locale.ts:157
 msgctxt "command-option-description"
 msgid "Card name, fuzzy matching supported."
 msgstr "カード名（あいまい検索に対応しています）"
@@ -1069,7 +1079,7 @@ msgctxt "command-option-description"
 msgid "Display the art for the card with this password."
 msgstr "このパスワードのカードのイラストを表示します"
 
-#: src\locale.ts:167
+#: src\locale.ts:176
 msgctxt "command-option-description"
 msgid "Card password, the eight-digit number printed on the bottom left corner."
 msgstr "カードパスワード（カード左下の8桁の数字）"
@@ -1079,8 +1089,8 @@ msgctxt "command-option-description"
 msgid "Display the art for the card with this official database ID."
 msgstr "このパスワードのカードのイラストを表示します"
 
-#: src\commands\rush-duel.ts:81
-#: src\locale.ts:182
+#: src\commands\rush-duel.ts:80
+#: src\locale.ts:191
 msgctxt "command-option-description"
 msgid "Konami's official card database identifier."
 msgstr "Konami公式カードDBでのカードID"
@@ -1120,22 +1130,22 @@ msgctxt "command-option-description"
 msgid "The new default language to use in this channel or server."
 msgstr "このチャンネルあるいはサーバ全体で使う新しい言語設定"
 
-#: src\commands\price.ts:98
+#: src\commands\price.ts:99
 msgctxt "command-option-description"
 msgid "Display the price for the card with this name."
 msgstr "この名称のカードの価格を表示します"
 
-#: src\commands\price.ts:102
+#: src\commands\price.ts:103
 msgctxt "command-option-description"
 msgid "Display the price for the card with this password."
 msgstr "このパスワードのカードの価格を表示します"
 
-#: src\commands\price.ts:105
+#: src\commands\price.ts:106
 msgctxt "command-option-description"
 msgid "Display the price for the card with this official database ID."
 msgstr "この公式カードDBのIDを持つカードの価格を表示します"
 
-#: src\commands\price.ts:95
+#: src\commands\price.ts:96
 msgctxt "command-option-description"
 msgid "The vendor to fetch the price data from."
 msgstr "価格情報の参照先"
@@ -1145,29 +1155,70 @@ msgctxt "command-option-description"
 msgid "The English name of the card you're looking for."
 msgstr "カード名称の英語名"
 
-#: src\commands\rush-duel.ts:64
+#: src\commands\rush-duel.ts:63
 msgctxt "command-option-description"
 msgid "Find all information for the Rush Duel card with this name."
 msgstr "この名称のラッシュデュエルカードの情報を表示します"
 
-#: src\commands\rush-duel.ts:75
+#: src\commands\rush-duel.ts:74
 msgctxt "command-option-description"
 msgid "Find all information for the Rush Duel card with this official database ID."
 msgstr "この公式カードDBのIDを持つラッシュデュエルカードの情報を表示します"
 
-#: src\commands\rush-duel.ts:86
+#: src\commands\rush-duel.ts:85
 msgctxt "command-option-description"
 msgid "Get a random Rush Duel card."
 msgstr "ラッシュデュエル用カードのおみくじ"
 
-#: src\commands\rush-duel.ts:91
+#: src\commands\rush-duel.ts:90
 msgctxt "command-option-description"
 msgid "Display just the art for the Rush Duel card with this name."
 msgstr "ラッシュデュエル用カードのイラストを表示します"
 
-#: src\commands\query.ts:37
+#: src\commands\query.ts:36
 msgctxt "command-option-description"
 msgid "Lucene query on YAML Yugi"
+msgstr ""
+
+#: src\commands\locale-user.ts:37
+msgctxt "command-option-description"
+msgid "Check your user-installed Bastion's locale."
+msgstr ""
+
+#: src\commands\locale-user.ts:42
+msgctxt "command-option-description"
+msgid "Configure your user-installed Bastion's locale."
+msgstr ""
+
+#: src\commands\locale-user.ts:47
+msgctxt "command-option-description"
+msgid "The new default language to use for user-installed Bastion."
+msgstr ""
+
+#: src\commands\metagame.ts:212
+msgctxt "command-option-description"
+msgid "Show the top competitive strategies in tournaments and the Master Duel ranked ladder."
+msgstr ""
+
+#: src\commands\metagame.ts:214
+msgctxt "command-option-description"
+msgid "Show the top competitive strategies in tournaments."
+msgstr ""
+
+#: src\commands\metagame.ts:235
+#: src\commands\metagame.ts:275
+msgctxt "command-option-description"
+msgid "Game region."
+msgstr ""
+
+#: src\commands\metagame.ts:242
+msgctxt "command-option-description"
+msgid "Show the most popular cards in tournaments and the Master Duel ranked ladder."
+msgstr ""
+
+#: src\commands\metagame.ts:312
+msgctxt "command-option-description"
+msgid "Limit card usage statistics to this date range. Has no effect for Master Duel."
 msgstr ""
 
 #: src\commands\art.ts:36
@@ -1175,12 +1226,12 @@ msgctxt "command-name"
 msgid "art"
 msgstr "いらすと"
 
-#: src\commands\help.ts:49
+#: src\commands\help.ts:52
 msgctxt "command-name"
 msgid "help"
 msgstr "つかいかた"
 
-#: src\commands\ping.ts:23
+#: src\commands\ping.ts:25
 msgctxt "command-name"
 msgid "ping"
 msgstr ""
@@ -1195,7 +1246,7 @@ msgctxt "command-name"
 msgid "yugipedia"
 msgstr ""
 
-#: src\commands\deck.ts:119
+#: src\commands\deck.ts:80
 msgctxt "command-name"
 msgid "deck"
 msgstr "でっき"
@@ -1210,24 +1261,34 @@ msgctxt "command-name"
 msgid "locale"
 msgstr "げんごせってい"
 
-#: src\commands\random.ts:44
+#: src\commands\random.ts:43
 msgctxt "command-name"
 msgid "random"
 msgstr "おみくじ"
 
-#: src\commands\price.ts:89
+#: src\commands\price.ts:90
 msgctxt "command-name"
 msgid "price"
 msgstr "かかく"
 
-#: src\commands\rush-duel.ts:58
+#: src\commands\rush-duel.ts:57
 msgctxt "command-name"
 msgid "rush-duel"
 msgstr "らっしゅ"
 
-#: src\commands\query.ts:30
+#: src\commands\query.ts:29
 msgctxt "command-name"
 msgid "query"
+msgstr ""
+
+#: src\commands\locale-user.ts:31
+msgctxt "command-name"
+msgid "locale-user"
+msgstr ""
+
+#: src\commands\metagame.ts:204
+msgctxt "command-name"
+msgid "metagame"
 msgstr ""
 
 #: src\commands\art.ts:37
@@ -1235,12 +1296,12 @@ msgctxt "command-description"
 msgid "Display the art for a card!"
 msgstr "カードの画像（イラスト）を表示します。"
 
-#: src\commands\help.ts:50
+#: src\commands\help.ts:53
 msgctxt "command-description"
 msgid "Get help with a Slash Command."
 msgstr "コマンドの使い方を表示します。"
 
-#: src\commands\ping.ts:24
+#: src\commands\ping.ts:26
 msgctxt "command-description"
 msgid "Test latency to the new bot instance."
 msgstr "ボットが落ちていないかを確認できます（pingの反応を表示します。）"
@@ -1255,7 +1316,7 @@ msgctxt "command-description"
 msgid "Search the Yugipedia wiki for a page and link to it."
 msgstr "Yugipediaを検索します。"
 
-#: src\commands\deck.ts:122
+#: src\commands\deck.ts:83
 msgctxt "command-description"
 msgid "Display a deck list from ydke:// or .ydk format, exported from a number of deck building programs."
 msgstr "ydke:// か .ydk 形式のデッキ情報を表示します。（多くのデッキ構築アプリで使われている形式です。）"
@@ -1270,24 +1331,34 @@ msgctxt "command-description"
 msgid "Check or set Bastion's locale for this channel or server."
 msgstr "このチャンネル（あるいはサーバー）のBastionのロケールを確認（あるいは変更）します。"
 
-#: src\commands\random.ts:45
+#: src\commands\random.ts:44
 msgctxt "command-description"
 msgid "Get a random Yu-Gi-Oh! card."
 msgstr "遊戯王カードをランダムに表示します。"
 
-#: src\commands\price.ts:90
+#: src\commands\price.ts:91
 msgctxt "command-description"
 msgid "Display the price for a card!"
 msgstr "カードの値段を表示します！"
 
-#: src\commands\rush-duel.ts:59
+#: src\commands\rush-duel.ts:58
 msgctxt "command-description"
 msgid "Find information on Rush Duel cards."
 msgstr "ラッシュデュエルのカード情報を探します。"
 
-#: src\commands\query.ts:31
+#: src\commands\query.ts:30
 msgctxt "command-description"
 msgid "Advanced search prototype"
+msgstr ""
+
+#: src\commands\locale-user.ts:32
+msgctxt "command-description"
+msgid "Check or set user-installed Bastion's locale."
+msgstr ""
+
+#: src\commands\metagame.ts:205
+msgctxt "command-description"
+msgid "Show statistics on the current competitive state of play."
 msgstr ""
 
 #: src\commands\locale.ts:43
@@ -1300,7 +1371,71 @@ msgctxt "command-option-choice"
 msgid "server"
 msgstr "サーバー"
 
+#: src\commands\locale-user.ts:49
 #: src\commands\locale.ts:51
 msgctxt "command-option-choice"
 msgid "Discord default"
 msgstr "ディスコードのデフォルト"
+
+#: src\commands\metagame.ts:219
+#: src\commands\metagame.ts:251
+msgctxt "command-option-choice"
+msgid "TCG"
+msgstr ""
+
+#: src\commands\metagame.ts:220
+#: src\commands\metagame.ts:255
+msgctxt "command-option-choice"
+msgid "OCG"
+msgstr ""
+
+#: src\commands\metagame.ts:221
+#: src\commands\metagame.ts:259
+msgctxt "command-option-choice"
+msgid "OCG (Asian-English)"
+msgstr ""
+
+#: src\commands\metagame.ts:228
+msgctxt "command-option-choice"
+msgid "Master Duel Diamond+ tier list"
+msgstr ""
+
+#: src\commands\metagame.ts:261
+msgctxt "command-option-choice"
+msgid "Master Duel ranked ladder"
+msgstr ""
+
+#: src\commands\metagame.ts:283
+msgctxt "command-option-choice"
+msgid "Current format"
+msgstr ""
+
+#: src\commands\metagame.ts:287
+msgctxt "command-option-choice"
+msgid "Since last Forbidden/Limited List"
+msgstr ""
+
+#: src\commands\metagame.ts:291
+msgctxt "command-option-choice"
+msgid "Last 7 days"
+msgstr ""
+
+#: src\commands\metagame.ts:295
+msgctxt "command-option-choice"
+msgid "Last 14 days"
+msgstr ""
+
+#: src\commands\metagame.ts:299
+msgctxt "command-option-choice"
+msgid "Last 30 days"
+msgstr ""
+
+#: src\commands\metagame.ts:303
+msgctxt "command-option-choice"
+msgid "Last three months"
+msgstr ""
+
+#: src\commands\metagame.ts:307
+msgctxt "command-option-choice"
+msgid "Last six months"
+msgstr ""

--- a/translations/ko.po
+++ b/translations/ko.po
@@ -30,13 +30,13 @@ msgstr "**종족**: ${ raceIcon } ${ localizedMonsterTypeLine }"
 #: src\card.ts:491
 #: src\rush-duel.ts:94
 #, javascript-format
-msgid "**Attribute**: ${ AttributeIcon[card.attribute] } ${ localizedAttribute }"
-msgstr "**속성**: ${ AttributeIcon[card.attribute] } ${ localizedAttribute }"
+msgid "**Attribute**: ${ attributeIcon } ${ localizedAttribute }"
+msgstr "**속성**: ${ attributeIcon } ${ localizedAttribute }"
 
 #: src\card.ts:495
 #, javascript-format
-msgid "**Rank**: ${ Icon.Rank } ${ card.rank } **ATK**: ${ card.atk } **DEF**: ${ card.def }"
-msgstr "**랭크**: ${ Icon.Rank } ${ card.rank } **공격력**: ${ card.atk } **수비력**: ${ card.def }"
+msgid "**Rank**: ${ rankIcon } ${ card.rank } **ATK**: ${ card.atk } **DEF**: ${ card.def }"
+msgstr "**랭크**: ${ rankIcon } ${ card.rank } **공격력**: ${ card.atk } **수비력**: ${ card.def }"
 
 #: src\card.ts:498
 #, javascript-format
@@ -46,8 +46,8 @@ msgstr "**LINK**: ${ card.link_arrows.length } **공격력**: ${ card.atk } **�
 #: src\card.ts:500
 #: src\rush-duel.ts:96
 #, javascript-format
-msgid "**Level**: ${ Icon.Level } ${ card.level } **ATK**: ${ card.atk } **DEF**: ${ card.def }"
-msgstr "**레벨**: ${ Icon.Level } ${ card.level } **공격력**: ${ card.atk } **수비력**: ${ card.def }"
+msgid "**Level**: ${ levelIcon } ${ card.level } **ATK**: ${ card.atk } **DEF**: ${ card.def }"
+msgstr "**레벨**: ${ levelIcon } ${ card.level } **공격력**: ${ card.atk } **수비력**: ${ card.def }"
 
 #: src\card.ts:507
 #, javascript-format
@@ -453,8 +453,8 @@ msgstr "Bastion은 호출한 사용자만 이용할 수 있습니다."
 
 #: src\card.ts:462
 #, javascript-format
-msgid "**Master Duel rarity**: ${ rarity_icon } ${ localized_rarity }"
-msgstr "**레어리티 (MD)**: ${ rarity_icon } ${ localized_rarity }"
+msgid "**Master Duel rarity**: ${ rarityIcon } ${ localizedRarity }"
+msgstr "**레어리티 (MD)**: ${ rarityIcon } ${ localizedRarity }"
 
 #: src\rush-duel.ts:205
 #, javascript-format

--- a/translations/ko.po
+++ b/translations/ko.po
@@ -6,50 +6,33 @@ msgstr ""
 "MIME-Version: 1.0\n"
 "Content-Transfer-Encoding: 8bit\n"
 
-#: src\card.ts:416
-#: src\rush-duel.ts:39
+#: src\card.ts:412
+#: src\rush-duel.ts:48
 msgid "🔗 Links"
 msgstr "🔗 링크"
 
-#: src\card.ts:417
+#: src\card.ts:413
 #, javascript-format
 msgid "[Official Konami DB](${ official }) | [OCG Rulings](${ rulings }) | [Yugipedia](${ yugipedia }) | [YGOPRODECK](${ ygoprodeck })"
 msgstr "[코나미 공식 카드 DB](${ official }) | [OCG 공식 재정](${ rulings }) | [Yugipedia](${ yugipedia }) | [YGOPRODECK](${ ygoprodeck })"
 
-#: src\card.ts:420
+#: src\card.ts:416
 #, javascript-format
 msgid "[Yugipedia](${ yugipedia }) | [YGOPRODECK](${ ygoprodeck })"
 msgstr "[Yugipedia](${ yugipedia }) | [YGOPRODECK](${ ygoprodeck })"
 
-#: src\card.ts:489
-#: src\rush-duel.ts:92
+#: src\card.ts:490
+#: src\rush-duel.ts:103
 #, javascript-format
 msgid "**Type**: ${ raceIcon } ${ localizedMonsterTypeLine }"
 msgstr "**종족**: ${ raceIcon } ${ localizedMonsterTypeLine }"
 
-#: src\card.ts:491
-#: src\rush-duel.ts:94
-#, javascript-format
-msgid "**Attribute**: ${ AttributeIcon[card.attribute] } ${ localizedAttribute }"
-msgstr "**속성**: ${ AttributeIcon[card.attribute] } ${ localizedAttribute }"
-
-#: src\card.ts:495
-#, javascript-format
-msgid "**Rank**: ${ Icon.Rank } ${ card.rank } **ATK**: ${ card.atk } **DEF**: ${ card.def }"
-msgstr "**랭크**: ${ Icon.Rank } ${ card.rank } **공격력**: ${ card.atk } **수비력**: ${ card.def }"
-
-#: src\card.ts:498
+#: src\card.ts:500
 #, javascript-format
 msgid "**Link Rating**: ${ card.link_arrows.length } **ATK**: ${ card.atk } **Link Arrows**: ${ arrows }"
 msgstr "**LINK**: ${ card.link_arrows.length } **공격력**: ${ card.atk } **링크 마커**: ${ arrows }"
 
-#: src\card.ts:500
-#: src\rush-duel.ts:96
-#, javascript-format
-msgid "**Level**: ${ Icon.Level } ${ card.level } **ATK**: ${ card.atk } **DEF**: ${ card.def }"
-msgstr "**레벨**: ${ Icon.Level } ${ card.level } **공격력**: ${ card.atk } **수비력**: ${ card.def }"
-
-#: src\card.ts:507
+#: src\card.ts:511
 #, javascript-format
 msgid "**Pendulum Scale**: ${ formattedScale }"
 msgstr "**펜듈럼 스케일**: ${ formattedScale }"
@@ -70,7 +53,7 @@ msgid "Password: ${ card.password } | Not yet released"
 msgstr "패스워드: ${ card.password } | Not yet released"
 
 #: src\card.ts:351
-#: src\rush-duel.ts:146
+#: src\rush-duel.ts:158
 msgid "Not yet released"
 msgstr "미발매"
 
@@ -79,64 +62,64 @@ msgstr "미발매"
 msgid "Placeholder ID: ${ card.fake_password }"
 msgstr "플레이스홀더 ID: ${ card.fake_password }"
 
-#: src\utils.ts:41
+#: src\utils.ts:44
 msgid "🛠️ This command is in development."
 msgstr "🛠️ 이 명령은 개발 중입니다."
 
-#: src\utils.ts:42
+#: src\utils.ts:45
 msgid "📨 Please send feedback to [our issue tracker](https://github.com/DawnbrandBots/bastion-bot) or the [support server](https://discord.gg/4aFuPyuE96)!"
 msgstr "📨 [문제 추적기](https://github.com/DawnbrandBots/bastion-bot) 또는 [지원 서버](https://discord.gg/4aFuPyuE96)로 피드백을 보내주십시오!"
 
-#: src\utils.ts:53
+#: src\utils.ts:56
 msgid "Please consider supporting us!"
 msgstr "저희를 지원해 주세요!"
 
-#: src\utils.ts:54
+#: src\utils.ts:57
 msgid "Help keep Bastion online!"
 msgstr "Bastion을 온라인 상태로 유지하는 것을 도와 주세요!"
 
-#: src\utils.ts:55
+#: src\utils.ts:58
 msgid "Please help keep Bastion online!"
 msgstr "저희가 Bastion을 온라인 상태로 유지하는 것을 도와 주세요!"
 
-#: src\utils.ts:56
+#: src\utils.ts:59
 msgid "Was Bastion helpful? Consider supporting us!"
 msgstr "Bastion이 도움이 되었나요? 저희를 지원해 주세요!"
 
-#: src\utils.ts:57
+#: src\utils.ts:60
 msgid "Was Bastion helpful? We need your support!"
 msgstr "Bastion이 도움이 되었나요? 여러분의 지원이 필요해요!"
 
-#: src\utils.ts:58
+#: src\utils.ts:61
 msgid "Did you find Bastion useful? Consider supporting us!"
 msgstr "Bastion이 유용하다고 생각했나요? 저희를 지원해 주시는 건 어떤가요?"
 
-#: src\utils.ts:59
+#: src\utils.ts:62
 msgid "Did you find Bastion useful? Help keep it online!"
 msgstr "Bastion이 유용하다고 생각했나요? 온라인 상태로 유지하는 것을 도와 주세요!"
 
-#: src\utils.ts:60
+#: src\utils.ts:63
 msgid "Did you find Bastion useful? We need your support!"
 msgstr "Bastion이 유용하다고 생각했나요? 여러분의 지원이 필요해요!"
 
-#: src\utils.ts:61
+#: src\utils.ts:64
 msgid "Enjoy Bastion? Help keep it online!"
 msgstr "Bastion을 잘 사용하고 계신가요? 온라인 상태로 유지하는 것을 도와 주세요!"
 
-#: src\utils.ts:62
+#: src\utils.ts:65
 msgid "Enjoy Bastion? Consider supporting us!"
 msgstr "Bastion을 잘 사용하고 계신가요? 저희를 지원해 주시는 건 어떤가요?"
 
-#: src\utils.ts:63
+#: src\utils.ts:66
 msgid "Found what you were looking for? Consider supporting us!"
 msgstr "찾으시려던 것을 찾으셨나요? 저희를 지원해 주시는 건 어떤가요?"
 
 #: src\commands\art.ts:63
-#: src\commands\price.ts:131
-#: src\commands\rush-duel.ts:172
-#: src\commands\rush-duel.ts:203
+#: src\commands\price.ts:132
+#: src\commands\rush-duel.ts:171
+#: src\commands\rush-duel.ts:202
 #: src\commands\search.ts:64
-#: src\events\message-search.ts:258
+#: src\events\message-search.ts:265
 #, javascript-format
 msgid "Could not find a card matching `${ input }`!"
 msgstr "`${ input }`에 일치하는 카드를 찾을 수 없습니다!"
@@ -163,11 +146,7 @@ msgstr "이 서버에 대한 언어 설정: ${ guildOverride }"
 msgid "Discord Community locale for this server: ${ interaction.guildLocale }"
 msgstr "이 서버의 디스코드 커뮤니티의 언어 설정: ${ interaction.guildLocale }"
 
-#: src\commands\locale.ts:89
-#, javascript-format
-msgid "Locale override for this direct message: ${ override }"
-msgstr "이 다이렉트 메시지에 대한 언어 설정: ${ override }"
-
+#: src\commands\locale-user.ts:76
 #: src\commands\locale.ts:92
 #, javascript-format
 msgid "Your Discord locale: ${ interaction.locale }"
@@ -205,24 +184,14 @@ msgstr "커뮤니티 서버의 서버 전체 기본값은 ${ interaction.guildLo
 msgid "Sorry, you must have the Manage Server permission to do this. If you think this is an error, contact your server admin or report a bug."
 msgstr "죄송합니다. 이 작업을 수행하려면 서버 관리 권한이 있어야 합니다. 이 메시지가 잘못 출력되었다면, 서버 관리자에게 문의하시거나 버그를 신고해 주세요."
 
-#: src\commands\locale.ts:146
-#, javascript-format
-msgid "Locale for this direct message overridden with ${ locale }. Your Discord setting is ${ interaction.locale }."
-msgstr "해당 다이렉트 메시지의 언어 설정은 ${ locale } 으로 재정의되었습니다. 당신의 디스코드 설정은 ${ interaction.locale } 입니다."
-
-#: src\commands\locale.ts:150
-#, javascript-format
-msgid "Locale for this direct message reset to Discord default. Your Discord setting is ${ interaction.locale }."
-msgstr "해당 다이렉트 메시지의 언어 설정은 디스코드 기본값으로 리셋되었습니다. 당신의 디스코드 설정은 ${ interaction.locale } 입니다."
-
-#: src\commands\ping.ts:36
-#: src\events\message-ping.ts:47
+#: src\commands\ping.ts:38
+#: src\events\message-ping.ts:45
 #, javascript-format
 msgid "Average WebSocket ping (new instance): ${ ping } ms"
 msgstr "평균 WebSocket 핑 (새로운 인스턴스): ${ ping } ms"
 
-#: src\commands\ping.ts:40
-#: src\events\message-ping.ts:112
+#: src\commands\ping.ts:42
+#: src\events\message-ping.ts:110
 #, javascript-format
 msgid "Total latency: ${ latency } ms"
 msgstr "총 지연 시간: ${ latency } ms"
@@ -232,130 +201,113 @@ msgstr "총 지연 시간: ${ latency } ms"
 msgid "Could not find a Yugipedia page named `${ page }`."
 msgstr "`${ page }`라는 이름의 Yugipedia 페이지를 찾을 수 없습니다."
 
-#: src\commands\deck.ts:244
+#: src\commands\deck.ts:205
 #, javascript-format
 msgid "${ counts.Monster } Monster"
 msgid_plural "${ counts.Monster } Monsters"
 msgstr[0] "몬스터 ${ counts.Monster } 장"
 
-#: src\commands\deck.ts:247
+#: src\commands\deck.ts:208
 #, javascript-format
 msgid "${ counts.Spell } Spell"
 msgid_plural "${ counts.Spell } Spells"
 msgstr[0] "마법 ${ counts.Spell } 장"
 
-#: src\commands\deck.ts:250
+#: src\commands\deck.ts:211
 #, javascript-format
 msgid "${ counts.Trap } Trap"
 msgid_plural "${ counts.Trap } Traps"
 msgstr[0] "함정 ${ counts.Trap } 장"
 
-#: src\commands\deck.ts:278
+#: src\commands\deck.ts:239
 msgid "Your Deck"
 msgstr "덱"
 
-#: src\commands\deck.ts:283
+#: src\commands\deck.ts:244
 #, javascript-format
 msgid "Main Deck (${ deck.main.length } card — ${ countDetail })"
 msgid_plural "Main Deck (${ deck.main.length } cards — ${ countDetail })"
 msgstr[0] "메인 덱 (${ deck.main.length } card — ${ countDetail })"
 
-#: src\commands\deck.ts:290
+#: src\commands\deck.ts:251
 msgid "Main Deck (continued)"
 msgstr "메인 덱 (계속)"
 
-#: src\commands\deck.ts:304
+#: src\commands\deck.ts:265
 msgid "Extra Deck (continued)"
 msgstr "엑스트라 덱 (계속)"
 
-#: src\commands\deck.ts:318
+#: src\commands\deck.ts:279
 msgid "Side Deck (continued)"
 msgstr "사이드 덱 (계속)"
 
-#: src\commands\deck.ts:407
+#: src\commands\deck.ts:347
 msgid "Error: Your deck is empty."
 msgstr "오류: 덱이 비었습니다."
 
-#: src\events\message-ping.ts:49
+#: src\events\message-ping.ts:47
 msgid "Free and open source _Yu-Gi-Oh!_ bot"
 msgstr "자유-오픈 소스 유희왕 봇"
 
-#: src\events\message-ping.ts:72
+#: src\events\message-ping.ts:70
 #, javascript-format
 msgid "Revision: ${ process.env.BOT_REVISION }."
 msgstr "수정: ${ process.env.BOT_REVISION }."
 
-#: src\commands\deck.ts:328
+#: src\commands\deck.ts:289
 msgid ".ydk files must have the .ydk extension!"
 msgstr ".ydk 파일의 확장자는 .ydk여야 합니다!"
 
-#: src\commands\deck.ts:331
+#: src\commands\deck.ts:292
 msgid ".ydk files should not be larger than 1 KB!"
 msgstr ".ydk 파일은 1 KB보다 크면 안 됩니다!"
 
-#: src\commands\deck.ts:321
+#: src\commands\deck.ts:282
 msgid "ydke URL"
 msgstr ""
 
 #: src\card.ts:455
-#: src\rush-duel.ts:61
+#: src\rush-duel.ts:75
 #. Forbidden/Limited Lists or Limit Regulations in the OCG
 #, javascript-format
 msgid "**Limit**: ${ limitRegulationDisplay }"
 msgstr "**제한**: ${ limitRegulationDisplay }"
 
-#: src\commands\price.ts:69
+#: src\commands\price.ts:70
 msgid "TCGPlayer"
 msgstr ""
 
-#: src\commands\price.ts:70
+#: src\commands\price.ts:71
 msgid "Cardmarket"
 msgstr ""
 
-#: src\commands\price.ts:147
+#: src\commands\price.ts:148
 msgid "No market price"
 msgstr "시장 가격 불명"
 
-#: src\commands\price.ts:155
+#: src\commands\price.ts:156
 #, javascript-format
 msgid "Prices for ${ card.name[resultLanguage] } - ${ vendorName }"
 msgstr "${ vendorName } 의 ${ card.name[resultLanguage] } 가격"
 
-#: src\commands\price.ts:169
+#: src\commands\price.ts:170
 #, javascript-format
 msgid "Could not find prices for `${ name }`!"
 msgstr "`${ name }`의 가격을 찾을 수 없습니다!"
 
-#: src\commands\deck.ts:425
-#. prepare interaction button for FTP upload
+#: src\commands\deck.ts:363
 msgid "Upload to YGOPRODECK"
 msgstr "YGOPRODECK에 업로드"
 
-#: src\commands\deck.ts:483
-#. disable original button
-#. prepare row to disable button on original message
-msgid "Upload Complete"
-msgstr "업로드 완료"
-
-#: src\commands\deck.ts:470
-msgid "Deck upload failed!"
-msgstr "덱 업로드에 실패했습니다!"
-
-#: src\commands\deck.ts:491
-#. reply in affirmation
-#, javascript-format
-msgid "Deck successfully uploaded to <${ url }>!"
-msgstr "<${ url }>에 덱 업로드를 완료했습니다!"
-
-#: src\events\message-search.ts:264
+#: src\events\message-search.ts:271
 msgid "💬 Translations missing?"
 msgstr "💬 번역이 존재합니까?"
 
-#: src\events\message-search.ts:265
+#: src\events\message-search.ts:272
 msgid "Help translate Bastion at the links above."
 msgstr "위 링크에서 Bastion 번역을 도와주세요."
 
-#: src\events\message-ping.ts:50
+#: src\events\message-ping.ts:48
 msgid ""
 "❓ Help documentation on [GitHub](https://github.com/DawnbrandBots/bastion-bot), or use `.commands` and `.help`.\n"
 "🟢 Licence: [GNU AGPL 3.0+](https://choosealicense.com/licenses/agpl-3.0/).\n"
@@ -371,37 +323,37 @@ msgid ""
 "💬 Translations missing? Help translate Bastion on [GitHub](https://github.com/DawnbrandBots/bastion-bot)."
 msgstr ""
 
-#: src\events\message-search.ts:256
-#: src\events\message-search.ts:294
+#: src\events\message-search.ts:263
+#: src\events\message-search.ts:302
 #, javascript-format
 msgid "Search type: ${ localisedType }"
 msgstr "검색 종류: ${ localisedType }"
 
-#: src\events\message-search.ts:236
+#: src\events\message-search.ts:242
 #, javascript-format
 msgid "Search language: **${ localisedInputLanguage }** (${ inputLanguage }). Check defaults with </locale get:${ id }> and configure with </locale set:${ id }>"
 msgstr "검색 언어: **${ localisedInputLanguage }** (${ inputLanguage }). </locale get:${ id }>의 기본값을 확인하고 </locale set:${ id }>를 설정합니다."
 
-#: src\events\message-ping.ts:95
+#: src\events\message-ping.ts:93
 msgid "⚠️ You pinged me, but I am missing permissions in the channel!"
 msgstr "⚠️ 당신은 저를 부르셨지만, 해당 채널에서 권한이 없습니다!"
 
-#: src\events\message-ping.ts:98
-#: src\events\message-search.ts:332
+#: src\events\message-ping.ts:96
+#: src\events\message-search.ts:340
 msgid "Please have a server administrator [fix this](https://github.com/DawnbrandBots/bastion-bot#discord-permissions)."
 msgstr "서버 관리자에게 문의하십시오 [문제 해결](https://github.com/DawnbrandBots/bastion-bot#discord-permissions)."
 
-#: src\events\message-search.ts:329
+#: src\events\message-search.ts:337
 msgid "⚠️ I am missing permissions in the channel!"
 msgstr "⚠️ 해당 채널에서 권한이 없습니다!"
 
-#: src\commands\deck.ts:297
+#: src\commands\deck.ts:258
 #, javascript-format
 msgid "Extra Deck (${ deck.extra.length } card — ${ countDetail })"
 msgid_plural "Extra Deck (${ deck.extra.length } cards — ${ countDetail })"
 msgstr[0] "엑스트라 덱 (${ deck.extra.length } cards — ${ countDetail })"
 
-#: src\commands\deck.ts:311
+#: src\commands\deck.ts:272
 #, javascript-format
 msgid "Side Deck (${ deck.side.length } card — ${ countDetail })"
 msgid_plural "Side Deck (${ deck.side.length } cards — ${ countDetail })"
@@ -422,48 +374,82 @@ msgstr "YGOPRODECK을 위해 `${ searchTerm }`을(를) 검색하는 데 문제�
 msgid "Something went wrong searching Yugipedia for `${ page }`."
 msgstr "Yugipedia를 위해 `${ page }`을(를) 검색하는 데 문제가 발생하였습니다."
 
-#: src\rush-duel.ts:40
+#: src\rush-duel.ts:49
 #, javascript-format
 msgid "[Official Konami DB](${ official }) | [Rulings (Japanese)](${ rulings }) | [Yugipedia](${ yugipedia }) | [RushCard](${ rushcard })"
 msgstr "[공식 코나미 DB](${ official }) | [OCG 규칙](${ rulings }) | [Yugipedia](${ yugipedia }) | [RushCard](${ rushcard })"
 
-#: src\rush-duel.ts:43
+#: src\rush-duel.ts:52
 #, javascript-format
 msgid "[Yugipedia](${ yugipedia }) | [RushCard](${ rushcard })"
 msgstr ""
 
-#: src\rush-duel.ts:57
+#: src\rush-duel.ts:71
 msgid "__**LEGEND**__"
 msgstr ""
 
-#: src\rush-duel.ts:99
+#: src\rush-duel.ts:110
 #, javascript-format
 msgid "**MAXIMUM ATK**: ${ card.maximum_atk }"
 msgstr ""
 
-#: src\rush-duel.ts:146
+#: src\rush-duel.ts:158
 #, javascript-format
 msgid "Konami ID #${ card.konami_id }"
 msgstr "코나미 ID #${ card.konami_id }"
 
 #: src\art.ts:129
-#: src\commands\deck.ts:451
 msgid "Buttons can only be used by the user who called Bastion."
 msgstr "Bastion은 호출한 사용자만 이용할 수 있습니다."
 
-#: src\card.ts:462
-#, javascript-format
-msgid "**Master Duel rarity**: ${ rarity_icon } ${ localized_rarity }"
-msgstr "**레어리티 (MD)**: ${ rarity_icon } ${ localized_rarity }"
-
-#: src\rush-duel.ts:205
+#: src\rush-duel.ts:217
 #, javascript-format
 msgid "Using ${ searchTrigger }, you can search for Rush Duel cards directly in messages without autocomplete"
 msgstr ""
 
-#: src\events\message-search.ts:296
+#: src\events\message-search.ts:304
 #, javascript-format
 msgid "Could not find a Rush Duel card matching `${ input }`!"
+msgstr ""
+
+#: src\card.ts:462
+#, javascript-format
+msgid "**Master Duel rarity**: ${ rarityIcon } ${ localizedRarity }"
+msgstr ""
+
+#: src\card.ts:492
+#: src\rush-duel.ts:105
+#, javascript-format
+msgid "**Attribute**: ${ attributeIcon } ${ localizedAttribute }"
+msgstr ""
+
+#: src\card.ts:497
+#, javascript-format
+msgid "**Rank**: ${ rankIcon } ${ card.rank } **ATK**: ${ card.atk } **DEF**: ${ card.def }"
+msgstr ""
+
+#: src\card.ts:503
+#: src\rush-duel.ts:107
+#, javascript-format
+msgid "**Level**: ${ levelIcon } ${ card.level } **ATK**: ${ card.atk } **DEF**: ${ card.def }"
+msgstr ""
+
+#: src\commands\locale-user.ts:73
+#: src\commands\locale.ts:89
+#, javascript-format
+msgid "Locale override for your direct messages: ${ override }"
+msgstr ""
+
+#: src\commands\locale-user.ts:83
+#: src\commands\locale.ts:146
+#, javascript-format
+msgid "Locale for your direct messages overridden with ${ locale }. Your Discord setting is ${ interaction.locale }."
+msgstr ""
+
+#: src\commands\locale-user.ts:87
+#: src\commands\locale.ts:150
+#, javascript-format
+msgid "Locale for your direct messages reset to Discord default. Your Discord setting is ${ interaction.locale }."
 msgstr ""
 
 #: src\card.ts:40
@@ -830,60 +816,60 @@ msgctxt "master-duel-rarity"
 msgid "Ultra Rare (UR)"
 msgstr "UR"
 
-#: src\card.ts:513
-#: src\card.ts:524
-#: src\rush-duel.ts:127
+#: src\card.ts:517
+#: src\card.ts:528
+#: src\rush-duel.ts:138
 msgctxt "card-embed"
 msgid "Card Text"
 msgstr "카드 텍스트"
 
-#: src\card.ts:518
+#: src\card.ts:522
 msgctxt "card-embed"
 msgid "Pendulum Effect"
 msgstr "펜듈럼 효과"
 
-#: src\card.ts:539
+#: src\card.ts:545
 msgctxt "card-embed"
 msgid "Card Effect"
 msgstr "카드 효과"
 
-#: src\rush-duel.ts:118
-#: src\rush-duel.ts:139
+#: src\rush-duel.ts:129
+#: src\rush-duel.ts:151
 msgctxt "card-embed"
 msgid "[REQUIREMENT]"
 msgstr "【조건】"
 
-#: src\rush-duel.ts:119
-#: src\rush-duel.ts:140
+#: src\rush-duel.ts:130
+#: src\rush-duel.ts:152
 msgctxt "card-embed"
 msgid "[EFFECT]"
 msgstr "【효과】"
 
-#: src\rush-duel.ts:121
+#: src\rush-duel.ts:132
 msgctxt "card-embed"
 msgid "[CONTINUOUS EFFECT]"
 msgstr "【지속 효과】"
 
-#: src\rush-duel.ts:123
+#: src\rush-duel.ts:134
 msgctxt "card-embed"
 msgid "[MULTI-CHOICE EFFECT]"
 msgstr "【선택 효과】"
 
-#: src\locale.ts:71
+#: src\locale.ts:74
 msgctxt "command-option"
 msgid "result-language"
 msgstr "출력언어"
 
-#: src\locale.ts:131
+#: src\locale.ts:140
 msgctxt "command-option"
 msgid "input-language"
 msgstr "입력언어"
 
-#: src\commands\rush-duel.ts:68
-#: src\commands\rush-duel.ts:80
-#: src\locale.ts:147
-#: src\locale.ts:165
-#: src\locale.ts:181
+#: src\commands\rush-duel.ts:67
+#: src\commands\rush-duel.ts:79
+#: src\locale.ts:156
+#: src\locale.ts:174
+#: src\locale.ts:190
 msgctxt "command-option"
 msgid "input"
 msgstr "입력"
@@ -898,59 +884,61 @@ msgctxt "command-option"
 msgid "page"
 msgstr "페이지"
 
-#: src\commands\help.ts:52
+#: src\commands\help.ts:55
 msgctxt "command-option"
 msgid "command"
 msgstr "명령"
 
-#: src\commands\deck.ts:126
+#: src\commands\deck.ts:87
 msgctxt "command-option"
 msgid "url"
 msgstr ""
 
-#: src\commands\deck.ts:132
+#: src\commands\deck.ts:93
 msgctxt "command-option"
 msgid "file"
 msgstr "파일"
 
-#: src\commands\deck.ts:138
-#: src\commands\deck.ts:144
+#: src\commands\deck.ts:99
+#: src\commands\deck.ts:105
 msgctxt "command-option"
 msgid "deck"
 msgstr "덱"
 
-#: src\commands\deck.ts:150
+#: src\commands\deck.ts:111
 msgctxt "command-option"
 msgid "public"
 msgstr "공개"
 
-#: src\commands\deck.ts:157
+#: src\commands\deck.ts:118
 msgctxt "command-option"
 msgid "stacked"
 msgstr "다량"
 
-#: src\locale.ts:142
+#: src\locale.ts:151
 msgctxt "command-option"
 msgid "name"
 msgstr "이름"
 
-#: src\locale.ts:160
+#: src\locale.ts:169
 msgctxt "command-option"
 msgid "password"
 msgstr "패스워드"
 
-#: src\commands\rush-duel.ts:73
-#: src\events\message-search.ts:293
-#: src\locale.ts:176
+#: src\commands\rush-duel.ts:72
+#: src\events\message-search.ts:301
+#: src\locale.ts:185
 msgctxt "command-option"
 msgid "konami-id"
 msgstr ""
 
+#: src\commands\locale-user.ts:36
 #: src\commands\locale.ts:30
 msgctxt "command-option"
 msgid "get"
 msgstr "가져오기"
 
+#: src\commands\locale-user.ts:41
 #: src\commands\locale.ts:35
 msgctxt "command-option"
 msgid "set"
@@ -961,42 +949,64 @@ msgctxt "command-option"
 msgid "scope"
 msgstr "범위"
 
+#: src\commands\locale-user.ts:46
 #: src\commands\locale.ts:48
 msgctxt "command-option"
 msgid "locale"
 msgstr "로케일"
 
-#: src\commands\price.ts:94
+#: src\commands\price.ts:95
 msgctxt "command-option"
 msgid "vendor"
 msgstr "상점"
 
-#: src\commands\rush-duel.ts:63
+#: src\commands\rush-duel.ts:62
 msgctxt "command-option"
 msgid "search"
 msgstr "검색"
 
-#: src\commands\rush-duel.ts:85
+#: src\commands\rush-duel.ts:84
 msgctxt "command-option"
 msgid "random"
 msgstr "무작위"
 
-#: src\commands\rush-duel.ts:90
+#: src\commands\rush-duel.ts:89
 msgctxt "command-option"
 msgid "art"
 msgstr "일러스트"
 
-#: src\commands\query.ts:36
+#: src\commands\query.ts:35
 msgctxt "command-option"
 msgid "lucene"
 msgstr ""
 
-#: src\locale.ts:74
+#: src\commands\metagame.ts:209
+msgctxt "command-option"
+msgid "strategies"
+msgstr ""
+
+#: src\commands\metagame.ts:234
+#: src\commands\metagame.ts:274
+msgctxt "command-option"
+msgid "format"
+msgstr ""
+
+#: src\commands\metagame.ts:240
+msgctxt "command-option"
+msgid "cards"
+msgstr ""
+
+#: src\commands\metagame.ts:310
+msgctxt "command-option"
+msgid "date-range"
+msgstr ""
+
+#: src\locale.ts:77
 msgctxt "command-option-description"
 msgid "The output language for the card embed, overriding other settings."
 msgstr "다른 설정을 재정의하는 카드 임베드의 출력 언어입니다."
 
-#: src\locale.ts:132
+#: src\locale.ts:141
 msgctxt "command-option-description"
 msgid "The language to search in, defaulting to the result language."
 msgstr "검색할 언어로, 기본적으로 출력 언어로 설정됩니다."
@@ -1006,37 +1016,37 @@ msgctxt "command-option-description"
 msgid "The name of the Yugipedia page you want to search for."
 msgstr "검색할 Yugipedia 페이지의 이름입니다."
 
-#: src\commands\help.ts:55
+#: src\commands\help.ts:58
 msgctxt "command-option-description"
 msgid "The name of a specific Slash Command."
 msgstr "특정 단축 명령의 이름입니다."
 
-#: src\commands\deck.ts:129
+#: src\commands\deck.ts:90
 msgctxt "command-option-description"
 msgid "View a deck by entering a ydke:// URL."
 msgstr "ydke:// URL을 입력하여 덱을 봅니다."
 
-#: src\commands\deck.ts:135
+#: src\commands\deck.ts:96
 msgctxt "command-option-description"
 msgid "View a deck by uploading a .ydk file."
 msgstr "ydk 파일을 업로드 후 덱을 봅니다."
 
-#: src\commands\deck.ts:141
+#: src\commands\deck.ts:102
 msgctxt "command-option-description"
 msgid "The ydke:// URL of the deck you want to view."
 msgstr "보려는 덱의 ydke:// URL입니다."
 
-#: src\commands\deck.ts:147
+#: src\commands\deck.ts:108
 msgctxt "command-option-description"
 msgid "The .ydk file of the deck you want to view."
 msgstr "보려는 덱의 ydk 파일입니다."
 
-#: src\commands\deck.ts:153
+#: src\commands\deck.ts:114
 msgctxt "command-option-description"
 msgid "Whether to display the deck details publicly in chat. This is false by default."
 msgstr "대화에서 덱 세부 정보를 공개적으로 표시할지 여부입니다.이것은 기본적으로 거짓입니다."
 
-#: src\commands\deck.ts:160
+#: src\commands\deck.ts:121
 msgctxt "command-option-description"
 msgid "Whether to display the deck sections as one stacked column. This is false (side-by-side) by default."
 msgstr ""
@@ -1046,8 +1056,8 @@ msgctxt "command-option-description"
 msgid "Display the art for the card with this name."
 msgstr "이 이름으로 카드에 대한 일러스트를 표시합니다."
 
-#: src\commands\rush-duel.ts:69
-#: src\locale.ts:148
+#: src\commands\rush-duel.ts:68
+#: src\locale.ts:157
 msgctxt "command-option-description"
 msgid "Card name, fuzzy matching supported."
 msgstr "카드 이름, 퍼지 매칭이 지원됩니다."
@@ -1057,7 +1067,7 @@ msgctxt "command-option-description"
 msgid "Display the art for the card with this password."
 msgstr "이 패스워드로 카드의 일러스트를 표시합니다."
 
-#: src\locale.ts:167
+#: src\locale.ts:176
 msgctxt "command-option-description"
 msgid "Card password, the eight-digit number printed on the bottom left corner."
 msgstr "카드 패스워드, 왼쪽 하단에 인쇄된 8자리 숫자."
@@ -1067,8 +1077,8 @@ msgctxt "command-option-description"
 msgid "Display the art for the card with this official database ID."
 msgstr "이 공식 데이터베이스 ID로 카드의 일러스트를 표시합니다."
 
-#: src\commands\rush-duel.ts:81
-#: src\locale.ts:182
+#: src\commands\rush-duel.ts:80
+#: src\locale.ts:191
 msgctxt "command-option-description"
 msgid "Konami's official card database identifier."
 msgstr "코나미의 공식 카드 데이터베이스 식별자입니다."
@@ -1108,22 +1118,22 @@ msgctxt "command-option-description"
 msgid "The new default language to use in this channel or server."
 msgstr "이 채널 또는 서버에서 사용할 새 기본 언어입니다."
 
-#: src\commands\price.ts:98
+#: src\commands\price.ts:99
 msgctxt "command-option-description"
 msgid "Display the price for the card with this name."
 msgstr "이 이름으로 카드 가격을 표시합니다."
 
-#: src\commands\price.ts:102
+#: src\commands\price.ts:103
 msgctxt "command-option-description"
 msgid "Display the price for the card with this password."
 msgstr "이 패스워드로 카드 가격을 표시합니다."
 
-#: src\commands\price.ts:105
+#: src\commands\price.ts:106
 msgctxt "command-option-description"
 msgid "Display the price for the card with this official database ID."
 msgstr "이 공식 데이터베이스 ID로 카드 가격을 표시합니다."
 
-#: src\commands\price.ts:95
+#: src\commands\price.ts:96
 msgctxt "command-option-description"
 msgid "The vendor to fetch the price data from."
 msgstr "가격 데이터를 가져올 업체입니다."
@@ -1133,29 +1143,70 @@ msgctxt "command-option-description"
 msgid "The English name of the card you're looking for."
 msgstr "찾고 있는 카드명은 영어입니다."
 
-#: src\commands\rush-duel.ts:64
+#: src\commands\rush-duel.ts:63
 msgctxt "command-option-description"
 msgid "Find all information for the Rush Duel card with this name."
 msgstr "이 이름으로 러시 듀얼 카드에 대한 모든 정보를 찾습니다."
 
-#: src\commands\rush-duel.ts:75
+#: src\commands\rush-duel.ts:74
 msgctxt "command-option-description"
 msgid "Find all information for the Rush Duel card with this official database ID."
 msgstr "이 공식 데이터베이스 ID로 러시 듀얼 카드에 대한 모든 정보를 찾습니다."
 
-#: src\commands\rush-duel.ts:86
+#: src\commands\rush-duel.ts:85
 msgctxt "command-option-description"
 msgid "Get a random Rush Duel card."
 msgstr "무작위로 러시 듀얼 카드를 가져옵니다."
 
-#: src\commands\rush-duel.ts:91
+#: src\commands\rush-duel.ts:90
 msgctxt "command-option-description"
 msgid "Display just the art for the Rush Duel card with this name."
 msgstr "이 이름으로 러시 듀얼 카드에 대한 일러스트만 표시합니다."
 
-#: src\commands\query.ts:37
+#: src\commands\query.ts:36
 msgctxt "command-option-description"
 msgid "Lucene query on YAML Yugi"
+msgstr ""
+
+#: src\commands\locale-user.ts:37
+msgctxt "command-option-description"
+msgid "Check your user-installed Bastion's locale."
+msgstr ""
+
+#: src\commands\locale-user.ts:42
+msgctxt "command-option-description"
+msgid "Configure your user-installed Bastion's locale."
+msgstr ""
+
+#: src\commands\locale-user.ts:47
+msgctxt "command-option-description"
+msgid "The new default language to use for user-installed Bastion."
+msgstr ""
+
+#: src\commands\metagame.ts:212
+msgctxt "command-option-description"
+msgid "Show the top competitive strategies in tournaments and the Master Duel ranked ladder."
+msgstr ""
+
+#: src\commands\metagame.ts:214
+msgctxt "command-option-description"
+msgid "Show the top competitive strategies in tournaments."
+msgstr ""
+
+#: src\commands\metagame.ts:235
+#: src\commands\metagame.ts:275
+msgctxt "command-option-description"
+msgid "Game region."
+msgstr ""
+
+#: src\commands\metagame.ts:242
+msgctxt "command-option-description"
+msgid "Show the most popular cards in tournaments and the Master Duel ranked ladder."
+msgstr ""
+
+#: src\commands\metagame.ts:312
+msgctxt "command-option-description"
+msgid "Limit card usage statistics to this date range. Has no effect for Master Duel."
 msgstr ""
 
 #: src\commands\art.ts:36
@@ -1163,7 +1214,7 @@ msgctxt "command-name"
 msgid "art"
 msgstr "일러스트"
 
-#: src\commands\ping.ts:23
+#: src\commands\ping.ts:25
 msgctxt "command-name"
 msgid "ping"
 msgstr "핑"
@@ -1178,12 +1229,12 @@ msgctxt "command-name"
 msgid "yugipedia"
 msgstr ""
 
-#: src\commands\help.ts:49
+#: src\commands\help.ts:52
 msgctxt "command-name"
 msgid "help"
 msgstr "도움말"
 
-#: src\commands\deck.ts:119
+#: src\commands\deck.ts:80
 msgctxt "command-name"
 msgid "deck"
 msgstr "덱"
@@ -1198,24 +1249,34 @@ msgctxt "command-name"
 msgid "locale"
 msgstr "로케일"
 
-#: src\commands\random.ts:44
+#: src\commands\random.ts:43
 msgctxt "command-name"
 msgid "random"
 msgstr "무작위"
 
-#: src\commands\price.ts:89
+#: src\commands\price.ts:90
 msgctxt "command-name"
 msgid "price"
 msgstr "가격"
 
-#: src\commands\rush-duel.ts:58
+#: src\commands\rush-duel.ts:57
 msgctxt "command-name"
 msgid "rush-duel"
 msgstr "러시듀얼"
 
-#: src\commands\query.ts:30
+#: src\commands\query.ts:29
 msgctxt "command-name"
 msgid "query"
+msgstr ""
+
+#: src\commands\locale-user.ts:31
+msgctxt "command-name"
+msgid "locale-user"
+msgstr ""
+
+#: src\commands\metagame.ts:204
+msgctxt "command-name"
+msgid "metagame"
 msgstr ""
 
 #: src\commands\art.ts:37
@@ -1223,7 +1284,7 @@ msgctxt "command-description"
 msgid "Display the art for a card!"
 msgstr "카드의 일러스트를 표시합니다."
 
-#: src\commands\ping.ts:24
+#: src\commands\ping.ts:26
 msgctxt "command-description"
 msgid "Test latency to the new bot instance."
 msgstr "새로운 봇 인스턴스의 지연 시간을 테스트합니다."
@@ -1238,12 +1299,12 @@ msgctxt "command-description"
 msgid "Search the Yugipedia wiki for a page and link to it."
 msgstr "Yugipedia에서 검색하고 링크를 출력합니다."
 
-#: src\commands\help.ts:50
+#: src\commands\help.ts:53
 msgctxt "command-description"
 msgid "Get help with a Slash Command."
 msgstr "슬래시 명령에 도움을 받으십시오."
 
-#: src\commands\deck.ts:122
+#: src\commands\deck.ts:83
 msgctxt "command-description"
 msgid "Display a deck list from ydke:// or .ydk format, exported from a number of deck building programs."
 msgstr "여러 덱 제작 프로그램에서 내보낸 덱 목록을ydke:// 또는 .ydk 형식으로 표시합니다."
@@ -1258,24 +1319,34 @@ msgctxt "command-description"
 msgid "Check or set Bastion's locale for this channel or server."
 msgstr "이 채널 또는 서버에 대한 Bastion의 로케일을 확인하거나 설정합니다."
 
-#: src\commands\random.ts:45
+#: src\commands\random.ts:44
 msgctxt "command-description"
 msgid "Get a random Yu-Gi-Oh! card."
 msgstr "유희왕 카드를 무작위로 받으십시오."
 
-#: src\commands\price.ts:90
+#: src\commands\price.ts:91
 msgctxt "command-description"
 msgid "Display the price for a card!"
 msgstr "카드 가격 표시"
 
-#: src\commands\rush-duel.ts:59
+#: src\commands\rush-duel.ts:58
 msgctxt "command-description"
 msgid "Find information on Rush Duel cards."
 msgstr "러시 듀얼 카드 정보 찾기"
 
-#: src\commands\query.ts:31
+#: src\commands\query.ts:30
 msgctxt "command-description"
 msgid "Advanced search prototype"
+msgstr ""
+
+#: src\commands\locale-user.ts:32
+msgctxt "command-description"
+msgid "Check or set user-installed Bastion's locale."
+msgstr ""
+
+#: src\commands\metagame.ts:205
+msgctxt "command-description"
+msgid "Show statistics on the current competitive state of play."
 msgstr ""
 
 #: src\commands\locale.ts:43
@@ -1288,7 +1359,71 @@ msgctxt "command-option-choice"
 msgid "server"
 msgstr "서버"
 
+#: src\commands\locale-user.ts:49
 #: src\commands\locale.ts:51
 msgctxt "command-option-choice"
 msgid "Discord default"
 msgstr "디스코드 기본값"
+
+#: src\commands\metagame.ts:219
+#: src\commands\metagame.ts:251
+msgctxt "command-option-choice"
+msgid "TCG"
+msgstr ""
+
+#: src\commands\metagame.ts:220
+#: src\commands\metagame.ts:255
+msgctxt "command-option-choice"
+msgid "OCG"
+msgstr ""
+
+#: src\commands\metagame.ts:221
+#: src\commands\metagame.ts:259
+msgctxt "command-option-choice"
+msgid "OCG (Asian-English)"
+msgstr ""
+
+#: src\commands\metagame.ts:228
+msgctxt "command-option-choice"
+msgid "Master Duel Diamond+ tier list"
+msgstr ""
+
+#: src\commands\metagame.ts:261
+msgctxt "command-option-choice"
+msgid "Master Duel ranked ladder"
+msgstr ""
+
+#: src\commands\metagame.ts:283
+msgctxt "command-option-choice"
+msgid "Current format"
+msgstr ""
+
+#: src\commands\metagame.ts:287
+msgctxt "command-option-choice"
+msgid "Since last Forbidden/Limited List"
+msgstr ""
+
+#: src\commands\metagame.ts:291
+msgctxt "command-option-choice"
+msgid "Last 7 days"
+msgstr ""
+
+#: src\commands\metagame.ts:295
+msgctxt "command-option-choice"
+msgid "Last 14 days"
+msgstr ""
+
+#: src\commands\metagame.ts:299
+msgctxt "command-option-choice"
+msgid "Last 30 days"
+msgstr ""
+
+#: src\commands\metagame.ts:303
+msgctxt "command-option-choice"
+msgid "Last three months"
+msgstr ""
+
+#: src\commands\metagame.ts:307
+msgctxt "command-option-choice"
+msgid "Last six months"
+msgstr ""

--- a/translations/ko.po
+++ b/translations/ko.po
@@ -6,33 +6,50 @@ msgstr ""
 "MIME-Version: 1.0\n"
 "Content-Transfer-Encoding: 8bit\n"
 
-#: src\card.ts:412
-#: src\rush-duel.ts:48
+#: src\card.ts:416
+#: src\rush-duel.ts:39
 msgid "🔗 Links"
 msgstr "🔗 링크"
 
-#: src\card.ts:413
+#: src\card.ts:417
 #, javascript-format
 msgid "[Official Konami DB](${ official }) | [OCG Rulings](${ rulings }) | [Yugipedia](${ yugipedia }) | [YGOPRODECK](${ ygoprodeck })"
 msgstr "[코나미 공식 카드 DB](${ official }) | [OCG 공식 재정](${ rulings }) | [Yugipedia](${ yugipedia }) | [YGOPRODECK](${ ygoprodeck })"
 
-#: src\card.ts:416
+#: src\card.ts:420
 #, javascript-format
 msgid "[Yugipedia](${ yugipedia }) | [YGOPRODECK](${ ygoprodeck })"
 msgstr "[Yugipedia](${ yugipedia }) | [YGOPRODECK](${ ygoprodeck })"
 
-#: src\card.ts:490
-#: src\rush-duel.ts:103
+#: src\card.ts:489
+#: src\rush-duel.ts:92
 #, javascript-format
 msgid "**Type**: ${ raceIcon } ${ localizedMonsterTypeLine }"
 msgstr "**종족**: ${ raceIcon } ${ localizedMonsterTypeLine }"
 
-#: src\card.ts:500
+#: src\card.ts:491
+#: src\rush-duel.ts:94
+#, javascript-format
+msgid "**Attribute**: ${ AttributeIcon[card.attribute] } ${ localizedAttribute }"
+msgstr "**속성**: ${ AttributeIcon[card.attribute] } ${ localizedAttribute }"
+
+#: src\card.ts:495
+#, javascript-format
+msgid "**Rank**: ${ Icon.Rank } ${ card.rank } **ATK**: ${ card.atk } **DEF**: ${ card.def }"
+msgstr "**랭크**: ${ Icon.Rank } ${ card.rank } **공격력**: ${ card.atk } **수비력**: ${ card.def }"
+
+#: src\card.ts:498
 #, javascript-format
 msgid "**Link Rating**: ${ card.link_arrows.length } **ATK**: ${ card.atk } **Link Arrows**: ${ arrows }"
 msgstr "**LINK**: ${ card.link_arrows.length } **공격력**: ${ card.atk } **링크 마커**: ${ arrows }"
 
-#: src\card.ts:511
+#: src\card.ts:500
+#: src\rush-duel.ts:96
+#, javascript-format
+msgid "**Level**: ${ Icon.Level } ${ card.level } **ATK**: ${ card.atk } **DEF**: ${ card.def }"
+msgstr "**레벨**: ${ Icon.Level } ${ card.level } **공격력**: ${ card.atk } **수비력**: ${ card.def }"
+
+#: src\card.ts:507
 #, javascript-format
 msgid "**Pendulum Scale**: ${ formattedScale }"
 msgstr "**펜듈럼 스케일**: ${ formattedScale }"
@@ -53,7 +70,7 @@ msgid "Password: ${ card.password } | Not yet released"
 msgstr "패스워드: ${ card.password } | Not yet released"
 
 #: src\card.ts:351
-#: src\rush-duel.ts:158
+#: src\rush-duel.ts:146
 msgid "Not yet released"
 msgstr "미발매"
 
@@ -62,64 +79,64 @@ msgstr "미발매"
 msgid "Placeholder ID: ${ card.fake_password }"
 msgstr "플레이스홀더 ID: ${ card.fake_password }"
 
-#: src\utils.ts:44
+#: src\utils.ts:41
 msgid "🛠️ This command is in development."
 msgstr "🛠️ 이 명령은 개발 중입니다."
 
-#: src\utils.ts:45
+#: src\utils.ts:42
 msgid "📨 Please send feedback to [our issue tracker](https://github.com/DawnbrandBots/bastion-bot) or the [support server](https://discord.gg/4aFuPyuE96)!"
 msgstr "📨 [문제 추적기](https://github.com/DawnbrandBots/bastion-bot) 또는 [지원 서버](https://discord.gg/4aFuPyuE96)로 피드백을 보내주십시오!"
 
-#: src\utils.ts:56
+#: src\utils.ts:53
 msgid "Please consider supporting us!"
 msgstr "저희를 지원해 주세요!"
 
-#: src\utils.ts:57
+#: src\utils.ts:54
 msgid "Help keep Bastion online!"
 msgstr "Bastion을 온라인 상태로 유지하는 것을 도와 주세요!"
 
-#: src\utils.ts:58
+#: src\utils.ts:55
 msgid "Please help keep Bastion online!"
 msgstr "저희가 Bastion을 온라인 상태로 유지하는 것을 도와 주세요!"
 
-#: src\utils.ts:59
+#: src\utils.ts:56
 msgid "Was Bastion helpful? Consider supporting us!"
 msgstr "Bastion이 도움이 되었나요? 저희를 지원해 주세요!"
 
-#: src\utils.ts:60
+#: src\utils.ts:57
 msgid "Was Bastion helpful? We need your support!"
 msgstr "Bastion이 도움이 되었나요? 여러분의 지원이 필요해요!"
 
-#: src\utils.ts:61
+#: src\utils.ts:58
 msgid "Did you find Bastion useful? Consider supporting us!"
 msgstr "Bastion이 유용하다고 생각했나요? 저희를 지원해 주시는 건 어떤가요?"
 
-#: src\utils.ts:62
+#: src\utils.ts:59
 msgid "Did you find Bastion useful? Help keep it online!"
 msgstr "Bastion이 유용하다고 생각했나요? 온라인 상태로 유지하는 것을 도와 주세요!"
 
-#: src\utils.ts:63
+#: src\utils.ts:60
 msgid "Did you find Bastion useful? We need your support!"
 msgstr "Bastion이 유용하다고 생각했나요? 여러분의 지원이 필요해요!"
 
-#: src\utils.ts:64
+#: src\utils.ts:61
 msgid "Enjoy Bastion? Help keep it online!"
 msgstr "Bastion을 잘 사용하고 계신가요? 온라인 상태로 유지하는 것을 도와 주세요!"
 
-#: src\utils.ts:65
+#: src\utils.ts:62
 msgid "Enjoy Bastion? Consider supporting us!"
 msgstr "Bastion을 잘 사용하고 계신가요? 저희를 지원해 주시는 건 어떤가요?"
 
-#: src\utils.ts:66
+#: src\utils.ts:63
 msgid "Found what you were looking for? Consider supporting us!"
 msgstr "찾으시려던 것을 찾으셨나요? 저희를 지원해 주시는 건 어떤가요?"
 
 #: src\commands\art.ts:63
-#: src\commands\price.ts:132
-#: src\commands\rush-duel.ts:171
-#: src\commands\rush-duel.ts:202
+#: src\commands\price.ts:131
+#: src\commands\rush-duel.ts:172
+#: src\commands\rush-duel.ts:203
 #: src\commands\search.ts:64
-#: src\events\message-search.ts:265
+#: src\events\message-search.ts:258
 #, javascript-format
 msgid "Could not find a card matching `${ input }`!"
 msgstr "`${ input }`에 일치하는 카드를 찾을 수 없습니다!"
@@ -146,7 +163,11 @@ msgstr "이 서버에 대한 언어 설정: ${ guildOverride }"
 msgid "Discord Community locale for this server: ${ interaction.guildLocale }"
 msgstr "이 서버의 디스코드 커뮤니티의 언어 설정: ${ interaction.guildLocale }"
 
-#: src\commands\locale-user.ts:76
+#: src\commands\locale.ts:89
+#, javascript-format
+msgid "Locale override for this direct message: ${ override }"
+msgstr "이 다이렉트 메시지에 대한 언어 설정: ${ override }"
+
 #: src\commands\locale.ts:92
 #, javascript-format
 msgid "Your Discord locale: ${ interaction.locale }"
@@ -184,14 +205,24 @@ msgstr "커뮤니티 서버의 서버 전체 기본값은 ${ interaction.guildLo
 msgid "Sorry, you must have the Manage Server permission to do this. If you think this is an error, contact your server admin or report a bug."
 msgstr "죄송합니다. 이 작업을 수행하려면 서버 관리 권한이 있어야 합니다. 이 메시지가 잘못 출력되었다면, 서버 관리자에게 문의하시거나 버그를 신고해 주세요."
 
-#: src\commands\ping.ts:38
-#: src\events\message-ping.ts:45
+#: src\commands\locale.ts:146
+#, javascript-format
+msgid "Locale for this direct message overridden with ${ locale }. Your Discord setting is ${ interaction.locale }."
+msgstr "해당 다이렉트 메시지의 언어 설정은 ${ locale } 으로 재정의되었습니다. 당신의 디스코드 설정은 ${ interaction.locale } 입니다."
+
+#: src\commands\locale.ts:150
+#, javascript-format
+msgid "Locale for this direct message reset to Discord default. Your Discord setting is ${ interaction.locale }."
+msgstr "해당 다이렉트 메시지의 언어 설정은 디스코드 기본값으로 리셋되었습니다. 당신의 디스코드 설정은 ${ interaction.locale } 입니다."
+
+#: src\commands\ping.ts:36
+#: src\events\message-ping.ts:47
 #, javascript-format
 msgid "Average WebSocket ping (new instance): ${ ping } ms"
 msgstr "평균 WebSocket 핑 (새로운 인스턴스): ${ ping } ms"
 
-#: src\commands\ping.ts:42
-#: src\events\message-ping.ts:110
+#: src\commands\ping.ts:40
+#: src\events\message-ping.ts:112
 #, javascript-format
 msgid "Total latency: ${ latency } ms"
 msgstr "총 지연 시간: ${ latency } ms"
@@ -201,113 +232,130 @@ msgstr "총 지연 시간: ${ latency } ms"
 msgid "Could not find a Yugipedia page named `${ page }`."
 msgstr "`${ page }`라는 이름의 Yugipedia 페이지를 찾을 수 없습니다."
 
-#: src\commands\deck.ts:205
+#: src\commands\deck.ts:244
 #, javascript-format
 msgid "${ counts.Monster } Monster"
 msgid_plural "${ counts.Monster } Monsters"
 msgstr[0] "몬스터 ${ counts.Monster } 장"
 
-#: src\commands\deck.ts:208
+#: src\commands\deck.ts:247
 #, javascript-format
 msgid "${ counts.Spell } Spell"
 msgid_plural "${ counts.Spell } Spells"
 msgstr[0] "마법 ${ counts.Spell } 장"
 
-#: src\commands\deck.ts:211
+#: src\commands\deck.ts:250
 #, javascript-format
 msgid "${ counts.Trap } Trap"
 msgid_plural "${ counts.Trap } Traps"
 msgstr[0] "함정 ${ counts.Trap } 장"
 
-#: src\commands\deck.ts:239
+#: src\commands\deck.ts:278
 msgid "Your Deck"
 msgstr "덱"
 
-#: src\commands\deck.ts:244
+#: src\commands\deck.ts:283
 #, javascript-format
 msgid "Main Deck (${ deck.main.length } card — ${ countDetail })"
 msgid_plural "Main Deck (${ deck.main.length } cards — ${ countDetail })"
 msgstr[0] "메인 덱 (${ deck.main.length } card — ${ countDetail })"
 
-#: src\commands\deck.ts:251
+#: src\commands\deck.ts:290
 msgid "Main Deck (continued)"
 msgstr "메인 덱 (계속)"
 
-#: src\commands\deck.ts:265
+#: src\commands\deck.ts:304
 msgid "Extra Deck (continued)"
 msgstr "엑스트라 덱 (계속)"
 
-#: src\commands\deck.ts:279
+#: src\commands\deck.ts:318
 msgid "Side Deck (continued)"
 msgstr "사이드 덱 (계속)"
 
-#: src\commands\deck.ts:347
+#: src\commands\deck.ts:407
 msgid "Error: Your deck is empty."
 msgstr "오류: 덱이 비었습니다."
 
-#: src\events\message-ping.ts:47
+#: src\events\message-ping.ts:49
 msgid "Free and open source _Yu-Gi-Oh!_ bot"
 msgstr "자유-오픈 소스 유희왕 봇"
 
-#: src\events\message-ping.ts:70
+#: src\events\message-ping.ts:72
 #, javascript-format
 msgid "Revision: ${ process.env.BOT_REVISION }."
 msgstr "수정: ${ process.env.BOT_REVISION }."
 
-#: src\commands\deck.ts:289
+#: src\commands\deck.ts:328
 msgid ".ydk files must have the .ydk extension!"
 msgstr ".ydk 파일의 확장자는 .ydk여야 합니다!"
 
-#: src\commands\deck.ts:292
+#: src\commands\deck.ts:331
 msgid ".ydk files should not be larger than 1 KB!"
 msgstr ".ydk 파일은 1 KB보다 크면 안 됩니다!"
 
-#: src\commands\deck.ts:282
+#: src\commands\deck.ts:321
 msgid "ydke URL"
 msgstr ""
 
 #: src\card.ts:455
-#: src\rush-duel.ts:75
+#: src\rush-duel.ts:61
 #. Forbidden/Limited Lists or Limit Regulations in the OCG
 #, javascript-format
 msgid "**Limit**: ${ limitRegulationDisplay }"
 msgstr "**제한**: ${ limitRegulationDisplay }"
 
-#: src\commands\price.ts:70
+#: src\commands\price.ts:69
 msgid "TCGPlayer"
 msgstr ""
 
-#: src\commands\price.ts:71
+#: src\commands\price.ts:70
 msgid "Cardmarket"
 msgstr ""
 
-#: src\commands\price.ts:148
+#: src\commands\price.ts:147
 msgid "No market price"
 msgstr "시장 가격 불명"
 
-#: src\commands\price.ts:156
+#: src\commands\price.ts:155
 #, javascript-format
 msgid "Prices for ${ card.name[resultLanguage] } - ${ vendorName }"
 msgstr "${ vendorName } 의 ${ card.name[resultLanguage] } 가격"
 
-#: src\commands\price.ts:170
+#: src\commands\price.ts:169
 #, javascript-format
 msgid "Could not find prices for `${ name }`!"
 msgstr "`${ name }`의 가격을 찾을 수 없습니다!"
 
-#: src\commands\deck.ts:363
+#: src\commands\deck.ts:425
+#. prepare interaction button for FTP upload
 msgid "Upload to YGOPRODECK"
 msgstr "YGOPRODECK에 업로드"
 
-#: src\events\message-search.ts:271
+#: src\commands\deck.ts:483
+#. disable original button
+#. prepare row to disable button on original message
+msgid "Upload Complete"
+msgstr "업로드 완료"
+
+#: src\commands\deck.ts:470
+msgid "Deck upload failed!"
+msgstr "덱 업로드에 실패했습니다!"
+
+#: src\commands\deck.ts:491
+#. reply in affirmation
+#, javascript-format
+msgid "Deck successfully uploaded to <${ url }>!"
+msgstr "<${ url }>에 덱 업로드를 완료했습니다!"
+
+#: src\events\message-search.ts:264
 msgid "💬 Translations missing?"
 msgstr "💬 번역이 존재합니까?"
 
-#: src\events\message-search.ts:272
+#: src\events\message-search.ts:265
 msgid "Help translate Bastion at the links above."
 msgstr "위 링크에서 Bastion 번역을 도와주세요."
 
-#: src\events\message-ping.ts:48
+#: src\events\message-ping.ts:50
 msgid ""
 "❓ Help documentation on [GitHub](https://github.com/DawnbrandBots/bastion-bot), or use `.commands` and `.help`.\n"
 "🟢 Licence: [GNU AGPL 3.0+](https://choosealicense.com/licenses/agpl-3.0/).\n"
@@ -323,37 +371,37 @@ msgid ""
 "💬 Translations missing? Help translate Bastion on [GitHub](https://github.com/DawnbrandBots/bastion-bot)."
 msgstr ""
 
-#: src\events\message-search.ts:263
-#: src\events\message-search.ts:302
+#: src\events\message-search.ts:256
+#: src\events\message-search.ts:294
 #, javascript-format
 msgid "Search type: ${ localisedType }"
 msgstr "검색 종류: ${ localisedType }"
 
-#: src\events\message-search.ts:242
+#: src\events\message-search.ts:236
 #, javascript-format
 msgid "Search language: **${ localisedInputLanguage }** (${ inputLanguage }). Check defaults with </locale get:${ id }> and configure with </locale set:${ id }>"
 msgstr "검색 언어: **${ localisedInputLanguage }** (${ inputLanguage }). </locale get:${ id }>의 기본값을 확인하고 </locale set:${ id }>를 설정합니다."
 
-#: src\events\message-ping.ts:93
+#: src\events\message-ping.ts:95
 msgid "⚠️ You pinged me, but I am missing permissions in the channel!"
 msgstr "⚠️ 당신은 저를 부르셨지만, 해당 채널에서 권한이 없습니다!"
 
-#: src\events\message-ping.ts:96
-#: src\events\message-search.ts:340
+#: src\events\message-ping.ts:98
+#: src\events\message-search.ts:332
 msgid "Please have a server administrator [fix this](https://github.com/DawnbrandBots/bastion-bot#discord-permissions)."
 msgstr "서버 관리자에게 문의하십시오 [문제 해결](https://github.com/DawnbrandBots/bastion-bot#discord-permissions)."
 
-#: src\events\message-search.ts:337
+#: src\events\message-search.ts:329
 msgid "⚠️ I am missing permissions in the channel!"
 msgstr "⚠️ 해당 채널에서 권한이 없습니다!"
 
-#: src\commands\deck.ts:258
+#: src\commands\deck.ts:297
 #, javascript-format
 msgid "Extra Deck (${ deck.extra.length } card — ${ countDetail })"
 msgid_plural "Extra Deck (${ deck.extra.length } cards — ${ countDetail })"
 msgstr[0] "엑스트라 덱 (${ deck.extra.length } cards — ${ countDetail })"
 
-#: src\commands\deck.ts:272
+#: src\commands\deck.ts:311
 #, javascript-format
 msgid "Side Deck (${ deck.side.length } card — ${ countDetail })"
 msgid_plural "Side Deck (${ deck.side.length } cards — ${ countDetail })"
@@ -374,82 +422,48 @@ msgstr "YGOPRODECK을 위해 `${ searchTerm }`을(를) 검색하는 데 문제�
 msgid "Something went wrong searching Yugipedia for `${ page }`."
 msgstr "Yugipedia를 위해 `${ page }`을(를) 검색하는 데 문제가 발생하였습니다."
 
-#: src\rush-duel.ts:49
+#: src\rush-duel.ts:40
 #, javascript-format
 msgid "[Official Konami DB](${ official }) | [Rulings (Japanese)](${ rulings }) | [Yugipedia](${ yugipedia }) | [RushCard](${ rushcard })"
 msgstr "[공식 코나미 DB](${ official }) | [OCG 규칙](${ rulings }) | [Yugipedia](${ yugipedia }) | [RushCard](${ rushcard })"
 
-#: src\rush-duel.ts:52
+#: src\rush-duel.ts:43
 #, javascript-format
 msgid "[Yugipedia](${ yugipedia }) | [RushCard](${ rushcard })"
 msgstr ""
 
-#: src\rush-duel.ts:71
+#: src\rush-duel.ts:57
 msgid "__**LEGEND**__"
 msgstr ""
 
-#: src\rush-duel.ts:110
+#: src\rush-duel.ts:99
 #, javascript-format
 msgid "**MAXIMUM ATK**: ${ card.maximum_atk }"
 msgstr ""
 
-#: src\rush-duel.ts:158
+#: src\rush-duel.ts:146
 #, javascript-format
 msgid "Konami ID #${ card.konami_id }"
 msgstr "코나미 ID #${ card.konami_id }"
 
 #: src\art.ts:129
+#: src\commands\deck.ts:451
 msgid "Buttons can only be used by the user who called Bastion."
 msgstr "Bastion은 호출한 사용자만 이용할 수 있습니다."
 
-#: src\rush-duel.ts:217
+#: src\card.ts:462
+#, javascript-format
+msgid "**Master Duel rarity**: ${ rarity_icon } ${ localized_rarity }"
+msgstr "**레어리티 (MD)**: ${ rarity_icon } ${ localized_rarity }"
+
+#: src\rush-duel.ts:205
 #, javascript-format
 msgid "Using ${ searchTrigger }, you can search for Rush Duel cards directly in messages without autocomplete"
 msgstr ""
 
-#: src\events\message-search.ts:304
+#: src\events\message-search.ts:296
 #, javascript-format
 msgid "Could not find a Rush Duel card matching `${ input }`!"
-msgstr ""
-
-#: src\card.ts:462
-#, javascript-format
-msgid "**Master Duel rarity**: ${ rarityIcon } ${ localizedRarity }"
-msgstr ""
-
-#: src\card.ts:492
-#: src\rush-duel.ts:105
-#, javascript-format
-msgid "**Attribute**: ${ attributeIcon } ${ localizedAttribute }"
-msgstr ""
-
-#: src\card.ts:497
-#, javascript-format
-msgid "**Rank**: ${ rankIcon } ${ card.rank } **ATK**: ${ card.atk } **DEF**: ${ card.def }"
-msgstr ""
-
-#: src\card.ts:503
-#: src\rush-duel.ts:107
-#, javascript-format
-msgid "**Level**: ${ levelIcon } ${ card.level } **ATK**: ${ card.atk } **DEF**: ${ card.def }"
-msgstr ""
-
-#: src\commands\locale-user.ts:73
-#: src\commands\locale.ts:89
-#, javascript-format
-msgid "Locale override for your direct messages: ${ override }"
-msgstr ""
-
-#: src\commands\locale-user.ts:83
-#: src\commands\locale.ts:146
-#, javascript-format
-msgid "Locale for your direct messages overridden with ${ locale }. Your Discord setting is ${ interaction.locale }."
-msgstr ""
-
-#: src\commands\locale-user.ts:87
-#: src\commands\locale.ts:150
-#, javascript-format
-msgid "Locale for your direct messages reset to Discord default. Your Discord setting is ${ interaction.locale }."
 msgstr ""
 
 #: src\card.ts:40
@@ -816,60 +830,60 @@ msgctxt "master-duel-rarity"
 msgid "Ultra Rare (UR)"
 msgstr "UR"
 
-#: src\card.ts:517
-#: src\card.ts:528
-#: src\rush-duel.ts:138
+#: src\card.ts:513
+#: src\card.ts:524
+#: src\rush-duel.ts:127
 msgctxt "card-embed"
 msgid "Card Text"
 msgstr "카드 텍스트"
 
-#: src\card.ts:522
+#: src\card.ts:518
 msgctxt "card-embed"
 msgid "Pendulum Effect"
 msgstr "펜듈럼 효과"
 
-#: src\card.ts:545
+#: src\card.ts:539
 msgctxt "card-embed"
 msgid "Card Effect"
 msgstr "카드 효과"
 
-#: src\rush-duel.ts:129
-#: src\rush-duel.ts:151
+#: src\rush-duel.ts:118
+#: src\rush-duel.ts:139
 msgctxt "card-embed"
 msgid "[REQUIREMENT]"
 msgstr "【조건】"
 
-#: src\rush-duel.ts:130
-#: src\rush-duel.ts:152
+#: src\rush-duel.ts:119
+#: src\rush-duel.ts:140
 msgctxt "card-embed"
 msgid "[EFFECT]"
 msgstr "【효과】"
 
-#: src\rush-duel.ts:132
+#: src\rush-duel.ts:121
 msgctxt "card-embed"
 msgid "[CONTINUOUS EFFECT]"
 msgstr "【지속 효과】"
 
-#: src\rush-duel.ts:134
+#: src\rush-duel.ts:123
 msgctxt "card-embed"
 msgid "[MULTI-CHOICE EFFECT]"
 msgstr "【선택 효과】"
 
-#: src\locale.ts:74
+#: src\locale.ts:71
 msgctxt "command-option"
 msgid "result-language"
 msgstr "출력언어"
 
-#: src\locale.ts:140
+#: src\locale.ts:131
 msgctxt "command-option"
 msgid "input-language"
 msgstr "입력언어"
 
-#: src\commands\rush-duel.ts:67
-#: src\commands\rush-duel.ts:79
-#: src\locale.ts:156
-#: src\locale.ts:174
-#: src\locale.ts:190
+#: src\commands\rush-duel.ts:68
+#: src\commands\rush-duel.ts:80
+#: src\locale.ts:147
+#: src\locale.ts:165
+#: src\locale.ts:181
 msgctxt "command-option"
 msgid "input"
 msgstr "입력"
@@ -884,61 +898,59 @@ msgctxt "command-option"
 msgid "page"
 msgstr "페이지"
 
-#: src\commands\help.ts:55
+#: src\commands\help.ts:52
 msgctxt "command-option"
 msgid "command"
 msgstr "명령"
 
-#: src\commands\deck.ts:87
+#: src\commands\deck.ts:126
 msgctxt "command-option"
 msgid "url"
 msgstr ""
 
-#: src\commands\deck.ts:93
+#: src\commands\deck.ts:132
 msgctxt "command-option"
 msgid "file"
 msgstr "파일"
 
-#: src\commands\deck.ts:99
-#: src\commands\deck.ts:105
+#: src\commands\deck.ts:138
+#: src\commands\deck.ts:144
 msgctxt "command-option"
 msgid "deck"
 msgstr "덱"
 
-#: src\commands\deck.ts:111
+#: src\commands\deck.ts:150
 msgctxt "command-option"
 msgid "public"
 msgstr "공개"
 
-#: src\commands\deck.ts:118
+#: src\commands\deck.ts:157
 msgctxt "command-option"
 msgid "stacked"
 msgstr "다량"
 
-#: src\locale.ts:151
+#: src\locale.ts:142
 msgctxt "command-option"
 msgid "name"
 msgstr "이름"
 
-#: src\locale.ts:169
+#: src\locale.ts:160
 msgctxt "command-option"
 msgid "password"
 msgstr "패스워드"
 
-#: src\commands\rush-duel.ts:72
-#: src\events\message-search.ts:301
-#: src\locale.ts:185
+#: src\commands\rush-duel.ts:73
+#: src\events\message-search.ts:293
+#: src\locale.ts:176
 msgctxt "command-option"
 msgid "konami-id"
 msgstr ""
 
-#: src\commands\locale-user.ts:36
 #: src\commands\locale.ts:30
 msgctxt "command-option"
 msgid "get"
 msgstr "가져오기"
 
-#: src\commands\locale-user.ts:41
 #: src\commands\locale.ts:35
 msgctxt "command-option"
 msgid "set"
@@ -949,64 +961,42 @@ msgctxt "command-option"
 msgid "scope"
 msgstr "범위"
 
-#: src\commands\locale-user.ts:46
 #: src\commands\locale.ts:48
 msgctxt "command-option"
 msgid "locale"
 msgstr "로케일"
 
-#: src\commands\price.ts:95
+#: src\commands\price.ts:94
 msgctxt "command-option"
 msgid "vendor"
 msgstr "상점"
 
-#: src\commands\rush-duel.ts:62
+#: src\commands\rush-duel.ts:63
 msgctxt "command-option"
 msgid "search"
 msgstr "검색"
 
-#: src\commands\rush-duel.ts:84
+#: src\commands\rush-duel.ts:85
 msgctxt "command-option"
 msgid "random"
 msgstr "무작위"
 
-#: src\commands\rush-duel.ts:89
+#: src\commands\rush-duel.ts:90
 msgctxt "command-option"
 msgid "art"
 msgstr "일러스트"
 
-#: src\commands\query.ts:35
+#: src\commands\query.ts:36
 msgctxt "command-option"
 msgid "lucene"
 msgstr ""
 
-#: src\commands\metagame.ts:209
-msgctxt "command-option"
-msgid "strategies"
-msgstr ""
-
-#: src\commands\metagame.ts:234
-#: src\commands\metagame.ts:274
-msgctxt "command-option"
-msgid "format"
-msgstr ""
-
-#: src\commands\metagame.ts:240
-msgctxt "command-option"
-msgid "cards"
-msgstr ""
-
-#: src\commands\metagame.ts:310
-msgctxt "command-option"
-msgid "date-range"
-msgstr ""
-
-#: src\locale.ts:77
+#: src\locale.ts:74
 msgctxt "command-option-description"
 msgid "The output language for the card embed, overriding other settings."
 msgstr "다른 설정을 재정의하는 카드 임베드의 출력 언어입니다."
 
-#: src\locale.ts:141
+#: src\locale.ts:132
 msgctxt "command-option-description"
 msgid "The language to search in, defaulting to the result language."
 msgstr "검색할 언어로, 기본적으로 출력 언어로 설정됩니다."
@@ -1016,37 +1006,37 @@ msgctxt "command-option-description"
 msgid "The name of the Yugipedia page you want to search for."
 msgstr "검색할 Yugipedia 페이지의 이름입니다."
 
-#: src\commands\help.ts:58
+#: src\commands\help.ts:55
 msgctxt "command-option-description"
 msgid "The name of a specific Slash Command."
 msgstr "특정 단축 명령의 이름입니다."
 
-#: src\commands\deck.ts:90
+#: src\commands\deck.ts:129
 msgctxt "command-option-description"
 msgid "View a deck by entering a ydke:// URL."
 msgstr "ydke:// URL을 입력하여 덱을 봅니다."
 
-#: src\commands\deck.ts:96
+#: src\commands\deck.ts:135
 msgctxt "command-option-description"
 msgid "View a deck by uploading a .ydk file."
 msgstr "ydk 파일을 업로드 후 덱을 봅니다."
 
-#: src\commands\deck.ts:102
+#: src\commands\deck.ts:141
 msgctxt "command-option-description"
 msgid "The ydke:// URL of the deck you want to view."
 msgstr "보려는 덱의 ydke:// URL입니다."
 
-#: src\commands\deck.ts:108
+#: src\commands\deck.ts:147
 msgctxt "command-option-description"
 msgid "The .ydk file of the deck you want to view."
 msgstr "보려는 덱의 ydk 파일입니다."
 
-#: src\commands\deck.ts:114
+#: src\commands\deck.ts:153
 msgctxt "command-option-description"
 msgid "Whether to display the deck details publicly in chat. This is false by default."
 msgstr "대화에서 덱 세부 정보를 공개적으로 표시할지 여부입니다.이것은 기본적으로 거짓입니다."
 
-#: src\commands\deck.ts:121
+#: src\commands\deck.ts:160
 msgctxt "command-option-description"
 msgid "Whether to display the deck sections as one stacked column. This is false (side-by-side) by default."
 msgstr ""
@@ -1056,8 +1046,8 @@ msgctxt "command-option-description"
 msgid "Display the art for the card with this name."
 msgstr "이 이름으로 카드에 대한 일러스트를 표시합니다."
 
-#: src\commands\rush-duel.ts:68
-#: src\locale.ts:157
+#: src\commands\rush-duel.ts:69
+#: src\locale.ts:148
 msgctxt "command-option-description"
 msgid "Card name, fuzzy matching supported."
 msgstr "카드 이름, 퍼지 매칭이 지원됩니다."
@@ -1067,7 +1057,7 @@ msgctxt "command-option-description"
 msgid "Display the art for the card with this password."
 msgstr "이 패스워드로 카드의 일러스트를 표시합니다."
 
-#: src\locale.ts:176
+#: src\locale.ts:167
 msgctxt "command-option-description"
 msgid "Card password, the eight-digit number printed on the bottom left corner."
 msgstr "카드 패스워드, 왼쪽 하단에 인쇄된 8자리 숫자."
@@ -1077,8 +1067,8 @@ msgctxt "command-option-description"
 msgid "Display the art for the card with this official database ID."
 msgstr "이 공식 데이터베이스 ID로 카드의 일러스트를 표시합니다."
 
-#: src\commands\rush-duel.ts:80
-#: src\locale.ts:191
+#: src\commands\rush-duel.ts:81
+#: src\locale.ts:182
 msgctxt "command-option-description"
 msgid "Konami's official card database identifier."
 msgstr "코나미의 공식 카드 데이터베이스 식별자입니다."
@@ -1118,22 +1108,22 @@ msgctxt "command-option-description"
 msgid "The new default language to use in this channel or server."
 msgstr "이 채널 또는 서버에서 사용할 새 기본 언어입니다."
 
-#: src\commands\price.ts:99
+#: src\commands\price.ts:98
 msgctxt "command-option-description"
 msgid "Display the price for the card with this name."
 msgstr "이 이름으로 카드 가격을 표시합니다."
 
-#: src\commands\price.ts:103
+#: src\commands\price.ts:102
 msgctxt "command-option-description"
 msgid "Display the price for the card with this password."
 msgstr "이 패스워드로 카드 가격을 표시합니다."
 
-#: src\commands\price.ts:106
+#: src\commands\price.ts:105
 msgctxt "command-option-description"
 msgid "Display the price for the card with this official database ID."
 msgstr "이 공식 데이터베이스 ID로 카드 가격을 표시합니다."
 
-#: src\commands\price.ts:96
+#: src\commands\price.ts:95
 msgctxt "command-option-description"
 msgid "The vendor to fetch the price data from."
 msgstr "가격 데이터를 가져올 업체입니다."
@@ -1143,70 +1133,29 @@ msgctxt "command-option-description"
 msgid "The English name of the card you're looking for."
 msgstr "찾고 있는 카드명은 영어입니다."
 
-#: src\commands\rush-duel.ts:63
+#: src\commands\rush-duel.ts:64
 msgctxt "command-option-description"
 msgid "Find all information for the Rush Duel card with this name."
 msgstr "이 이름으로 러시 듀얼 카드에 대한 모든 정보를 찾습니다."
 
-#: src\commands\rush-duel.ts:74
+#: src\commands\rush-duel.ts:75
 msgctxt "command-option-description"
 msgid "Find all information for the Rush Duel card with this official database ID."
 msgstr "이 공식 데이터베이스 ID로 러시 듀얼 카드에 대한 모든 정보를 찾습니다."
 
-#: src\commands\rush-duel.ts:85
+#: src\commands\rush-duel.ts:86
 msgctxt "command-option-description"
 msgid "Get a random Rush Duel card."
 msgstr "무작위로 러시 듀얼 카드를 가져옵니다."
 
-#: src\commands\rush-duel.ts:90
+#: src\commands\rush-duel.ts:91
 msgctxt "command-option-description"
 msgid "Display just the art for the Rush Duel card with this name."
 msgstr "이 이름으로 러시 듀얼 카드에 대한 일러스트만 표시합니다."
 
-#: src\commands\query.ts:36
+#: src\commands\query.ts:37
 msgctxt "command-option-description"
 msgid "Lucene query on YAML Yugi"
-msgstr ""
-
-#: src\commands\locale-user.ts:37
-msgctxt "command-option-description"
-msgid "Check your user-installed Bastion's locale."
-msgstr ""
-
-#: src\commands\locale-user.ts:42
-msgctxt "command-option-description"
-msgid "Configure your user-installed Bastion's locale."
-msgstr ""
-
-#: src\commands\locale-user.ts:47
-msgctxt "command-option-description"
-msgid "The new default language to use for user-installed Bastion."
-msgstr ""
-
-#: src\commands\metagame.ts:212
-msgctxt "command-option-description"
-msgid "Show the top competitive strategies in tournaments and the Master Duel ranked ladder."
-msgstr ""
-
-#: src\commands\metagame.ts:214
-msgctxt "command-option-description"
-msgid "Show the top competitive strategies in tournaments."
-msgstr ""
-
-#: src\commands\metagame.ts:235
-#: src\commands\metagame.ts:275
-msgctxt "command-option-description"
-msgid "Game region."
-msgstr ""
-
-#: src\commands\metagame.ts:242
-msgctxt "command-option-description"
-msgid "Show the most popular cards in tournaments and the Master Duel ranked ladder."
-msgstr ""
-
-#: src\commands\metagame.ts:312
-msgctxt "command-option-description"
-msgid "Limit card usage statistics to this date range. Has no effect for Master Duel."
 msgstr ""
 
 #: src\commands\art.ts:36
@@ -1214,7 +1163,7 @@ msgctxt "command-name"
 msgid "art"
 msgstr "일러스트"
 
-#: src\commands\ping.ts:25
+#: src\commands\ping.ts:23
 msgctxt "command-name"
 msgid "ping"
 msgstr "핑"
@@ -1229,12 +1178,12 @@ msgctxt "command-name"
 msgid "yugipedia"
 msgstr ""
 
-#: src\commands\help.ts:52
+#: src\commands\help.ts:49
 msgctxt "command-name"
 msgid "help"
 msgstr "도움말"
 
-#: src\commands\deck.ts:80
+#: src\commands\deck.ts:119
 msgctxt "command-name"
 msgid "deck"
 msgstr "덱"
@@ -1249,34 +1198,24 @@ msgctxt "command-name"
 msgid "locale"
 msgstr "로케일"
 
-#: src\commands\random.ts:43
+#: src\commands\random.ts:44
 msgctxt "command-name"
 msgid "random"
 msgstr "무작위"
 
-#: src\commands\price.ts:90
+#: src\commands\price.ts:89
 msgctxt "command-name"
 msgid "price"
 msgstr "가격"
 
-#: src\commands\rush-duel.ts:57
+#: src\commands\rush-duel.ts:58
 msgctxt "command-name"
 msgid "rush-duel"
 msgstr "러시듀얼"
 
-#: src\commands\query.ts:29
+#: src\commands\query.ts:30
 msgctxt "command-name"
 msgid "query"
-msgstr ""
-
-#: src\commands\locale-user.ts:31
-msgctxt "command-name"
-msgid "locale-user"
-msgstr ""
-
-#: src\commands\metagame.ts:204
-msgctxt "command-name"
-msgid "metagame"
 msgstr ""
 
 #: src\commands\art.ts:37
@@ -1284,7 +1223,7 @@ msgctxt "command-description"
 msgid "Display the art for a card!"
 msgstr "카드의 일러스트를 표시합니다."
 
-#: src\commands\ping.ts:26
+#: src\commands\ping.ts:24
 msgctxt "command-description"
 msgid "Test latency to the new bot instance."
 msgstr "새로운 봇 인스턴스의 지연 시간을 테스트합니다."
@@ -1299,12 +1238,12 @@ msgctxt "command-description"
 msgid "Search the Yugipedia wiki for a page and link to it."
 msgstr "Yugipedia에서 검색하고 링크를 출력합니다."
 
-#: src\commands\help.ts:53
+#: src\commands\help.ts:50
 msgctxt "command-description"
 msgid "Get help with a Slash Command."
 msgstr "슬래시 명령에 도움을 받으십시오."
 
-#: src\commands\deck.ts:83
+#: src\commands\deck.ts:122
 msgctxt "command-description"
 msgid "Display a deck list from ydke:// or .ydk format, exported from a number of deck building programs."
 msgstr "여러 덱 제작 프로그램에서 내보낸 덱 목록을ydke:// 또는 .ydk 형식으로 표시합니다."
@@ -1319,34 +1258,24 @@ msgctxt "command-description"
 msgid "Check or set Bastion's locale for this channel or server."
 msgstr "이 채널 또는 서버에 대한 Bastion의 로케일을 확인하거나 설정합니다."
 
-#: src\commands\random.ts:44
+#: src\commands\random.ts:45
 msgctxt "command-description"
 msgid "Get a random Yu-Gi-Oh! card."
 msgstr "유희왕 카드를 무작위로 받으십시오."
 
-#: src\commands\price.ts:91
+#: src\commands\price.ts:90
 msgctxt "command-description"
 msgid "Display the price for a card!"
 msgstr "카드 가격 표시"
 
-#: src\commands\rush-duel.ts:58
+#: src\commands\rush-duel.ts:59
 msgctxt "command-description"
 msgid "Find information on Rush Duel cards."
 msgstr "러시 듀얼 카드 정보 찾기"
 
-#: src\commands\query.ts:30
+#: src\commands\query.ts:31
 msgctxt "command-description"
 msgid "Advanced search prototype"
-msgstr ""
-
-#: src\commands\locale-user.ts:32
-msgctxt "command-description"
-msgid "Check or set user-installed Bastion's locale."
-msgstr ""
-
-#: src\commands\metagame.ts:205
-msgctxt "command-description"
-msgid "Show statistics on the current competitive state of play."
 msgstr ""
 
 #: src\commands\locale.ts:43
@@ -1359,71 +1288,7 @@ msgctxt "command-option-choice"
 msgid "server"
 msgstr "서버"
 
-#: src\commands\locale-user.ts:49
 #: src\commands\locale.ts:51
 msgctxt "command-option-choice"
 msgid "Discord default"
 msgstr "디스코드 기본값"
-
-#: src\commands\metagame.ts:219
-#: src\commands\metagame.ts:251
-msgctxt "command-option-choice"
-msgid "TCG"
-msgstr ""
-
-#: src\commands\metagame.ts:220
-#: src\commands\metagame.ts:255
-msgctxt "command-option-choice"
-msgid "OCG"
-msgstr ""
-
-#: src\commands\metagame.ts:221
-#: src\commands\metagame.ts:259
-msgctxt "command-option-choice"
-msgid "OCG (Asian-English)"
-msgstr ""
-
-#: src\commands\metagame.ts:228
-msgctxt "command-option-choice"
-msgid "Master Duel Diamond+ tier list"
-msgstr ""
-
-#: src\commands\metagame.ts:261
-msgctxt "command-option-choice"
-msgid "Master Duel ranked ladder"
-msgstr ""
-
-#: src\commands\metagame.ts:283
-msgctxt "command-option-choice"
-msgid "Current format"
-msgstr ""
-
-#: src\commands\metagame.ts:287
-msgctxt "command-option-choice"
-msgid "Since last Forbidden/Limited List"
-msgstr ""
-
-#: src\commands\metagame.ts:291
-msgctxt "command-option-choice"
-msgid "Last 7 days"
-msgstr ""
-
-#: src\commands\metagame.ts:295
-msgctxt "command-option-choice"
-msgid "Last 14 days"
-msgstr ""
-
-#: src\commands\metagame.ts:299
-msgctxt "command-option-choice"
-msgid "Last 30 days"
-msgstr ""
-
-#: src\commands\metagame.ts:303
-msgctxt "command-option-choice"
-msgid "Last three months"
-msgstr ""
-
-#: src\commands\metagame.ts:307
-msgctxt "command-option-choice"
-msgid "Last six months"
-msgstr ""

--- a/translations/ko.po
+++ b/translations/ko.po
@@ -6,50 +6,50 @@ msgstr ""
 "MIME-Version: 1.0\n"
 "Content-Transfer-Encoding: 8bit\n"
 
-#: src\card.ts:416
-#: src\rush-duel.ts:39
+#: src\card.ts:412
+#: src\rush-duel.ts:48
 msgid "🔗 Links"
 msgstr "🔗 링크"
 
-#: src\card.ts:417
+#: src\card.ts:413
 #, javascript-format
 msgid "[Official Konami DB](${ official }) | [OCG Rulings](${ rulings }) | [Yugipedia](${ yugipedia }) | [YGOPRODECK](${ ygoprodeck })"
 msgstr "[코나미 공식 카드 DB](${ official }) | [OCG 공식 재정](${ rulings }) | [Yugipedia](${ yugipedia }) | [YGOPRODECK](${ ygoprodeck })"
 
-#: src\card.ts:420
+#: src\card.ts:416
 #, javascript-format
 msgid "[Yugipedia](${ yugipedia }) | [YGOPRODECK](${ ygoprodeck })"
 msgstr "[Yugipedia](${ yugipedia }) | [YGOPRODECK](${ ygoprodeck })"
 
-#: src\card.ts:489
-#: src\rush-duel.ts:92
+#: src\card.ts:490
+#: src\rush-duel.ts:103
 #, javascript-format
 msgid "**Type**: ${ raceIcon } ${ localizedMonsterTypeLine }"
 msgstr "**종족**: ${ raceIcon } ${ localizedMonsterTypeLine }"
 
-#: src\card.ts:491
-#: src\rush-duel.ts:94
+#: src\card.ts:492
+#: src\rush-duel.ts:105
 #, javascript-format
 msgid "**Attribute**: ${ attributeIcon } ${ localizedAttribute }"
 msgstr "**속성**: ${ attributeIcon } ${ localizedAttribute }"
 
-#: src\card.ts:495
+#: src\card.ts:497
 #, javascript-format
 msgid "**Rank**: ${ rankIcon } ${ card.rank } **ATK**: ${ card.atk } **DEF**: ${ card.def }"
 msgstr "**랭크**: ${ rankIcon } ${ card.rank } **공격력**: ${ card.atk } **수비력**: ${ card.def }"
 
-#: src\card.ts:498
+#: src\card.ts:500
 #, javascript-format
 msgid "**Link Rating**: ${ card.link_arrows.length } **ATK**: ${ card.atk } **Link Arrows**: ${ arrows }"
 msgstr "**LINK**: ${ card.link_arrows.length } **공격력**: ${ card.atk } **링크 마커**: ${ arrows }"
 
-#: src\card.ts:500
-#: src\rush-duel.ts:96
+#: src\card.ts:503
+#: src\rush-duel.ts:107
 #, javascript-format
 msgid "**Level**: ${ levelIcon } ${ card.level } **ATK**: ${ card.atk } **DEF**: ${ card.def }"
 msgstr "**레벨**: ${ levelIcon } ${ card.level } **공격력**: ${ card.atk } **수비력**: ${ card.def }"
 
-#: src\card.ts:507
+#: src\card.ts:511
 #, javascript-format
 msgid "**Pendulum Scale**: ${ formattedScale }"
 msgstr "**펜듈럼 스케일**: ${ formattedScale }"
@@ -70,7 +70,7 @@ msgid "Password: ${ card.password } | Not yet released"
 msgstr "패스워드: ${ card.password } | Not yet released"
 
 #: src\card.ts:351
-#: src\rush-duel.ts:146
+#: src\rush-duel.ts:158
 msgid "Not yet released"
 msgstr "미발매"
 
@@ -79,64 +79,64 @@ msgstr "미발매"
 msgid "Placeholder ID: ${ card.fake_password }"
 msgstr "플레이스홀더 ID: ${ card.fake_password }"
 
-#: src\utils.ts:41
+#: src\utils.ts:44
 msgid "🛠️ This command is in development."
 msgstr "🛠️ 이 명령은 개발 중입니다."
 
-#: src\utils.ts:42
+#: src\utils.ts:45
 msgid "📨 Please send feedback to [our issue tracker](https://github.com/DawnbrandBots/bastion-bot) or the [support server](https://discord.gg/4aFuPyuE96)!"
 msgstr "📨 [문제 추적기](https://github.com/DawnbrandBots/bastion-bot) 또는 [지원 서버](https://discord.gg/4aFuPyuE96)로 피드백을 보내주십시오!"
 
-#: src\utils.ts:53
+#: src\utils.ts:56
 msgid "Please consider supporting us!"
 msgstr "저희를 지원해 주세요!"
 
-#: src\utils.ts:54
+#: src\utils.ts:57
 msgid "Help keep Bastion online!"
 msgstr "Bastion을 온라인 상태로 유지하는 것을 도와 주세요!"
 
-#: src\utils.ts:55
+#: src\utils.ts:58
 msgid "Please help keep Bastion online!"
 msgstr "저희가 Bastion을 온라인 상태로 유지하는 것을 도와 주세요!"
 
-#: src\utils.ts:56
+#: src\utils.ts:59
 msgid "Was Bastion helpful? Consider supporting us!"
 msgstr "Bastion이 도움이 되었나요? 저희를 지원해 주세요!"
 
-#: src\utils.ts:57
+#: src\utils.ts:60
 msgid "Was Bastion helpful? We need your support!"
 msgstr "Bastion이 도움이 되었나요? 여러분의 지원이 필요해요!"
 
-#: src\utils.ts:58
+#: src\utils.ts:61
 msgid "Did you find Bastion useful? Consider supporting us!"
 msgstr "Bastion이 유용하다고 생각했나요? 저희를 지원해 주시는 건 어떤가요?"
 
-#: src\utils.ts:59
+#: src\utils.ts:62
 msgid "Did you find Bastion useful? Help keep it online!"
 msgstr "Bastion이 유용하다고 생각했나요? 온라인 상태로 유지하는 것을 도와 주세요!"
 
-#: src\utils.ts:60
+#: src\utils.ts:63
 msgid "Did you find Bastion useful? We need your support!"
 msgstr "Bastion이 유용하다고 생각했나요? 여러분의 지원이 필요해요!"
 
-#: src\utils.ts:61
+#: src\utils.ts:64
 msgid "Enjoy Bastion? Help keep it online!"
 msgstr "Bastion을 잘 사용하고 계신가요? 온라인 상태로 유지하는 것을 도와 주세요!"
 
-#: src\utils.ts:62
+#: src\utils.ts:65
 msgid "Enjoy Bastion? Consider supporting us!"
 msgstr "Bastion을 잘 사용하고 계신가요? 저희를 지원해 주시는 건 어떤가요?"
 
-#: src\utils.ts:63
+#: src\utils.ts:66
 msgid "Found what you were looking for? Consider supporting us!"
 msgstr "찾으시려던 것을 찾으셨나요? 저희를 지원해 주시는 건 어떤가요?"
 
 #: src\commands\art.ts:63
-#: src\commands\price.ts:131
-#: src\commands\rush-duel.ts:172
-#: src\commands\rush-duel.ts:203
+#: src\commands\price.ts:132
+#: src\commands\rush-duel.ts:171
+#: src\commands\rush-duel.ts:202
 #: src\commands\search.ts:64
-#: src\events\message-search.ts:258
+#: src\events\message-search.ts:265
 #, javascript-format
 msgid "Could not find a card matching `${ input }`!"
 msgstr "`${ input }`에 일치하는 카드를 찾을 수 없습니다!"
@@ -163,11 +163,7 @@ msgstr "이 서버에 대한 언어 설정: ${ guildOverride }"
 msgid "Discord Community locale for this server: ${ interaction.guildLocale }"
 msgstr "이 서버의 디스코드 커뮤니티의 언어 설정: ${ interaction.guildLocale }"
 
-#: src\commands\locale.ts:89
-#, javascript-format
-msgid "Locale override for this direct message: ${ override }"
-msgstr "이 다이렉트 메시지에 대한 언어 설정: ${ override }"
-
+#: src\commands\locale-user.ts:76
 #: src\commands\locale.ts:92
 #, javascript-format
 msgid "Your Discord locale: ${ interaction.locale }"
@@ -205,24 +201,14 @@ msgstr "커뮤니티 서버의 서버 전체 기본값은 ${ interaction.guildLo
 msgid "Sorry, you must have the Manage Server permission to do this. If you think this is an error, contact your server admin or report a bug."
 msgstr "죄송합니다. 이 작업을 수행하려면 서버 관리 권한이 있어야 합니다. 이 메시지가 잘못 출력되었다면, 서버 관리자에게 문의하시거나 버그를 신고해 주세요."
 
-#: src\commands\locale.ts:146
-#, javascript-format
-msgid "Locale for this direct message overridden with ${ locale }. Your Discord setting is ${ interaction.locale }."
-msgstr "해당 다이렉트 메시지의 언어 설정은 ${ locale } 으로 재정의되었습니다. 당신의 디스코드 설정은 ${ interaction.locale } 입니다."
-
-#: src\commands\locale.ts:150
-#, javascript-format
-msgid "Locale for this direct message reset to Discord default. Your Discord setting is ${ interaction.locale }."
-msgstr "해당 다이렉트 메시지의 언어 설정은 디스코드 기본값으로 리셋되었습니다. 당신의 디스코드 설정은 ${ interaction.locale } 입니다."
-
-#: src\commands\ping.ts:36
-#: src\events\message-ping.ts:47
+#: src\commands\ping.ts:38
+#: src\events\message-ping.ts:45
 #, javascript-format
 msgid "Average WebSocket ping (new instance): ${ ping } ms"
 msgstr "평균 WebSocket 핑 (새로운 인스턴스): ${ ping } ms"
 
-#: src\commands\ping.ts:40
-#: src\events\message-ping.ts:112
+#: src\commands\ping.ts:42
+#: src\events\message-ping.ts:110
 #, javascript-format
 msgid "Total latency: ${ latency } ms"
 msgstr "총 지연 시간: ${ latency } ms"
@@ -232,130 +218,113 @@ msgstr "총 지연 시간: ${ latency } ms"
 msgid "Could not find a Yugipedia page named `${ page }`."
 msgstr "`${ page }`라는 이름의 Yugipedia 페이지를 찾을 수 없습니다."
 
-#: src\commands\deck.ts:244
+#: src\commands\deck.ts:205
 #, javascript-format
 msgid "${ counts.Monster } Monster"
 msgid_plural "${ counts.Monster } Monsters"
 msgstr[0] "몬스터 ${ counts.Monster } 장"
 
-#: src\commands\deck.ts:247
+#: src\commands\deck.ts:208
 #, javascript-format
 msgid "${ counts.Spell } Spell"
 msgid_plural "${ counts.Spell } Spells"
 msgstr[0] "마법 ${ counts.Spell } 장"
 
-#: src\commands\deck.ts:250
+#: src\commands\deck.ts:211
 #, javascript-format
 msgid "${ counts.Trap } Trap"
 msgid_plural "${ counts.Trap } Traps"
 msgstr[0] "함정 ${ counts.Trap } 장"
 
-#: src\commands\deck.ts:278
+#: src\commands\deck.ts:239
 msgid "Your Deck"
 msgstr "덱"
 
-#: src\commands\deck.ts:283
+#: src\commands\deck.ts:244
 #, javascript-format
 msgid "Main Deck (${ deck.main.length } card — ${ countDetail })"
 msgid_plural "Main Deck (${ deck.main.length } cards — ${ countDetail })"
 msgstr[0] "메인 덱 (${ deck.main.length } card — ${ countDetail })"
 
-#: src\commands\deck.ts:290
+#: src\commands\deck.ts:251
 msgid "Main Deck (continued)"
 msgstr "메인 덱 (계속)"
 
-#: src\commands\deck.ts:304
+#: src\commands\deck.ts:265
 msgid "Extra Deck (continued)"
 msgstr "엑스트라 덱 (계속)"
 
-#: src\commands\deck.ts:318
+#: src\commands\deck.ts:279
 msgid "Side Deck (continued)"
 msgstr "사이드 덱 (계속)"
 
-#: src\commands\deck.ts:407
+#: src\commands\deck.ts:347
 msgid "Error: Your deck is empty."
 msgstr "오류: 덱이 비었습니다."
 
-#: src\events\message-ping.ts:49
+#: src\events\message-ping.ts:47
 msgid "Free and open source _Yu-Gi-Oh!_ bot"
 msgstr "자유-오픈 소스 유희왕 봇"
 
-#: src\events\message-ping.ts:72
+#: src\events\message-ping.ts:70
 #, javascript-format
 msgid "Revision: ${ process.env.BOT_REVISION }."
 msgstr "수정: ${ process.env.BOT_REVISION }."
 
-#: src\commands\deck.ts:328
+#: src\commands\deck.ts:289
 msgid ".ydk files must have the .ydk extension!"
 msgstr ".ydk 파일의 확장자는 .ydk여야 합니다!"
 
-#: src\commands\deck.ts:331
+#: src\commands\deck.ts:292
 msgid ".ydk files should not be larger than 1 KB!"
 msgstr ".ydk 파일은 1 KB보다 크면 안 됩니다!"
 
-#: src\commands\deck.ts:321
+#: src\commands\deck.ts:282
 msgid "ydke URL"
 msgstr ""
 
 #: src\card.ts:455
-#: src\rush-duel.ts:61
+#: src\rush-duel.ts:75
 #. Forbidden/Limited Lists or Limit Regulations in the OCG
 #, javascript-format
 msgid "**Limit**: ${ limitRegulationDisplay }"
 msgstr "**제한**: ${ limitRegulationDisplay }"
 
-#: src\commands\price.ts:69
+#: src\commands\price.ts:70
 msgid "TCGPlayer"
 msgstr ""
 
-#: src\commands\price.ts:70
+#: src\commands\price.ts:71
 msgid "Cardmarket"
 msgstr ""
 
-#: src\commands\price.ts:147
+#: src\commands\price.ts:148
 msgid "No market price"
 msgstr "시장 가격 불명"
 
-#: src\commands\price.ts:155
+#: src\commands\price.ts:156
 #, javascript-format
 msgid "Prices for ${ card.name[resultLanguage] } - ${ vendorName }"
 msgstr "${ vendorName } 의 ${ card.name[resultLanguage] } 가격"
 
-#: src\commands\price.ts:169
+#: src\commands\price.ts:170
 #, javascript-format
 msgid "Could not find prices for `${ name }`!"
 msgstr "`${ name }`의 가격을 찾을 수 없습니다!"
 
-#: src\commands\deck.ts:425
-#. prepare interaction button for FTP upload
+#: src\commands\deck.ts:363
 msgid "Upload to YGOPRODECK"
 msgstr "YGOPRODECK에 업로드"
 
-#: src\commands\deck.ts:483
-#. disable original button
-#. prepare row to disable button on original message
-msgid "Upload Complete"
-msgstr "업로드 완료"
-
-#: src\commands\deck.ts:470
-msgid "Deck upload failed!"
-msgstr "덱 업로드에 실패했습니다!"
-
-#: src\commands\deck.ts:491
-#. reply in affirmation
-#, javascript-format
-msgid "Deck successfully uploaded to <${ url }>!"
-msgstr "<${ url }>에 덱 업로드를 완료했습니다!"
-
-#: src\events\message-search.ts:264
+#: src\events\message-search.ts:271
 msgid "💬 Translations missing?"
 msgstr "💬 번역이 존재합니까?"
 
-#: src\events\message-search.ts:265
+#: src\events\message-search.ts:272
 msgid "Help translate Bastion at the links above."
 msgstr "위 링크에서 Bastion 번역을 도와주세요."
 
-#: src\events\message-ping.ts:50
+#: src\events\message-ping.ts:48
 msgid ""
 "❓ Help documentation on [GitHub](https://github.com/DawnbrandBots/bastion-bot), or use `.commands` and `.help`.\n"
 "🟢 Licence: [GNU AGPL 3.0+](https://choosealicense.com/licenses/agpl-3.0/).\n"
@@ -371,37 +340,37 @@ msgid ""
 "💬 Translations missing? Help translate Bastion on [GitHub](https://github.com/DawnbrandBots/bastion-bot)."
 msgstr ""
 
-#: src\events\message-search.ts:256
-#: src\events\message-search.ts:294
+#: src\events\message-search.ts:263
+#: src\events\message-search.ts:302
 #, javascript-format
 msgid "Search type: ${ localisedType }"
 msgstr "검색 종류: ${ localisedType }"
 
-#: src\events\message-search.ts:236
+#: src\events\message-search.ts:242
 #, javascript-format
 msgid "Search language: **${ localisedInputLanguage }** (${ inputLanguage }). Check defaults with </locale get:${ id }> and configure with </locale set:${ id }>"
 msgstr "검색 언어: **${ localisedInputLanguage }** (${ inputLanguage }). </locale get:${ id }>의 기본값을 확인하고 </locale set:${ id }>를 설정합니다."
 
-#: src\events\message-ping.ts:95
+#: src\events\message-ping.ts:93
 msgid "⚠️ You pinged me, but I am missing permissions in the channel!"
 msgstr "⚠️ 당신은 저를 부르셨지만, 해당 채널에서 권한이 없습니다!"
 
-#: src\events\message-ping.ts:98
-#: src\events\message-search.ts:332
+#: src\events\message-ping.ts:96
+#: src\events\message-search.ts:340
 msgid "Please have a server administrator [fix this](https://github.com/DawnbrandBots/bastion-bot#discord-permissions)."
 msgstr "서버 관리자에게 문의하십시오 [문제 해결](https://github.com/DawnbrandBots/bastion-bot#discord-permissions)."
 
-#: src\events\message-search.ts:329
+#: src\events\message-search.ts:337
 msgid "⚠️ I am missing permissions in the channel!"
 msgstr "⚠️ 해당 채널에서 권한이 없습니다!"
 
-#: src\commands\deck.ts:297
+#: src\commands\deck.ts:258
 #, javascript-format
 msgid "Extra Deck (${ deck.extra.length } card — ${ countDetail })"
 msgid_plural "Extra Deck (${ deck.extra.length } cards — ${ countDetail })"
 msgstr[0] "엑스트라 덱 (${ deck.extra.length } cards — ${ countDetail })"
 
-#: src\commands\deck.ts:311
+#: src\commands\deck.ts:272
 #, javascript-format
 msgid "Side Deck (${ deck.side.length } card — ${ countDetail })"
 msgid_plural "Side Deck (${ deck.side.length } cards — ${ countDetail })"
@@ -422,32 +391,31 @@ msgstr "YGOPRODECK을 위해 `${ searchTerm }`을(를) 검색하는 데 문제�
 msgid "Something went wrong searching Yugipedia for `${ page }`."
 msgstr "Yugipedia를 위해 `${ page }`을(를) 검색하는 데 문제가 발생하였습니다."
 
-#: src\rush-duel.ts:40
+#: src\rush-duel.ts:49
 #, javascript-format
 msgid "[Official Konami DB](${ official }) | [Rulings (Japanese)](${ rulings }) | [Yugipedia](${ yugipedia }) | [RushCard](${ rushcard })"
 msgstr "[공식 코나미 DB](${ official }) | [OCG 규칙](${ rulings }) | [Yugipedia](${ yugipedia }) | [RushCard](${ rushcard })"
 
-#: src\rush-duel.ts:43
+#: src\rush-duel.ts:52
 #, javascript-format
 msgid "[Yugipedia](${ yugipedia }) | [RushCard](${ rushcard })"
 msgstr ""
 
-#: src\rush-duel.ts:57
+#: src\rush-duel.ts:71
 msgid "__**LEGEND**__"
 msgstr ""
 
-#: src\rush-duel.ts:99
+#: src\rush-duel.ts:110
 #, javascript-format
 msgid "**MAXIMUM ATK**: ${ card.maximum_atk }"
 msgstr ""
 
-#: src\rush-duel.ts:146
+#: src\rush-duel.ts:158
 #, javascript-format
 msgid "Konami ID #${ card.konami_id }"
 msgstr "코나미 ID #${ card.konami_id }"
 
 #: src\art.ts:129
-#: src\commands\deck.ts:451
 msgid "Buttons can only be used by the user who called Bastion."
 msgstr "Bastion은 호출한 사용자만 이용할 수 있습니다."
 
@@ -456,14 +424,32 @@ msgstr "Bastion은 호출한 사용자만 이용할 수 있습니다."
 msgid "**Master Duel rarity**: ${ rarityIcon } ${ localizedRarity }"
 msgstr "**레어리티 (MD)**: ${ rarityIcon } ${ localizedRarity }"
 
-#: src\rush-duel.ts:205
+#: src\rush-duel.ts:217
 #, javascript-format
 msgid "Using ${ searchTrigger }, you can search for Rush Duel cards directly in messages without autocomplete"
 msgstr ""
 
-#: src\events\message-search.ts:296
+#: src\events\message-search.ts:304
 #, javascript-format
 msgid "Could not find a Rush Duel card matching `${ input }`!"
+msgstr ""
+
+#: src\commands\locale-user.ts:73
+#: src\commands\locale.ts:89
+#, javascript-format
+msgid "Locale override for your direct messages: ${ override }"
+msgstr ""
+
+#: src\commands\locale-user.ts:83
+#: src\commands\locale.ts:146
+#, javascript-format
+msgid "Locale for your direct messages overridden with ${ locale }. Your Discord setting is ${ interaction.locale }."
+msgstr ""
+
+#: src\commands\locale-user.ts:87
+#: src\commands\locale.ts:150
+#, javascript-format
+msgid "Locale for your direct messages reset to Discord default. Your Discord setting is ${ interaction.locale }."
 msgstr ""
 
 #: src\card.ts:40
@@ -830,60 +816,60 @@ msgctxt "master-duel-rarity"
 msgid "Ultra Rare (UR)"
 msgstr "UR"
 
-#: src\card.ts:513
-#: src\card.ts:524
-#: src\rush-duel.ts:127
+#: src\card.ts:517
+#: src\card.ts:528
+#: src\rush-duel.ts:138
 msgctxt "card-embed"
 msgid "Card Text"
 msgstr "카드 텍스트"
 
-#: src\card.ts:518
+#: src\card.ts:522
 msgctxt "card-embed"
 msgid "Pendulum Effect"
 msgstr "펜듈럼 효과"
 
-#: src\card.ts:539
+#: src\card.ts:545
 msgctxt "card-embed"
 msgid "Card Effect"
 msgstr "카드 효과"
 
-#: src\rush-duel.ts:118
-#: src\rush-duel.ts:139
+#: src\rush-duel.ts:129
+#: src\rush-duel.ts:151
 msgctxt "card-embed"
 msgid "[REQUIREMENT]"
 msgstr "【조건】"
 
-#: src\rush-duel.ts:119
-#: src\rush-duel.ts:140
+#: src\rush-duel.ts:130
+#: src\rush-duel.ts:152
 msgctxt "card-embed"
 msgid "[EFFECT]"
 msgstr "【효과】"
 
-#: src\rush-duel.ts:121
+#: src\rush-duel.ts:132
 msgctxt "card-embed"
 msgid "[CONTINUOUS EFFECT]"
 msgstr "【지속 효과】"
 
-#: src\rush-duel.ts:123
+#: src\rush-duel.ts:134
 msgctxt "card-embed"
 msgid "[MULTI-CHOICE EFFECT]"
 msgstr "【선택 효과】"
 
-#: src\locale.ts:71
+#: src\locale.ts:74
 msgctxt "command-option"
 msgid "result-language"
 msgstr "출력언어"
 
-#: src\locale.ts:131
+#: src\locale.ts:140
 msgctxt "command-option"
 msgid "input-language"
 msgstr "입력언어"
 
-#: src\commands\rush-duel.ts:68
-#: src\commands\rush-duel.ts:80
-#: src\locale.ts:147
-#: src\locale.ts:165
-#: src\locale.ts:181
+#: src\commands\rush-duel.ts:67
+#: src\commands\rush-duel.ts:79
+#: src\locale.ts:156
+#: src\locale.ts:174
+#: src\locale.ts:190
 msgctxt "command-option"
 msgid "input"
 msgstr "입력"
@@ -898,59 +884,61 @@ msgctxt "command-option"
 msgid "page"
 msgstr "페이지"
 
-#: src\commands\help.ts:52
+#: src\commands\help.ts:55
 msgctxt "command-option"
 msgid "command"
 msgstr "명령"
 
-#: src\commands\deck.ts:126
+#: src\commands\deck.ts:87
 msgctxt "command-option"
 msgid "url"
 msgstr ""
 
-#: src\commands\deck.ts:132
+#: src\commands\deck.ts:93
 msgctxt "command-option"
 msgid "file"
 msgstr "파일"
 
-#: src\commands\deck.ts:138
-#: src\commands\deck.ts:144
+#: src\commands\deck.ts:99
+#: src\commands\deck.ts:105
 msgctxt "command-option"
 msgid "deck"
 msgstr "덱"
 
-#: src\commands\deck.ts:150
+#: src\commands\deck.ts:111
 msgctxt "command-option"
 msgid "public"
 msgstr "공개"
 
-#: src\commands\deck.ts:157
+#: src\commands\deck.ts:118
 msgctxt "command-option"
 msgid "stacked"
 msgstr "다량"
 
-#: src\locale.ts:142
+#: src\locale.ts:151
 msgctxt "command-option"
 msgid "name"
 msgstr "이름"
 
-#: src\locale.ts:160
+#: src\locale.ts:169
 msgctxt "command-option"
 msgid "password"
 msgstr "패스워드"
 
-#: src\commands\rush-duel.ts:73
-#: src\events\message-search.ts:293
-#: src\locale.ts:176
+#: src\commands\rush-duel.ts:72
+#: src\events\message-search.ts:301
+#: src\locale.ts:185
 msgctxt "command-option"
 msgid "konami-id"
 msgstr ""
 
+#: src\commands\locale-user.ts:36
 #: src\commands\locale.ts:30
 msgctxt "command-option"
 msgid "get"
 msgstr "가져오기"
 
+#: src\commands\locale-user.ts:41
 #: src\commands\locale.ts:35
 msgctxt "command-option"
 msgid "set"
@@ -961,42 +949,64 @@ msgctxt "command-option"
 msgid "scope"
 msgstr "범위"
 
+#: src\commands\locale-user.ts:46
 #: src\commands\locale.ts:48
 msgctxt "command-option"
 msgid "locale"
 msgstr "로케일"
 
-#: src\commands\price.ts:94
+#: src\commands\price.ts:95
 msgctxt "command-option"
 msgid "vendor"
 msgstr "상점"
 
-#: src\commands\rush-duel.ts:63
+#: src\commands\rush-duel.ts:62
 msgctxt "command-option"
 msgid "search"
 msgstr "검색"
 
-#: src\commands\rush-duel.ts:85
+#: src\commands\rush-duel.ts:84
 msgctxt "command-option"
 msgid "random"
 msgstr "무작위"
 
-#: src\commands\rush-duel.ts:90
+#: src\commands\rush-duel.ts:89
 msgctxt "command-option"
 msgid "art"
 msgstr "일러스트"
 
-#: src\commands\query.ts:36
+#: src\commands\query.ts:35
 msgctxt "command-option"
 msgid "lucene"
 msgstr ""
 
-#: src\locale.ts:74
+#: src\commands\metagame.ts:209
+msgctxt "command-option"
+msgid "strategies"
+msgstr ""
+
+#: src\commands\metagame.ts:234
+#: src\commands\metagame.ts:274
+msgctxt "command-option"
+msgid "format"
+msgstr ""
+
+#: src\commands\metagame.ts:240
+msgctxt "command-option"
+msgid "cards"
+msgstr ""
+
+#: src\commands\metagame.ts:310
+msgctxt "command-option"
+msgid "date-range"
+msgstr ""
+
+#: src\locale.ts:77
 msgctxt "command-option-description"
 msgid "The output language for the card embed, overriding other settings."
 msgstr "다른 설정을 재정의하는 카드 임베드의 출력 언어입니다."
 
-#: src\locale.ts:132
+#: src\locale.ts:141
 msgctxt "command-option-description"
 msgid "The language to search in, defaulting to the result language."
 msgstr "검색할 언어로, 기본적으로 출력 언어로 설정됩니다."
@@ -1006,37 +1016,37 @@ msgctxt "command-option-description"
 msgid "The name of the Yugipedia page you want to search for."
 msgstr "검색할 Yugipedia 페이지의 이름입니다."
 
-#: src\commands\help.ts:55
+#: src\commands\help.ts:58
 msgctxt "command-option-description"
 msgid "The name of a specific Slash Command."
 msgstr "특정 단축 명령의 이름입니다."
 
-#: src\commands\deck.ts:129
+#: src\commands\deck.ts:90
 msgctxt "command-option-description"
 msgid "View a deck by entering a ydke:// URL."
 msgstr "ydke:// URL을 입력하여 덱을 봅니다."
 
-#: src\commands\deck.ts:135
+#: src\commands\deck.ts:96
 msgctxt "command-option-description"
 msgid "View a deck by uploading a .ydk file."
 msgstr "ydk 파일을 업로드 후 덱을 봅니다."
 
-#: src\commands\deck.ts:141
+#: src\commands\deck.ts:102
 msgctxt "command-option-description"
 msgid "The ydke:// URL of the deck you want to view."
 msgstr "보려는 덱의 ydke:// URL입니다."
 
-#: src\commands\deck.ts:147
+#: src\commands\deck.ts:108
 msgctxt "command-option-description"
 msgid "The .ydk file of the deck you want to view."
 msgstr "보려는 덱의 ydk 파일입니다."
 
-#: src\commands\deck.ts:153
+#: src\commands\deck.ts:114
 msgctxt "command-option-description"
 msgid "Whether to display the deck details publicly in chat. This is false by default."
 msgstr "대화에서 덱 세부 정보를 공개적으로 표시할지 여부입니다.이것은 기본적으로 거짓입니다."
 
-#: src\commands\deck.ts:160
+#: src\commands\deck.ts:121
 msgctxt "command-option-description"
 msgid "Whether to display the deck sections as one stacked column. This is false (side-by-side) by default."
 msgstr ""
@@ -1046,8 +1056,8 @@ msgctxt "command-option-description"
 msgid "Display the art for the card with this name."
 msgstr "이 이름으로 카드에 대한 일러스트를 표시합니다."
 
-#: src\commands\rush-duel.ts:69
-#: src\locale.ts:148
+#: src\commands\rush-duel.ts:68
+#: src\locale.ts:157
 msgctxt "command-option-description"
 msgid "Card name, fuzzy matching supported."
 msgstr "카드 이름, 퍼지 매칭이 지원됩니다."
@@ -1057,7 +1067,7 @@ msgctxt "command-option-description"
 msgid "Display the art for the card with this password."
 msgstr "이 패스워드로 카드의 일러스트를 표시합니다."
 
-#: src\locale.ts:167
+#: src\locale.ts:176
 msgctxt "command-option-description"
 msgid "Card password, the eight-digit number printed on the bottom left corner."
 msgstr "카드 패스워드, 왼쪽 하단에 인쇄된 8자리 숫자."
@@ -1067,8 +1077,8 @@ msgctxt "command-option-description"
 msgid "Display the art for the card with this official database ID."
 msgstr "이 공식 데이터베이스 ID로 카드의 일러스트를 표시합니다."
 
-#: src\commands\rush-duel.ts:81
-#: src\locale.ts:182
+#: src\commands\rush-duel.ts:80
+#: src\locale.ts:191
 msgctxt "command-option-description"
 msgid "Konami's official card database identifier."
 msgstr "코나미의 공식 카드 데이터베이스 식별자입니다."
@@ -1108,22 +1118,22 @@ msgctxt "command-option-description"
 msgid "The new default language to use in this channel or server."
 msgstr "이 채널 또는 서버에서 사용할 새 기본 언어입니다."
 
-#: src\commands\price.ts:98
+#: src\commands\price.ts:99
 msgctxt "command-option-description"
 msgid "Display the price for the card with this name."
 msgstr "이 이름으로 카드 가격을 표시합니다."
 
-#: src\commands\price.ts:102
+#: src\commands\price.ts:103
 msgctxt "command-option-description"
 msgid "Display the price for the card with this password."
 msgstr "이 패스워드로 카드 가격을 표시합니다."
 
-#: src\commands\price.ts:105
+#: src\commands\price.ts:106
 msgctxt "command-option-description"
 msgid "Display the price for the card with this official database ID."
 msgstr "이 공식 데이터베이스 ID로 카드 가격을 표시합니다."
 
-#: src\commands\price.ts:95
+#: src\commands\price.ts:96
 msgctxt "command-option-description"
 msgid "The vendor to fetch the price data from."
 msgstr "가격 데이터를 가져올 업체입니다."
@@ -1133,29 +1143,70 @@ msgctxt "command-option-description"
 msgid "The English name of the card you're looking for."
 msgstr "찾고 있는 카드명은 영어입니다."
 
-#: src\commands\rush-duel.ts:64
+#: src\commands\rush-duel.ts:63
 msgctxt "command-option-description"
 msgid "Find all information for the Rush Duel card with this name."
 msgstr "이 이름으로 러시 듀얼 카드에 대한 모든 정보를 찾습니다."
 
-#: src\commands\rush-duel.ts:75
+#: src\commands\rush-duel.ts:74
 msgctxt "command-option-description"
 msgid "Find all information for the Rush Duel card with this official database ID."
 msgstr "이 공식 데이터베이스 ID로 러시 듀얼 카드에 대한 모든 정보를 찾습니다."
 
-#: src\commands\rush-duel.ts:86
+#: src\commands\rush-duel.ts:85
 msgctxt "command-option-description"
 msgid "Get a random Rush Duel card."
 msgstr "무작위로 러시 듀얼 카드를 가져옵니다."
 
-#: src\commands\rush-duel.ts:91
+#: src\commands\rush-duel.ts:90
 msgctxt "command-option-description"
 msgid "Display just the art for the Rush Duel card with this name."
 msgstr "이 이름으로 러시 듀얼 카드에 대한 일러스트만 표시합니다."
 
-#: src\commands\query.ts:37
+#: src\commands\query.ts:36
 msgctxt "command-option-description"
 msgid "Lucene query on YAML Yugi"
+msgstr ""
+
+#: src\commands\locale-user.ts:37
+msgctxt "command-option-description"
+msgid "Check your user-installed Bastion's locale."
+msgstr ""
+
+#: src\commands\locale-user.ts:42
+msgctxt "command-option-description"
+msgid "Configure your user-installed Bastion's locale."
+msgstr ""
+
+#: src\commands\locale-user.ts:47
+msgctxt "command-option-description"
+msgid "The new default language to use for user-installed Bastion."
+msgstr ""
+
+#: src\commands\metagame.ts:212
+msgctxt "command-option-description"
+msgid "Show the top competitive strategies in tournaments and the Master Duel ranked ladder."
+msgstr ""
+
+#: src\commands\metagame.ts:214
+msgctxt "command-option-description"
+msgid "Show the top competitive strategies in tournaments."
+msgstr ""
+
+#: src\commands\metagame.ts:235
+#: src\commands\metagame.ts:275
+msgctxt "command-option-description"
+msgid "Game region."
+msgstr ""
+
+#: src\commands\metagame.ts:242
+msgctxt "command-option-description"
+msgid "Show the most popular cards in tournaments and the Master Duel ranked ladder."
+msgstr ""
+
+#: src\commands\metagame.ts:312
+msgctxt "command-option-description"
+msgid "Limit card usage statistics to this date range. Has no effect for Master Duel."
 msgstr ""
 
 #: src\commands\art.ts:36
@@ -1163,7 +1214,7 @@ msgctxt "command-name"
 msgid "art"
 msgstr "일러스트"
 
-#: src\commands\ping.ts:23
+#: src\commands\ping.ts:25
 msgctxt "command-name"
 msgid "ping"
 msgstr "핑"
@@ -1178,12 +1229,12 @@ msgctxt "command-name"
 msgid "yugipedia"
 msgstr ""
 
-#: src\commands\help.ts:49
+#: src\commands\help.ts:52
 msgctxt "command-name"
 msgid "help"
 msgstr "도움말"
 
-#: src\commands\deck.ts:119
+#: src\commands\deck.ts:80
 msgctxt "command-name"
 msgid "deck"
 msgstr "덱"
@@ -1198,24 +1249,34 @@ msgctxt "command-name"
 msgid "locale"
 msgstr "로케일"
 
-#: src\commands\random.ts:44
+#: src\commands\random.ts:43
 msgctxt "command-name"
 msgid "random"
 msgstr "무작위"
 
-#: src\commands\price.ts:89
+#: src\commands\price.ts:90
 msgctxt "command-name"
 msgid "price"
 msgstr "가격"
 
-#: src\commands\rush-duel.ts:58
+#: src\commands\rush-duel.ts:57
 msgctxt "command-name"
 msgid "rush-duel"
 msgstr "러시듀얼"
 
-#: src\commands\query.ts:30
+#: src\commands\query.ts:29
 msgctxt "command-name"
 msgid "query"
+msgstr ""
+
+#: src\commands\locale-user.ts:31
+msgctxt "command-name"
+msgid "locale-user"
+msgstr ""
+
+#: src\commands\metagame.ts:204
+msgctxt "command-name"
+msgid "metagame"
 msgstr ""
 
 #: src\commands\art.ts:37
@@ -1223,7 +1284,7 @@ msgctxt "command-description"
 msgid "Display the art for a card!"
 msgstr "카드의 일러스트를 표시합니다."
 
-#: src\commands\ping.ts:24
+#: src\commands\ping.ts:26
 msgctxt "command-description"
 msgid "Test latency to the new bot instance."
 msgstr "새로운 봇 인스턴스의 지연 시간을 테스트합니다."
@@ -1238,12 +1299,12 @@ msgctxt "command-description"
 msgid "Search the Yugipedia wiki for a page and link to it."
 msgstr "Yugipedia에서 검색하고 링크를 출력합니다."
 
-#: src\commands\help.ts:50
+#: src\commands\help.ts:53
 msgctxt "command-description"
 msgid "Get help with a Slash Command."
 msgstr "슬래시 명령에 도움을 받으십시오."
 
-#: src\commands\deck.ts:122
+#: src\commands\deck.ts:83
 msgctxt "command-description"
 msgid "Display a deck list from ydke:// or .ydk format, exported from a number of deck building programs."
 msgstr "여러 덱 제작 프로그램에서 내보낸 덱 목록을ydke:// 또는 .ydk 형식으로 표시합니다."
@@ -1258,24 +1319,34 @@ msgctxt "command-description"
 msgid "Check or set Bastion's locale for this channel or server."
 msgstr "이 채널 또는 서버에 대한 Bastion의 로케일을 확인하거나 설정합니다."
 
-#: src\commands\random.ts:45
+#: src\commands\random.ts:44
 msgctxt "command-description"
 msgid "Get a random Yu-Gi-Oh! card."
 msgstr "유희왕 카드를 무작위로 받으십시오."
 
-#: src\commands\price.ts:90
+#: src\commands\price.ts:91
 msgctxt "command-description"
 msgid "Display the price for a card!"
 msgstr "카드 가격 표시"
 
-#: src\commands\rush-duel.ts:59
+#: src\commands\rush-duel.ts:58
 msgctxt "command-description"
 msgid "Find information on Rush Duel cards."
 msgstr "러시 듀얼 카드 정보 찾기"
 
-#: src\commands\query.ts:31
+#: src\commands\query.ts:30
 msgctxt "command-description"
 msgid "Advanced search prototype"
+msgstr ""
+
+#: src\commands\locale-user.ts:32
+msgctxt "command-description"
+msgid "Check or set user-installed Bastion's locale."
+msgstr ""
+
+#: src\commands\metagame.ts:205
+msgctxt "command-description"
+msgid "Show statistics on the current competitive state of play."
 msgstr ""
 
 #: src\commands\locale.ts:43
@@ -1288,7 +1359,71 @@ msgctxt "command-option-choice"
 msgid "server"
 msgstr "서버"
 
+#: src\commands\locale-user.ts:49
 #: src\commands\locale.ts:51
 msgctxt "command-option-choice"
 msgid "Discord default"
 msgstr "디스코드 기본값"
+
+#: src\commands\metagame.ts:219
+#: src\commands\metagame.ts:251
+msgctxt "command-option-choice"
+msgid "TCG"
+msgstr ""
+
+#: src\commands\metagame.ts:220
+#: src\commands\metagame.ts:255
+msgctxt "command-option-choice"
+msgid "OCG"
+msgstr ""
+
+#: src\commands\metagame.ts:221
+#: src\commands\metagame.ts:259
+msgctxt "command-option-choice"
+msgid "OCG (Asian-English)"
+msgstr ""
+
+#: src\commands\metagame.ts:228
+msgctxt "command-option-choice"
+msgid "Master Duel Diamond+ tier list"
+msgstr ""
+
+#: src\commands\metagame.ts:261
+msgctxt "command-option-choice"
+msgid "Master Duel ranked ladder"
+msgstr ""
+
+#: src\commands\metagame.ts:283
+msgctxt "command-option-choice"
+msgid "Current format"
+msgstr ""
+
+#: src\commands\metagame.ts:287
+msgctxt "command-option-choice"
+msgid "Since last Forbidden/Limited List"
+msgstr ""
+
+#: src\commands\metagame.ts:291
+msgctxt "command-option-choice"
+msgid "Last 7 days"
+msgstr ""
+
+#: src\commands\metagame.ts:295
+msgctxt "command-option-choice"
+msgid "Last 14 days"
+msgstr ""
+
+#: src\commands\metagame.ts:299
+msgctxt "command-option-choice"
+msgid "Last 30 days"
+msgstr ""
+
+#: src\commands\metagame.ts:303
+msgctxt "command-option-choice"
+msgid "Last three months"
+msgstr ""
+
+#: src\commands\metagame.ts:307
+msgctxt "command-option-choice"
+msgid "Last six months"
+msgstr ""

--- a/translations/pt.po
+++ b/translations/pt.po
@@ -6,50 +6,50 @@ msgstr ""
 "MIME-Version: 1.0\n"
 "Content-Transfer-Encoding: 8bit\n"
 
-#: src\card.ts:416
-#: src\rush-duel.ts:39
+#: src\card.ts:412
+#: src\rush-duel.ts:48
 msgid "🔗 Links"
 msgstr ""
 
-#: src\card.ts:417
+#: src\card.ts:413
 #, javascript-format
 msgid "[Official Konami DB](${ official }) | [OCG Rulings](${ rulings }) | [Yugipedia](${ yugipedia }) | [YGOPRODECK](${ ygoprodeck })"
 msgstr "[Database oficial da Konami](${ official }) | [Regras no OCG](${ rulings }) | [Yugipedia](${ yugipedia }) | [YGOPRODECK](${ ygoprodeck })"
 
-#: src\card.ts:420
+#: src\card.ts:416
 #, javascript-format
 msgid "[Yugipedia](${ yugipedia }) | [YGOPRODECK](${ ygoprodeck })"
 msgstr ""
 
-#: src\card.ts:489
-#: src\rush-duel.ts:92
+#: src\card.ts:490
+#: src\rush-duel.ts:103
 #, javascript-format
 msgid "**Type**: ${ raceIcon } ${ localizedMonsterTypeLine }"
 msgstr "**Tipo**: ${ raceIcon } ${ localizedMonsterTypeLine }"
 
-#: src\card.ts:491
-#: src\rush-duel.ts:94
+#: src\card.ts:492
+#: src\rush-duel.ts:105
 #, javascript-format
 msgid "**Attribute**: ${ attributeIcon } ${ localizedAttribute }"
 msgstr "**Atributo**: ${ attributeIcon } ${ localizedAttribute }"
 
-#: src\card.ts:495
+#: src\card.ts:497
 #, javascript-format
 msgid "**Rank**: ${ rankIcon } ${ card.rank } **ATK**: ${ card.atk } **DEF**: ${ card.def }"
 msgstr "**Classe**: ${ rankIcon } ${ card.rank } **ATK**: ${ card.atk } **DEF**: ${ card.def }"
 
-#: src\card.ts:498
+#: src\card.ts:500
 #, javascript-format
 msgid "**Link Rating**: ${ card.link_arrows.length } **ATK**: ${ card.atk } **Link Arrows**: ${ arrows }"
 msgstr "**Valor Link**: ${ card.link_arrows.length } **ATK**: ${ card.atk } **Link Flechas Link**: ${ arrows }"
 
-#: src\card.ts:500
-#: src\rush-duel.ts:96
+#: src\card.ts:503
+#: src\rush-duel.ts:107
 #, javascript-format
 msgid "**Level**: ${ levelIcon } ${ card.level } **ATK**: ${ card.atk } **DEF**: ${ card.def }"
 msgstr "**Nível**: ${ levelIcon } ${ card.level } **ATK**: ${ card.atk } **DEF**: ${ card.def }"
 
-#: src\card.ts:507
+#: src\card.ts:511
 #, javascript-format
 msgid "**Pendulum Scale**: ${ formattedScale }"
 msgstr "**Escala Pêndulo**: ${ formattedScale }"
@@ -70,7 +70,7 @@ msgid "Password: ${ card.password } | Not yet released"
 msgstr "Senha: ${ card.password } | Not yet released"
 
 #: src\card.ts:351
-#: src\rush-duel.ts:146
+#: src\rush-duel.ts:158
 msgid "Not yet released"
 msgstr ""
 
@@ -79,64 +79,64 @@ msgstr ""
 msgid "Placeholder ID: ${ card.fake_password }"
 msgstr ""
 
-#: src\utils.ts:41
+#: src\utils.ts:44
 msgid "🛠️ This command is in development."
 msgstr "🛠️ Este comando está em desenvolvimento."
 
-#: src\utils.ts:42
+#: src\utils.ts:45
 msgid "📨 Please send feedback to [our issue tracker](https://github.com/DawnbrandBots/bastion-bot) or the [support server](https://discord.gg/4aFuPyuE96)!"
 msgstr "📨 Por favor, envie um feedback para o [nosso Github](https://github.com/DawnbrandBots/bastion-bot)ou no nosso [servidor no Discord](https://discord.gg/4aFuPyuE96)!"
 
-#: src\utils.ts:53
+#: src\utils.ts:56
 msgid "Please consider supporting us!"
 msgstr "Por favor, considere nos apoiar!"
 
-#: src\utils.ts:54
+#: src\utils.ts:57
 msgid "Help keep Bastion online!"
 msgstr "Ajude a manter o Bastion online!"
 
-#: src\utils.ts:55
+#: src\utils.ts:58
 msgid "Please help keep Bastion online!"
 msgstr "Por favor, ajude a manter o Bastion online!"
 
-#: src\utils.ts:56
+#: src\utils.ts:59
 msgid "Was Bastion helpful? Consider supporting us!"
 msgstr ""
 
-#: src\utils.ts:57
+#: src\utils.ts:60
 msgid "Was Bastion helpful? We need your support!"
 msgstr "Bastion foi útil? Nós precisamos do seu apoio!"
 
-#: src\utils.ts:58
+#: src\utils.ts:61
 msgid "Did you find Bastion useful? Consider supporting us!"
 msgstr "Você acha que o Bastion foi útil? Conside nos apoiar!"
 
-#: src\utils.ts:59
+#: src\utils.ts:62
 msgid "Did you find Bastion useful? Help keep it online!"
 msgstr "Você acha que o Bastion foi útil? Ajude a mantê-lo online!"
 
-#: src\utils.ts:60
+#: src\utils.ts:63
 msgid "Did you find Bastion useful? We need your support!"
 msgstr "Você acha que o Bastion foi útil? Nós precisamos do seu apoio!"
 
-#: src\utils.ts:61
+#: src\utils.ts:64
 msgid "Enjoy Bastion? Help keep it online!"
 msgstr "Você está gostando do Bastion? Ajude a mantê-lo online!"
 
-#: src\utils.ts:62
+#: src\utils.ts:65
 msgid "Enjoy Bastion? Consider supporting us!"
 msgstr "Você está gostando do Bastion? Considere nos apoiar!"
 
-#: src\utils.ts:63
+#: src\utils.ts:66
 msgid "Found what you were looking for? Consider supporting us!"
 msgstr "Você encontrou o que procurava? Considere nos apoiar!"
 
 #: src\commands\art.ts:63
-#: src\commands\price.ts:131
-#: src\commands\rush-duel.ts:172
-#: src\commands\rush-duel.ts:203
+#: src\commands\price.ts:132
+#: src\commands\rush-duel.ts:171
+#: src\commands\rush-duel.ts:202
 #: src\commands\search.ts:64
-#: src\events\message-search.ts:258
+#: src\events\message-search.ts:265
 #, javascript-format
 msgid "Could not find a card matching `${ input }`!"
 msgstr "Não foi possível encontrar uma carta compatível com `${ input }`!"
@@ -147,51 +147,51 @@ msgstr "Não foi possível encontrar uma carta compatível com `${ input }`!"
 msgid "Could not find art for `${ name }`!"
 msgstr "Não foi possível encontrar uma arte para `${ name }`!"
 
-#: src\commands\deck.ts:244
+#: src\commands\deck.ts:205
 #, javascript-format
 msgid "${ counts.Monster } Monster"
 msgid_plural "${ counts.Monster } Monsters"
 msgstr[0] "${ counts.Monster } Monstro"
 msgstr[1] "${ counts.Monster } Monstros"
 
-#: src\commands\deck.ts:247
+#: src\commands\deck.ts:208
 #, javascript-format
 msgid "${ counts.Spell } Spell"
 msgid_plural "${ counts.Spell } Spells"
 msgstr[0] "${ counts.Spell } Magia"
 msgstr[1] "${ counts.Spell } Magias"
 
-#: src\commands\deck.ts:250
+#: src\commands\deck.ts:211
 #, javascript-format
 msgid "${ counts.Trap } Trap"
 msgid_plural "${ counts.Trap } Traps"
 msgstr[0] "${ counts.Trap } Armadilha"
 msgstr[1] "${ counts.Trap } Armadilhas"
 
-#: src\commands\deck.ts:278
+#: src\commands\deck.ts:239
 msgid "Your Deck"
 msgstr "Seu Deck"
 
-#: src\commands\deck.ts:283
+#: src\commands\deck.ts:244
 #, javascript-format
 msgid "Main Deck (${ deck.main.length } card — ${ countDetail })"
 msgid_plural "Main Deck (${ deck.main.length } cards — ${ countDetail })"
 msgstr[0] "Deck Principal (${ deck.main.length } carta — ${ countDetail })"
 msgstr[1] "Deck Principal (${ deck.main.length } cartas — ${ countDetail })"
 
-#: src\commands\deck.ts:290
+#: src\commands\deck.ts:251
 msgid "Main Deck (continued)"
 msgstr "Deck Principal (continuação)"
 
-#: src\commands\deck.ts:304
+#: src\commands\deck.ts:265
 msgid "Extra Deck (continued)"
 msgstr "Deck Adicional (continuação)"
 
-#: src\commands\deck.ts:318
+#: src\commands\deck.ts:279
 msgid "Side Deck (continued)"
 msgstr "Deck Auxiliar (continuação)"
 
-#: src\commands\deck.ts:407
+#: src\commands\deck.ts:347
 msgid "Error: Your deck is empty."
 msgstr "Erro: Seu deck está vazio"
 
@@ -211,11 +211,7 @@ msgstr ""
 msgid "Discord Community locale for this server: ${ interaction.guildLocale }"
 msgstr ""
 
-#: src\commands\locale.ts:89
-#, javascript-format
-msgid "Locale override for this direct message: ${ override }"
-msgstr ""
-
+#: src\commands\locale-user.ts:76
 #: src\commands\locale.ts:92
 #, javascript-format
 msgid "Your Discord locale: ${ interaction.locale }"
@@ -253,24 +249,14 @@ msgstr ""
 msgid "Sorry, you must have the Manage Server permission to do this. If you think this is an error, contact your server admin or report a bug."
 msgstr ""
 
-#: src\commands\locale.ts:146
-#, javascript-format
-msgid "Locale for this direct message overridden with ${ locale }. Your Discord setting is ${ interaction.locale }."
-msgstr ""
-
-#: src\commands\locale.ts:150
-#, javascript-format
-msgid "Locale for this direct message reset to Discord default. Your Discord setting is ${ interaction.locale }."
-msgstr ""
-
-#: src\commands\ping.ts:36
-#: src\events\message-ping.ts:47
+#: src\commands\ping.ts:38
+#: src\events\message-ping.ts:45
 #, javascript-format
 msgid "Average WebSocket ping (new instance): ${ ping } ms"
 msgstr ""
 
-#: src\commands\ping.ts:40
-#: src\events\message-ping.ts:112
+#: src\commands\ping.ts:42
+#: src\events\message-ping.ts:110
 #, javascript-format
 msgid "Total latency: ${ latency } ms"
 msgstr "Latência total: ${ latency } ms"
@@ -280,86 +266,69 @@ msgstr "Latência total: ${ latency } ms"
 msgid "Could not find a Yugipedia page named `${ page }`."
 msgstr "Não foi possível encontrar uma página na Yugipedia chamada `${ page }`."
 
-#: src\events\message-ping.ts:49
+#: src\events\message-ping.ts:47
 msgid "Free and open source _Yu-Gi-Oh!_ bot"
 msgstr "Um bot de _Yu-Gi-Oh!_ gratuito e de código aberto"
 
-#: src\events\message-ping.ts:72
+#: src\events\message-ping.ts:70
 #, javascript-format
 msgid "Revision: ${ process.env.BOT_REVISION }."
 msgstr "Revisão: ${ process.env.BOT_REVISION }."
 
-#: src\commands\deck.ts:328
+#: src\commands\deck.ts:289
 msgid ".ydk files must have the .ydk extension!"
 msgstr ""
 
-#: src\commands\deck.ts:331
+#: src\commands\deck.ts:292
 msgid ".ydk files should not be larger than 1 KB!"
 msgstr ""
 
-#: src\commands\deck.ts:321
+#: src\commands\deck.ts:282
 msgid "ydke URL"
 msgstr ""
 
 #: src\card.ts:455
-#: src\rush-duel.ts:61
+#: src\rush-duel.ts:75
 #. Forbidden/Limited Lists or Limit Regulations in the OCG
 #, javascript-format
 msgid "**Limit**: ${ limitRegulationDisplay }"
 msgstr ""
 
-#: src\commands\price.ts:69
+#: src\commands\price.ts:70
 msgid "TCGPlayer"
 msgstr ""
 
-#: src\commands\price.ts:70
+#: src\commands\price.ts:71
 msgid "Cardmarket"
 msgstr ""
 
-#: src\commands\price.ts:147
+#: src\commands\price.ts:148
 msgid "No market price"
 msgstr ""
 
-#: src\commands\price.ts:155
+#: src\commands\price.ts:156
 #, javascript-format
 msgid "Prices for ${ card.name[resultLanguage] } - ${ vendorName }"
 msgstr ""
 
-#: src\commands\price.ts:169
+#: src\commands\price.ts:170
 #, javascript-format
 msgid "Could not find prices for `${ name }`!"
 msgstr ""
 
-#: src\commands\deck.ts:425
-#. prepare interaction button for FTP upload
+#: src\commands\deck.ts:363
 msgid "Upload to YGOPRODECK"
 msgstr ""
 
-#: src\commands\deck.ts:483
-#. disable original button
-#. prepare row to disable button on original message
-msgid "Upload Complete"
-msgstr ""
-
-#: src\commands\deck.ts:470
-msgid "Deck upload failed!"
-msgstr ""
-
-#: src\commands\deck.ts:491
-#. reply in affirmation
-#, javascript-format
-msgid "Deck successfully uploaded to <${ url }>!"
-msgstr ""
-
-#: src\events\message-search.ts:264
+#: src\events\message-search.ts:271
 msgid "💬 Translations missing?"
 msgstr ""
 
-#: src\events\message-search.ts:265
+#: src\events\message-search.ts:272
 msgid "Help translate Bastion at the links above."
 msgstr ""
 
-#: src\events\message-ping.ts:50
+#: src\events\message-ping.ts:48
 msgid ""
 "❓ Help documentation on [GitHub](https://github.com/DawnbrandBots/bastion-bot), or use `.commands` and `.help`.\n"
 "🟢 Licence: [GNU AGPL 3.0+](https://choosealicense.com/licenses/agpl-3.0/).\n"
@@ -375,38 +344,38 @@ msgid ""
 "💬 Translations missing? Help translate Bastion on [GitHub](https://github.com/DawnbrandBots/bastion-bot)."
 msgstr ""
 
-#: src\events\message-search.ts:256
-#: src\events\message-search.ts:294
+#: src\events\message-search.ts:263
+#: src\events\message-search.ts:302
 #, javascript-format
 msgid "Search type: ${ localisedType }"
 msgstr ""
 
-#: src\events\message-search.ts:236
+#: src\events\message-search.ts:242
 #, javascript-format
 msgid "Search language: **${ localisedInputLanguage }** (${ inputLanguage }). Check defaults with </locale get:${ id }> and configure with </locale set:${ id }>"
 msgstr ""
 
-#: src\events\message-ping.ts:95
+#: src\events\message-ping.ts:93
 msgid "⚠️ You pinged me, but I am missing permissions in the channel!"
 msgstr ""
 
-#: src\events\message-ping.ts:98
-#: src\events\message-search.ts:332
+#: src\events\message-ping.ts:96
+#: src\events\message-search.ts:340
 msgid "Please have a server administrator [fix this](https://github.com/DawnbrandBots/bastion-bot#discord-permissions)."
 msgstr ""
 
-#: src\events\message-search.ts:329
+#: src\events\message-search.ts:337
 msgid "⚠️ I am missing permissions in the channel!"
 msgstr ""
 
-#: src\commands\deck.ts:297
+#: src\commands\deck.ts:258
 #, javascript-format
 msgid "Extra Deck (${ deck.extra.length } card — ${ countDetail })"
 msgid_plural "Extra Deck (${ deck.extra.length } cards — ${ countDetail })"
 msgstr[0] "Deck Adicional (${ deck.extra.length } carta — ${ countDetail })"
 msgstr[1] "Deck Adicional (${ deck.extra.length } cartas — ${ countDetail })"
 
-#: src\commands\deck.ts:311
+#: src\commands\deck.ts:272
 #, javascript-format
 msgid "Side Deck (${ deck.side.length } card — ${ countDetail })"
 msgid_plural "Side Deck (${ deck.side.length } cards — ${ countDetail })"
@@ -428,32 +397,31 @@ msgstr ""
 msgid "Something went wrong searching Yugipedia for `${ page }`."
 msgstr ""
 
-#: src\rush-duel.ts:40
+#: src\rush-duel.ts:49
 #, javascript-format
 msgid "[Official Konami DB](${ official }) | [Rulings (Japanese)](${ rulings }) | [Yugipedia](${ yugipedia }) | [RushCard](${ rushcard })"
 msgstr "[Database oficial da Konami](${ official }) | [Regras no OCG](${ rulings }) | [Yugipedia](${ yugipedia }) | [RushCard](${ rushcard })"
 
-#: src\rush-duel.ts:43
+#: src\rush-duel.ts:52
 #, javascript-format
 msgid "[Yugipedia](${ yugipedia }) | [RushCard](${ rushcard })"
 msgstr ""
 
-#: src\rush-duel.ts:57
+#: src\rush-duel.ts:71
 msgid "__**LEGEND**__"
 msgstr ""
 
-#: src\rush-duel.ts:99
+#: src\rush-duel.ts:110
 #, javascript-format
 msgid "**MAXIMUM ATK**: ${ card.maximum_atk }"
 msgstr ""
 
-#: src\rush-duel.ts:146
+#: src\rush-duel.ts:158
 #, javascript-format
 msgid "Konami ID #${ card.konami_id }"
 msgstr ""
 
 #: src\art.ts:129
-#: src\commands\deck.ts:451
 msgid "Buttons can only be used by the user who called Bastion."
 msgstr ""
 
@@ -462,14 +430,32 @@ msgstr ""
 msgid "**Master Duel rarity**: ${ rarityIcon } ${ localizedRarity }"
 msgstr ""
 
-#: src\rush-duel.ts:205
+#: src\rush-duel.ts:217
 #, javascript-format
 msgid "Using ${ searchTrigger }, you can search for Rush Duel cards directly in messages without autocomplete"
 msgstr ""
 
-#: src\events\message-search.ts:296
+#: src\events\message-search.ts:304
 #, javascript-format
 msgid "Could not find a Rush Duel card matching `${ input }`!"
+msgstr ""
+
+#: src\commands\locale-user.ts:73
+#: src\commands\locale.ts:89
+#, javascript-format
+msgid "Locale override for your direct messages: ${ override }"
+msgstr ""
+
+#: src\commands\locale-user.ts:83
+#: src\commands\locale.ts:146
+#, javascript-format
+msgid "Locale for your direct messages overridden with ${ locale }. Your Discord setting is ${ interaction.locale }."
+msgstr ""
+
+#: src\commands\locale-user.ts:87
+#: src\commands\locale.ts:150
+#, javascript-format
+msgid "Locale for your direct messages reset to Discord default. Your Discord setting is ${ interaction.locale }."
 msgstr ""
 
 #: src\card.ts:40
@@ -836,60 +822,60 @@ msgctxt "master-duel-rarity"
 msgid "Ultra Rare (UR)"
 msgstr "Ultra Raro (UR)"
 
-#: src\card.ts:513
-#: src\card.ts:524
-#: src\rush-duel.ts:127
+#: src\card.ts:517
+#: src\card.ts:528
+#: src\rush-duel.ts:138
 msgctxt "card-embed"
 msgid "Card Text"
 msgstr "Texto da carta"
 
-#: src\card.ts:518
+#: src\card.ts:522
 msgctxt "card-embed"
 msgid "Pendulum Effect"
 msgstr "Efeito Pêndulo"
 
-#: src\card.ts:539
+#: src\card.ts:545
 msgctxt "card-embed"
 msgid "Card Effect"
 msgstr "Efeito da Carta"
 
-#: src\rush-duel.ts:118
-#: src\rush-duel.ts:139
+#: src\rush-duel.ts:129
+#: src\rush-duel.ts:151
 msgctxt "card-embed"
 msgid "[REQUIREMENT]"
 msgstr ""
 
-#: src\rush-duel.ts:119
-#: src\rush-duel.ts:140
+#: src\rush-duel.ts:130
+#: src\rush-duel.ts:152
 msgctxt "card-embed"
 msgid "[EFFECT]"
 msgstr ""
 
-#: src\rush-duel.ts:121
+#: src\rush-duel.ts:132
 msgctxt "card-embed"
 msgid "[CONTINUOUS EFFECT]"
 msgstr ""
 
-#: src\rush-duel.ts:123
+#: src\rush-duel.ts:134
 msgctxt "card-embed"
 msgid "[MULTI-CHOICE EFFECT]"
 msgstr ""
 
-#: src\locale.ts:71
+#: src\locale.ts:74
 msgctxt "command-option"
 msgid "result-language"
 msgstr ""
 
-#: src\locale.ts:131
+#: src\locale.ts:140
 msgctxt "command-option"
 msgid "input-language"
 msgstr "idioma-de-entrada"
 
-#: src\commands\rush-duel.ts:68
-#: src\commands\rush-duel.ts:80
-#: src\locale.ts:147
-#: src\locale.ts:165
-#: src\locale.ts:181
+#: src\commands\rush-duel.ts:67
+#: src\commands\rush-duel.ts:79
+#: src\locale.ts:156
+#: src\locale.ts:174
+#: src\locale.ts:190
 msgctxt "command-option"
 msgid "input"
 msgstr "entrada"
@@ -904,59 +890,61 @@ msgctxt "command-option"
 msgid "page"
 msgstr "página"
 
-#: src\commands\help.ts:52
+#: src\commands\help.ts:55
 msgctxt "command-option"
 msgid "command"
 msgstr ""
 
-#: src\commands\deck.ts:126
+#: src\commands\deck.ts:87
 msgctxt "command-option"
 msgid "url"
 msgstr ""
 
-#: src\commands\deck.ts:132
+#: src\commands\deck.ts:93
 msgctxt "command-option"
 msgid "file"
 msgstr ""
 
-#: src\commands\deck.ts:138
-#: src\commands\deck.ts:144
+#: src\commands\deck.ts:99
+#: src\commands\deck.ts:105
 msgctxt "command-option"
 msgid "deck"
 msgstr ""
 
-#: src\commands\deck.ts:150
+#: src\commands\deck.ts:111
 msgctxt "command-option"
 msgid "public"
 msgstr ""
 
-#: src\commands\deck.ts:157
+#: src\commands\deck.ts:118
 msgctxt "command-option"
 msgid "stacked"
 msgstr ""
 
-#: src\locale.ts:142
+#: src\locale.ts:151
 msgctxt "command-option"
 msgid "name"
 msgstr ""
 
-#: src\locale.ts:160
+#: src\locale.ts:169
 msgctxt "command-option"
 msgid "password"
 msgstr ""
 
-#: src\commands\rush-duel.ts:73
-#: src\events\message-search.ts:293
-#: src\locale.ts:176
+#: src\commands\rush-duel.ts:72
+#: src\events\message-search.ts:301
+#: src\locale.ts:185
 msgctxt "command-option"
 msgid "konami-id"
 msgstr ""
 
+#: src\commands\locale-user.ts:36
 #: src\commands\locale.ts:30
 msgctxt "command-option"
 msgid "get"
 msgstr ""
 
+#: src\commands\locale-user.ts:41
 #: src\commands\locale.ts:35
 msgctxt "command-option"
 msgid "set"
@@ -967,42 +955,64 @@ msgctxt "command-option"
 msgid "scope"
 msgstr ""
 
+#: src\commands\locale-user.ts:46
 #: src\commands\locale.ts:48
 msgctxt "command-option"
 msgid "locale"
 msgstr ""
 
-#: src\commands\price.ts:94
+#: src\commands\price.ts:95
 msgctxt "command-option"
 msgid "vendor"
 msgstr ""
 
-#: src\commands\rush-duel.ts:63
+#: src\commands\rush-duel.ts:62
 msgctxt "command-option"
 msgid "search"
 msgstr ""
 
-#: src\commands\rush-duel.ts:85
+#: src\commands\rush-duel.ts:84
 msgctxt "command-option"
 msgid "random"
 msgstr ""
 
-#: src\commands\rush-duel.ts:90
+#: src\commands\rush-duel.ts:89
 msgctxt "command-option"
 msgid "art"
 msgstr ""
 
-#: src\commands\query.ts:36
+#: src\commands\query.ts:35
 msgctxt "command-option"
 msgid "lucene"
 msgstr ""
 
-#: src\locale.ts:74
+#: src\commands\metagame.ts:209
+msgctxt "command-option"
+msgid "strategies"
+msgstr ""
+
+#: src\commands\metagame.ts:234
+#: src\commands\metagame.ts:274
+msgctxt "command-option"
+msgid "format"
+msgstr ""
+
+#: src\commands\metagame.ts:240
+msgctxt "command-option"
+msgid "cards"
+msgstr ""
+
+#: src\commands\metagame.ts:310
+msgctxt "command-option"
+msgid "date-range"
+msgstr ""
+
+#: src\locale.ts:77
 msgctxt "command-option-description"
 msgid "The output language for the card embed, overriding other settings."
 msgstr ""
 
-#: src\locale.ts:132
+#: src\locale.ts:141
 msgctxt "command-option-description"
 msgid "The language to search in, defaulting to the result language."
 msgstr "O idioma no qual procurar, tendo como padrão o idioma do resultado"
@@ -1012,37 +1022,37 @@ msgctxt "command-option-description"
 msgid "The name of the Yugipedia page you want to search for."
 msgstr "O nome da página da Yugipedia que você gostaria de procurar"
 
-#: src\commands\help.ts:55
+#: src\commands\help.ts:58
 msgctxt "command-option-description"
 msgid "The name of a specific Slash Command."
 msgstr ""
 
-#: src\commands\deck.ts:129
+#: src\commands\deck.ts:90
 msgctxt "command-option-description"
 msgid "View a deck by entering a ydke:// URL."
 msgstr ""
 
-#: src\commands\deck.ts:135
+#: src\commands\deck.ts:96
 msgctxt "command-option-description"
 msgid "View a deck by uploading a .ydk file."
 msgstr ""
 
-#: src\commands\deck.ts:141
+#: src\commands\deck.ts:102
 msgctxt "command-option-description"
 msgid "The ydke:// URL of the deck you want to view."
 msgstr ""
 
-#: src\commands\deck.ts:147
+#: src\commands\deck.ts:108
 msgctxt "command-option-description"
 msgid "The .ydk file of the deck you want to view."
 msgstr ""
 
-#: src\commands\deck.ts:153
+#: src\commands\deck.ts:114
 msgctxt "command-option-description"
 msgid "Whether to display the deck details publicly in chat. This is false by default."
 msgstr ""
 
-#: src\commands\deck.ts:160
+#: src\commands\deck.ts:121
 msgctxt "command-option-description"
 msgid "Whether to display the deck sections as one stacked column. This is false (side-by-side) by default."
 msgstr ""
@@ -1052,8 +1062,8 @@ msgctxt "command-option-description"
 msgid "Display the art for the card with this name."
 msgstr ""
 
-#: src\commands\rush-duel.ts:69
-#: src\locale.ts:148
+#: src\commands\rush-duel.ts:68
+#: src\locale.ts:157
 msgctxt "command-option-description"
 msgid "Card name, fuzzy matching supported."
 msgstr ""
@@ -1063,7 +1073,7 @@ msgctxt "command-option-description"
 msgid "Display the art for the card with this password."
 msgstr ""
 
-#: src\locale.ts:167
+#: src\locale.ts:176
 msgctxt "command-option-description"
 msgid "Card password, the eight-digit number printed on the bottom left corner."
 msgstr ""
@@ -1073,8 +1083,8 @@ msgctxt "command-option-description"
 msgid "Display the art for the card with this official database ID."
 msgstr ""
 
-#: src\commands\rush-duel.ts:81
-#: src\locale.ts:182
+#: src\commands\rush-duel.ts:80
+#: src\locale.ts:191
 msgctxt "command-option-description"
 msgid "Konami's official card database identifier."
 msgstr ""
@@ -1114,22 +1124,22 @@ msgctxt "command-option-description"
 msgid "The new default language to use in this channel or server."
 msgstr ""
 
-#: src\commands\price.ts:98
+#: src\commands\price.ts:99
 msgctxt "command-option-description"
 msgid "Display the price for the card with this name."
 msgstr ""
 
-#: src\commands\price.ts:102
+#: src\commands\price.ts:103
 msgctxt "command-option-description"
 msgid "Display the price for the card with this password."
 msgstr ""
 
-#: src\commands\price.ts:105
+#: src\commands\price.ts:106
 msgctxt "command-option-description"
 msgid "Display the price for the card with this official database ID."
 msgstr ""
 
-#: src\commands\price.ts:95
+#: src\commands\price.ts:96
 msgctxt "command-option-description"
 msgid "The vendor to fetch the price data from."
 msgstr ""
@@ -1139,29 +1149,70 @@ msgctxt "command-option-description"
 msgid "The English name of the card you're looking for."
 msgstr ""
 
-#: src\commands\rush-duel.ts:64
+#: src\commands\rush-duel.ts:63
 msgctxt "command-option-description"
 msgid "Find all information for the Rush Duel card with this name."
 msgstr ""
 
-#: src\commands\rush-duel.ts:75
+#: src\commands\rush-duel.ts:74
 msgctxt "command-option-description"
 msgid "Find all information for the Rush Duel card with this official database ID."
 msgstr ""
 
-#: src\commands\rush-duel.ts:86
+#: src\commands\rush-duel.ts:85
 msgctxt "command-option-description"
 msgid "Get a random Rush Duel card."
 msgstr ""
 
-#: src\commands\rush-duel.ts:91
+#: src\commands\rush-duel.ts:90
 msgctxt "command-option-description"
 msgid "Display just the art for the Rush Duel card with this name."
 msgstr ""
 
-#: src\commands\query.ts:37
+#: src\commands\query.ts:36
 msgctxt "command-option-description"
 msgid "Lucene query on YAML Yugi"
+msgstr ""
+
+#: src\commands\locale-user.ts:37
+msgctxt "command-option-description"
+msgid "Check your user-installed Bastion's locale."
+msgstr ""
+
+#: src\commands\locale-user.ts:42
+msgctxt "command-option-description"
+msgid "Configure your user-installed Bastion's locale."
+msgstr ""
+
+#: src\commands\locale-user.ts:47
+msgctxt "command-option-description"
+msgid "The new default language to use for user-installed Bastion."
+msgstr ""
+
+#: src\commands\metagame.ts:212
+msgctxt "command-option-description"
+msgid "Show the top competitive strategies in tournaments and the Master Duel ranked ladder."
+msgstr ""
+
+#: src\commands\metagame.ts:214
+msgctxt "command-option-description"
+msgid "Show the top competitive strategies in tournaments."
+msgstr ""
+
+#: src\commands\metagame.ts:235
+#: src\commands\metagame.ts:275
+msgctxt "command-option-description"
+msgid "Game region."
+msgstr ""
+
+#: src\commands\metagame.ts:242
+msgctxt "command-option-description"
+msgid "Show the most popular cards in tournaments and the Master Duel ranked ladder."
+msgstr ""
+
+#: src\commands\metagame.ts:312
+msgctxt "command-option-description"
+msgid "Limit card usage statistics to this date range. Has no effect for Master Duel."
 msgstr ""
 
 #: src\commands\art.ts:36
@@ -1169,7 +1220,7 @@ msgctxt "command-name"
 msgid "art"
 msgstr "arte"
 
-#: src\commands\ping.ts:23
+#: src\commands\ping.ts:25
 msgctxt "command-name"
 msgid "ping"
 msgstr "ping"
@@ -1184,12 +1235,12 @@ msgctxt "command-name"
 msgid "yugipedia"
 msgstr "yugipedia"
 
-#: src\commands\help.ts:49
+#: src\commands\help.ts:52
 msgctxt "command-name"
 msgid "help"
 msgstr ""
 
-#: src\commands\deck.ts:119
+#: src\commands\deck.ts:80
 msgctxt "command-name"
 msgid "deck"
 msgstr ""
@@ -1204,24 +1255,34 @@ msgctxt "command-name"
 msgid "locale"
 msgstr ""
 
-#: src\commands\random.ts:44
+#: src\commands\random.ts:43
 msgctxt "command-name"
 msgid "random"
 msgstr ""
 
-#: src\commands\price.ts:89
+#: src\commands\price.ts:90
 msgctxt "command-name"
 msgid "price"
 msgstr ""
 
-#: src\commands\rush-duel.ts:58
+#: src\commands\rush-duel.ts:57
 msgctxt "command-name"
 msgid "rush-duel"
 msgstr ""
 
-#: src\commands\query.ts:30
+#: src\commands\query.ts:29
 msgctxt "command-name"
 msgid "query"
+msgstr ""
+
+#: src\commands\locale-user.ts:31
+msgctxt "command-name"
+msgid "locale-user"
+msgstr ""
+
+#: src\commands\metagame.ts:204
+msgctxt "command-name"
+msgid "metagame"
 msgstr ""
 
 #: src\commands\art.ts:37
@@ -1229,7 +1290,7 @@ msgctxt "command-description"
 msgid "Display the art for a card!"
 msgstr "Mostra a arte de uma carta!"
 
-#: src\commands\ping.ts:24
+#: src\commands\ping.ts:26
 msgctxt "command-description"
 msgid "Test latency to the new bot instance."
 msgstr "Testa a latência para uma nova instância do bot"
@@ -1244,12 +1305,12 @@ msgctxt "command-description"
 msgid "Search the Yugipedia wiki for a page and link to it."
 msgstr "Procura uma página da wiki da Yugipedia e a linka"
 
-#: src\commands\help.ts:50
+#: src\commands\help.ts:53
 msgctxt "command-description"
 msgid "Get help with a Slash Command."
 msgstr ""
 
-#: src\commands\deck.ts:122
+#: src\commands\deck.ts:83
 msgctxt "command-description"
 msgid "Display a deck list from ydke:// or .ydk format, exported from a number of deck building programs."
 msgstr ""
@@ -1264,24 +1325,34 @@ msgctxt "command-description"
 msgid "Check or set Bastion's locale for this channel or server."
 msgstr ""
 
-#: src\commands\random.ts:45
+#: src\commands\random.ts:44
 msgctxt "command-description"
 msgid "Get a random Yu-Gi-Oh! card."
 msgstr ""
 
-#: src\commands\price.ts:90
+#: src\commands\price.ts:91
 msgctxt "command-description"
 msgid "Display the price for a card!"
 msgstr ""
 
-#: src\commands\rush-duel.ts:59
+#: src\commands\rush-duel.ts:58
 msgctxt "command-description"
 msgid "Find information on Rush Duel cards."
 msgstr ""
 
-#: src\commands\query.ts:31
+#: src\commands\query.ts:30
 msgctxt "command-description"
 msgid "Advanced search prototype"
+msgstr ""
+
+#: src\commands\locale-user.ts:32
+msgctxt "command-description"
+msgid "Check or set user-installed Bastion's locale."
+msgstr ""
+
+#: src\commands\metagame.ts:205
+msgctxt "command-description"
+msgid "Show statistics on the current competitive state of play."
 msgstr ""
 
 #: src\commands\locale.ts:43
@@ -1294,7 +1365,71 @@ msgctxt "command-option-choice"
 msgid "server"
 msgstr ""
 
+#: src\commands\locale-user.ts:49
 #: src\commands\locale.ts:51
 msgctxt "command-option-choice"
 msgid "Discord default"
+msgstr ""
+
+#: src\commands\metagame.ts:219
+#: src\commands\metagame.ts:251
+msgctxt "command-option-choice"
+msgid "TCG"
+msgstr ""
+
+#: src\commands\metagame.ts:220
+#: src\commands\metagame.ts:255
+msgctxt "command-option-choice"
+msgid "OCG"
+msgstr ""
+
+#: src\commands\metagame.ts:221
+#: src\commands\metagame.ts:259
+msgctxt "command-option-choice"
+msgid "OCG (Asian-English)"
+msgstr ""
+
+#: src\commands\metagame.ts:228
+msgctxt "command-option-choice"
+msgid "Master Duel Diamond+ tier list"
+msgstr ""
+
+#: src\commands\metagame.ts:261
+msgctxt "command-option-choice"
+msgid "Master Duel ranked ladder"
+msgstr ""
+
+#: src\commands\metagame.ts:283
+msgctxt "command-option-choice"
+msgid "Current format"
+msgstr ""
+
+#: src\commands\metagame.ts:287
+msgctxt "command-option-choice"
+msgid "Since last Forbidden/Limited List"
+msgstr ""
+
+#: src\commands\metagame.ts:291
+msgctxt "command-option-choice"
+msgid "Last 7 days"
+msgstr ""
+
+#: src\commands\metagame.ts:295
+msgctxt "command-option-choice"
+msgid "Last 14 days"
+msgstr ""
+
+#: src\commands\metagame.ts:299
+msgctxt "command-option-choice"
+msgid "Last 30 days"
+msgstr ""
+
+#: src\commands\metagame.ts:303
+msgctxt "command-option-choice"
+msgid "Last three months"
+msgstr ""
+
+#: src\commands\metagame.ts:307
+msgctxt "command-option-choice"
+msgid "Last six months"
 msgstr ""

--- a/translations/pt.po
+++ b/translations/pt.po
@@ -30,13 +30,13 @@ msgstr "**Tipo**: ${ raceIcon } ${ localizedMonsterTypeLine }"
 #: src\card.ts:491
 #: src\rush-duel.ts:94
 #, javascript-format
-msgid "**Attribute**: ${ AttributeIcon[card.attribute] } ${ localizedAttribute }"
-msgstr "**Atributo**: ${ AttributeIcon[card.attribute] } ${ localizedAttribute }"
+msgid "**Attribute**: ${ attributeIcon } ${ localizedAttribute }"
+msgstr "**Atributo**: ${ attributeIcon } ${ localizedAttribute }"
 
 #: src\card.ts:495
 #, javascript-format
-msgid "**Rank**: ${ Icon.Rank } ${ card.rank } **ATK**: ${ card.atk } **DEF**: ${ card.def }"
-msgstr "**Classe**: ${ Icon.Rank } ${ card.rank } **ATK**: ${ card.atk } **DEF**: ${ card.def }"
+msgid "**Rank**: ${ rankIcon } ${ card.rank } **ATK**: ${ card.atk } **DEF**: ${ card.def }"
+msgstr "**Classe**: ${ rankIcon } ${ card.rank } **ATK**: ${ card.atk } **DEF**: ${ card.def }"
 
 #: src\card.ts:498
 #, javascript-format
@@ -46,8 +46,8 @@ msgstr "**Valor Link**: ${ card.link_arrows.length } **ATK**: ${ card.atk } **Li
 #: src\card.ts:500
 #: src\rush-duel.ts:96
 #, javascript-format
-msgid "**Level**: ${ Icon.Level } ${ card.level } **ATK**: ${ card.atk } **DEF**: ${ card.def }"
-msgstr "**Nível**: ${ Icon.Level } ${ card.level } **ATK**: ${ card.atk } **DEF**: ${ card.def }"
+msgid "**Level**: ${ levelIcon } ${ card.level } **ATK**: ${ card.atk } **DEF**: ${ card.def }"
+msgstr "**Nível**: ${ levelIcon } ${ card.level } **ATK**: ${ card.atk } **DEF**: ${ card.def }"
 
 #: src\card.ts:507
 #, javascript-format
@@ -459,7 +459,7 @@ msgstr ""
 
 #: src\card.ts:462
 #, javascript-format
-msgid "**Master Duel rarity**: ${ rarity_icon } ${ localized_rarity }"
+msgid "**Master Duel rarity**: ${ rarityIcon } ${ localizedRarity }"
 msgstr ""
 
 #: src\rush-duel.ts:205

--- a/translations/pt.po
+++ b/translations/pt.po
@@ -6,50 +6,33 @@ msgstr ""
 "MIME-Version: 1.0\n"
 "Content-Transfer-Encoding: 8bit\n"
 
-#: src\card.ts:416
-#: src\rush-duel.ts:39
+#: src\card.ts:412
+#: src\rush-duel.ts:48
 msgid "🔗 Links"
 msgstr ""
 
-#: src\card.ts:417
+#: src\card.ts:413
 #, javascript-format
 msgid "[Official Konami DB](${ official }) | [OCG Rulings](${ rulings }) | [Yugipedia](${ yugipedia }) | [YGOPRODECK](${ ygoprodeck })"
 msgstr "[Database oficial da Konami](${ official }) | [Regras no OCG](${ rulings }) | [Yugipedia](${ yugipedia }) | [YGOPRODECK](${ ygoprodeck })"
 
-#: src\card.ts:420
+#: src\card.ts:416
 #, javascript-format
 msgid "[Yugipedia](${ yugipedia }) | [YGOPRODECK](${ ygoprodeck })"
 msgstr ""
 
-#: src\card.ts:489
-#: src\rush-duel.ts:92
+#: src\card.ts:490
+#: src\rush-duel.ts:103
 #, javascript-format
 msgid "**Type**: ${ raceIcon } ${ localizedMonsterTypeLine }"
 msgstr "**Tipo**: ${ raceIcon } ${ localizedMonsterTypeLine }"
 
-#: src\card.ts:491
-#: src\rush-duel.ts:94
-#, javascript-format
-msgid "**Attribute**: ${ AttributeIcon[card.attribute] } ${ localizedAttribute }"
-msgstr "**Atributo**: ${ AttributeIcon[card.attribute] } ${ localizedAttribute }"
-
-#: src\card.ts:495
-#, javascript-format
-msgid "**Rank**: ${ Icon.Rank } ${ card.rank } **ATK**: ${ card.atk } **DEF**: ${ card.def }"
-msgstr "**Classe**: ${ Icon.Rank } ${ card.rank } **ATK**: ${ card.atk } **DEF**: ${ card.def }"
-
-#: src\card.ts:498
+#: src\card.ts:500
 #, javascript-format
 msgid "**Link Rating**: ${ card.link_arrows.length } **ATK**: ${ card.atk } **Link Arrows**: ${ arrows }"
 msgstr "**Valor Link**: ${ card.link_arrows.length } **ATK**: ${ card.atk } **Link Flechas Link**: ${ arrows }"
 
-#: src\card.ts:500
-#: src\rush-duel.ts:96
-#, javascript-format
-msgid "**Level**: ${ Icon.Level } ${ card.level } **ATK**: ${ card.atk } **DEF**: ${ card.def }"
-msgstr "**Nível**: ${ Icon.Level } ${ card.level } **ATK**: ${ card.atk } **DEF**: ${ card.def }"
-
-#: src\card.ts:507
+#: src\card.ts:511
 #, javascript-format
 msgid "**Pendulum Scale**: ${ formattedScale }"
 msgstr "**Escala Pêndulo**: ${ formattedScale }"
@@ -70,7 +53,7 @@ msgid "Password: ${ card.password } | Not yet released"
 msgstr "Senha: ${ card.password } | Not yet released"
 
 #: src\card.ts:351
-#: src\rush-duel.ts:146
+#: src\rush-duel.ts:158
 msgid "Not yet released"
 msgstr ""
 
@@ -79,64 +62,64 @@ msgstr ""
 msgid "Placeholder ID: ${ card.fake_password }"
 msgstr ""
 
-#: src\utils.ts:41
+#: src\utils.ts:44
 msgid "🛠️ This command is in development."
 msgstr "🛠️ Este comando está em desenvolvimento."
 
-#: src\utils.ts:42
+#: src\utils.ts:45
 msgid "📨 Please send feedback to [our issue tracker](https://github.com/DawnbrandBots/bastion-bot) or the [support server](https://discord.gg/4aFuPyuE96)!"
 msgstr "📨 Por favor, envie um feedback para o [nosso Github](https://github.com/DawnbrandBots/bastion-bot)ou no nosso [servidor no Discord](https://discord.gg/4aFuPyuE96)!"
 
-#: src\utils.ts:53
+#: src\utils.ts:56
 msgid "Please consider supporting us!"
 msgstr "Por favor, considere nos apoiar!"
 
-#: src\utils.ts:54
+#: src\utils.ts:57
 msgid "Help keep Bastion online!"
 msgstr "Ajude a manter o Bastion online!"
 
-#: src\utils.ts:55
+#: src\utils.ts:58
 msgid "Please help keep Bastion online!"
 msgstr "Por favor, ajude a manter o Bastion online!"
 
-#: src\utils.ts:56
+#: src\utils.ts:59
 msgid "Was Bastion helpful? Consider supporting us!"
 msgstr ""
 
-#: src\utils.ts:57
+#: src\utils.ts:60
 msgid "Was Bastion helpful? We need your support!"
 msgstr "Bastion foi útil? Nós precisamos do seu apoio!"
 
-#: src\utils.ts:58
+#: src\utils.ts:61
 msgid "Did you find Bastion useful? Consider supporting us!"
 msgstr "Você acha que o Bastion foi útil? Conside nos apoiar!"
 
-#: src\utils.ts:59
+#: src\utils.ts:62
 msgid "Did you find Bastion useful? Help keep it online!"
 msgstr "Você acha que o Bastion foi útil? Ajude a mantê-lo online!"
 
-#: src\utils.ts:60
+#: src\utils.ts:63
 msgid "Did you find Bastion useful? We need your support!"
 msgstr "Você acha que o Bastion foi útil? Nós precisamos do seu apoio!"
 
-#: src\utils.ts:61
+#: src\utils.ts:64
 msgid "Enjoy Bastion? Help keep it online!"
 msgstr "Você está gostando do Bastion? Ajude a mantê-lo online!"
 
-#: src\utils.ts:62
+#: src\utils.ts:65
 msgid "Enjoy Bastion? Consider supporting us!"
 msgstr "Você está gostando do Bastion? Considere nos apoiar!"
 
-#: src\utils.ts:63
+#: src\utils.ts:66
 msgid "Found what you were looking for? Consider supporting us!"
 msgstr "Você encontrou o que procurava? Considere nos apoiar!"
 
 #: src\commands\art.ts:63
-#: src\commands\price.ts:131
-#: src\commands\rush-duel.ts:172
-#: src\commands\rush-duel.ts:203
+#: src\commands\price.ts:132
+#: src\commands\rush-duel.ts:171
+#: src\commands\rush-duel.ts:202
 #: src\commands\search.ts:64
-#: src\events\message-search.ts:258
+#: src\events\message-search.ts:265
 #, javascript-format
 msgid "Could not find a card matching `${ input }`!"
 msgstr "Não foi possível encontrar uma carta compatível com `${ input }`!"
@@ -147,51 +130,51 @@ msgstr "Não foi possível encontrar uma carta compatível com `${ input }`!"
 msgid "Could not find art for `${ name }`!"
 msgstr "Não foi possível encontrar uma arte para `${ name }`!"
 
-#: src\commands\deck.ts:244
+#: src\commands\deck.ts:205
 #, javascript-format
 msgid "${ counts.Monster } Monster"
 msgid_plural "${ counts.Monster } Monsters"
 msgstr[0] "${ counts.Monster } Monstro"
 msgstr[1] "${ counts.Monster } Monstros"
 
-#: src\commands\deck.ts:247
+#: src\commands\deck.ts:208
 #, javascript-format
 msgid "${ counts.Spell } Spell"
 msgid_plural "${ counts.Spell } Spells"
 msgstr[0] "${ counts.Spell } Magia"
 msgstr[1] "${ counts.Spell } Magias"
 
-#: src\commands\deck.ts:250
+#: src\commands\deck.ts:211
 #, javascript-format
 msgid "${ counts.Trap } Trap"
 msgid_plural "${ counts.Trap } Traps"
 msgstr[0] "${ counts.Trap } Armadilha"
 msgstr[1] "${ counts.Trap } Armadilhas"
 
-#: src\commands\deck.ts:278
+#: src\commands\deck.ts:239
 msgid "Your Deck"
 msgstr "Seu Deck"
 
-#: src\commands\deck.ts:283
+#: src\commands\deck.ts:244
 #, javascript-format
 msgid "Main Deck (${ deck.main.length } card — ${ countDetail })"
 msgid_plural "Main Deck (${ deck.main.length } cards — ${ countDetail })"
 msgstr[0] "Deck Principal (${ deck.main.length } carta — ${ countDetail })"
 msgstr[1] "Deck Principal (${ deck.main.length } cartas — ${ countDetail })"
 
-#: src\commands\deck.ts:290
+#: src\commands\deck.ts:251
 msgid "Main Deck (continued)"
 msgstr "Deck Principal (continuação)"
 
-#: src\commands\deck.ts:304
+#: src\commands\deck.ts:265
 msgid "Extra Deck (continued)"
 msgstr "Deck Adicional (continuação)"
 
-#: src\commands\deck.ts:318
+#: src\commands\deck.ts:279
 msgid "Side Deck (continued)"
 msgstr "Deck Auxiliar (continuação)"
 
-#: src\commands\deck.ts:407
+#: src\commands\deck.ts:347
 msgid "Error: Your deck is empty."
 msgstr "Erro: Seu deck está vazio"
 
@@ -211,11 +194,7 @@ msgstr ""
 msgid "Discord Community locale for this server: ${ interaction.guildLocale }"
 msgstr ""
 
-#: src\commands\locale.ts:89
-#, javascript-format
-msgid "Locale override for this direct message: ${ override }"
-msgstr ""
-
+#: src\commands\locale-user.ts:76
 #: src\commands\locale.ts:92
 #, javascript-format
 msgid "Your Discord locale: ${ interaction.locale }"
@@ -253,24 +232,14 @@ msgstr ""
 msgid "Sorry, you must have the Manage Server permission to do this. If you think this is an error, contact your server admin or report a bug."
 msgstr ""
 
-#: src\commands\locale.ts:146
-#, javascript-format
-msgid "Locale for this direct message overridden with ${ locale }. Your Discord setting is ${ interaction.locale }."
-msgstr ""
-
-#: src\commands\locale.ts:150
-#, javascript-format
-msgid "Locale for this direct message reset to Discord default. Your Discord setting is ${ interaction.locale }."
-msgstr ""
-
-#: src\commands\ping.ts:36
-#: src\events\message-ping.ts:47
+#: src\commands\ping.ts:38
+#: src\events\message-ping.ts:45
 #, javascript-format
 msgid "Average WebSocket ping (new instance): ${ ping } ms"
 msgstr ""
 
-#: src\commands\ping.ts:40
-#: src\events\message-ping.ts:112
+#: src\commands\ping.ts:42
+#: src\events\message-ping.ts:110
 #, javascript-format
 msgid "Total latency: ${ latency } ms"
 msgstr "Latência total: ${ latency } ms"
@@ -280,86 +249,69 @@ msgstr "Latência total: ${ latency } ms"
 msgid "Could not find a Yugipedia page named `${ page }`."
 msgstr "Não foi possível encontrar uma página na Yugipedia chamada `${ page }`."
 
-#: src\events\message-ping.ts:49
+#: src\events\message-ping.ts:47
 msgid "Free and open source _Yu-Gi-Oh!_ bot"
 msgstr "Um bot de _Yu-Gi-Oh!_ gratuito e de código aberto"
 
-#: src\events\message-ping.ts:72
+#: src\events\message-ping.ts:70
 #, javascript-format
 msgid "Revision: ${ process.env.BOT_REVISION }."
 msgstr "Revisão: ${ process.env.BOT_REVISION }."
 
-#: src\commands\deck.ts:328
+#: src\commands\deck.ts:289
 msgid ".ydk files must have the .ydk extension!"
 msgstr ""
 
-#: src\commands\deck.ts:331
+#: src\commands\deck.ts:292
 msgid ".ydk files should not be larger than 1 KB!"
 msgstr ""
 
-#: src\commands\deck.ts:321
+#: src\commands\deck.ts:282
 msgid "ydke URL"
 msgstr ""
 
 #: src\card.ts:455
-#: src\rush-duel.ts:61
+#: src\rush-duel.ts:75
 #. Forbidden/Limited Lists or Limit Regulations in the OCG
 #, javascript-format
 msgid "**Limit**: ${ limitRegulationDisplay }"
 msgstr ""
 
-#: src\commands\price.ts:69
+#: src\commands\price.ts:70
 msgid "TCGPlayer"
 msgstr ""
 
-#: src\commands\price.ts:70
+#: src\commands\price.ts:71
 msgid "Cardmarket"
 msgstr ""
 
-#: src\commands\price.ts:147
+#: src\commands\price.ts:148
 msgid "No market price"
 msgstr ""
 
-#: src\commands\price.ts:155
+#: src\commands\price.ts:156
 #, javascript-format
 msgid "Prices for ${ card.name[resultLanguage] } - ${ vendorName }"
 msgstr ""
 
-#: src\commands\price.ts:169
+#: src\commands\price.ts:170
 #, javascript-format
 msgid "Could not find prices for `${ name }`!"
 msgstr ""
 
-#: src\commands\deck.ts:425
-#. prepare interaction button for FTP upload
+#: src\commands\deck.ts:363
 msgid "Upload to YGOPRODECK"
 msgstr ""
 
-#: src\commands\deck.ts:483
-#. disable original button
-#. prepare row to disable button on original message
-msgid "Upload Complete"
-msgstr ""
-
-#: src\commands\deck.ts:470
-msgid "Deck upload failed!"
-msgstr ""
-
-#: src\commands\deck.ts:491
-#. reply in affirmation
-#, javascript-format
-msgid "Deck successfully uploaded to <${ url }>!"
-msgstr ""
-
-#: src\events\message-search.ts:264
+#: src\events\message-search.ts:271
 msgid "💬 Translations missing?"
 msgstr ""
 
-#: src\events\message-search.ts:265
+#: src\events\message-search.ts:272
 msgid "Help translate Bastion at the links above."
 msgstr ""
 
-#: src\events\message-ping.ts:50
+#: src\events\message-ping.ts:48
 msgid ""
 "❓ Help documentation on [GitHub](https://github.com/DawnbrandBots/bastion-bot), or use `.commands` and `.help`.\n"
 "🟢 Licence: [GNU AGPL 3.0+](https://choosealicense.com/licenses/agpl-3.0/).\n"
@@ -375,38 +327,38 @@ msgid ""
 "💬 Translations missing? Help translate Bastion on [GitHub](https://github.com/DawnbrandBots/bastion-bot)."
 msgstr ""
 
-#: src\events\message-search.ts:256
-#: src\events\message-search.ts:294
+#: src\events\message-search.ts:263
+#: src\events\message-search.ts:302
 #, javascript-format
 msgid "Search type: ${ localisedType }"
 msgstr ""
 
-#: src\events\message-search.ts:236
+#: src\events\message-search.ts:242
 #, javascript-format
 msgid "Search language: **${ localisedInputLanguage }** (${ inputLanguage }). Check defaults with </locale get:${ id }> and configure with </locale set:${ id }>"
 msgstr ""
 
-#: src\events\message-ping.ts:95
+#: src\events\message-ping.ts:93
 msgid "⚠️ You pinged me, but I am missing permissions in the channel!"
 msgstr ""
 
-#: src\events\message-ping.ts:98
-#: src\events\message-search.ts:332
+#: src\events\message-ping.ts:96
+#: src\events\message-search.ts:340
 msgid "Please have a server administrator [fix this](https://github.com/DawnbrandBots/bastion-bot#discord-permissions)."
 msgstr ""
 
-#: src\events\message-search.ts:329
+#: src\events\message-search.ts:337
 msgid "⚠️ I am missing permissions in the channel!"
 msgstr ""
 
-#: src\commands\deck.ts:297
+#: src\commands\deck.ts:258
 #, javascript-format
 msgid "Extra Deck (${ deck.extra.length } card — ${ countDetail })"
 msgid_plural "Extra Deck (${ deck.extra.length } cards — ${ countDetail })"
 msgstr[0] "Deck Adicional (${ deck.extra.length } carta — ${ countDetail })"
 msgstr[1] "Deck Adicional (${ deck.extra.length } cartas — ${ countDetail })"
 
-#: src\commands\deck.ts:311
+#: src\commands\deck.ts:272
 #, javascript-format
 msgid "Side Deck (${ deck.side.length } card — ${ countDetail })"
 msgid_plural "Side Deck (${ deck.side.length } cards — ${ countDetail })"
@@ -428,48 +380,82 @@ msgstr ""
 msgid "Something went wrong searching Yugipedia for `${ page }`."
 msgstr ""
 
-#: src\rush-duel.ts:40
+#: src\rush-duel.ts:49
 #, javascript-format
 msgid "[Official Konami DB](${ official }) | [Rulings (Japanese)](${ rulings }) | [Yugipedia](${ yugipedia }) | [RushCard](${ rushcard })"
 msgstr "[Database oficial da Konami](${ official }) | [Regras no OCG](${ rulings }) | [Yugipedia](${ yugipedia }) | [RushCard](${ rushcard })"
 
-#: src\rush-duel.ts:43
+#: src\rush-duel.ts:52
 #, javascript-format
 msgid "[Yugipedia](${ yugipedia }) | [RushCard](${ rushcard })"
 msgstr ""
 
-#: src\rush-duel.ts:57
+#: src\rush-duel.ts:71
 msgid "__**LEGEND**__"
 msgstr ""
 
-#: src\rush-duel.ts:99
+#: src\rush-duel.ts:110
 #, javascript-format
 msgid "**MAXIMUM ATK**: ${ card.maximum_atk }"
 msgstr ""
 
-#: src\rush-duel.ts:146
+#: src\rush-duel.ts:158
 #, javascript-format
 msgid "Konami ID #${ card.konami_id }"
 msgstr ""
 
 #: src\art.ts:129
-#: src\commands\deck.ts:451
 msgid "Buttons can only be used by the user who called Bastion."
 msgstr ""
 
-#: src\card.ts:462
-#, javascript-format
-msgid "**Master Duel rarity**: ${ rarity_icon } ${ localized_rarity }"
-msgstr ""
-
-#: src\rush-duel.ts:205
+#: src\rush-duel.ts:217
 #, javascript-format
 msgid "Using ${ searchTrigger }, you can search for Rush Duel cards directly in messages without autocomplete"
 msgstr ""
 
-#: src\events\message-search.ts:296
+#: src\events\message-search.ts:304
 #, javascript-format
 msgid "Could not find a Rush Duel card matching `${ input }`!"
+msgstr ""
+
+#: src\card.ts:462
+#, javascript-format
+msgid "**Master Duel rarity**: ${ rarityIcon } ${ localizedRarity }"
+msgstr ""
+
+#: src\card.ts:492
+#: src\rush-duel.ts:105
+#, javascript-format
+msgid "**Attribute**: ${ attributeIcon } ${ localizedAttribute }"
+msgstr ""
+
+#: src\card.ts:497
+#, javascript-format
+msgid "**Rank**: ${ rankIcon } ${ card.rank } **ATK**: ${ card.atk } **DEF**: ${ card.def }"
+msgstr ""
+
+#: src\card.ts:503
+#: src\rush-duel.ts:107
+#, javascript-format
+msgid "**Level**: ${ levelIcon } ${ card.level } **ATK**: ${ card.atk } **DEF**: ${ card.def }"
+msgstr ""
+
+#: src\commands\locale-user.ts:73
+#: src\commands\locale.ts:89
+#, javascript-format
+msgid "Locale override for your direct messages: ${ override }"
+msgstr ""
+
+#: src\commands\locale-user.ts:83
+#: src\commands\locale.ts:146
+#, javascript-format
+msgid "Locale for your direct messages overridden with ${ locale }. Your Discord setting is ${ interaction.locale }."
+msgstr ""
+
+#: src\commands\locale-user.ts:87
+#: src\commands\locale.ts:150
+#, javascript-format
+msgid "Locale for your direct messages reset to Discord default. Your Discord setting is ${ interaction.locale }."
 msgstr ""
 
 #: src\card.ts:40
@@ -836,60 +822,60 @@ msgctxt "master-duel-rarity"
 msgid "Ultra Rare (UR)"
 msgstr "Ultra Raro (UR)"
 
-#: src\card.ts:513
-#: src\card.ts:524
-#: src\rush-duel.ts:127
+#: src\card.ts:517
+#: src\card.ts:528
+#: src\rush-duel.ts:138
 msgctxt "card-embed"
 msgid "Card Text"
 msgstr "Texto da carta"
 
-#: src\card.ts:518
+#: src\card.ts:522
 msgctxt "card-embed"
 msgid "Pendulum Effect"
 msgstr "Efeito Pêndulo"
 
-#: src\card.ts:539
+#: src\card.ts:545
 msgctxt "card-embed"
 msgid "Card Effect"
 msgstr "Efeito da Carta"
 
-#: src\rush-duel.ts:118
-#: src\rush-duel.ts:139
+#: src\rush-duel.ts:129
+#: src\rush-duel.ts:151
 msgctxt "card-embed"
 msgid "[REQUIREMENT]"
 msgstr ""
 
-#: src\rush-duel.ts:119
-#: src\rush-duel.ts:140
+#: src\rush-duel.ts:130
+#: src\rush-duel.ts:152
 msgctxt "card-embed"
 msgid "[EFFECT]"
 msgstr ""
 
-#: src\rush-duel.ts:121
+#: src\rush-duel.ts:132
 msgctxt "card-embed"
 msgid "[CONTINUOUS EFFECT]"
 msgstr ""
 
-#: src\rush-duel.ts:123
+#: src\rush-duel.ts:134
 msgctxt "card-embed"
 msgid "[MULTI-CHOICE EFFECT]"
 msgstr ""
 
-#: src\locale.ts:71
+#: src\locale.ts:74
 msgctxt "command-option"
 msgid "result-language"
 msgstr ""
 
-#: src\locale.ts:131
+#: src\locale.ts:140
 msgctxt "command-option"
 msgid "input-language"
 msgstr "idioma-de-entrada"
 
-#: src\commands\rush-duel.ts:68
-#: src\commands\rush-duel.ts:80
-#: src\locale.ts:147
-#: src\locale.ts:165
-#: src\locale.ts:181
+#: src\commands\rush-duel.ts:67
+#: src\commands\rush-duel.ts:79
+#: src\locale.ts:156
+#: src\locale.ts:174
+#: src\locale.ts:190
 msgctxt "command-option"
 msgid "input"
 msgstr "entrada"
@@ -904,59 +890,61 @@ msgctxt "command-option"
 msgid "page"
 msgstr "página"
 
-#: src\commands\help.ts:52
+#: src\commands\help.ts:55
 msgctxt "command-option"
 msgid "command"
 msgstr ""
 
-#: src\commands\deck.ts:126
+#: src\commands\deck.ts:87
 msgctxt "command-option"
 msgid "url"
 msgstr ""
 
-#: src\commands\deck.ts:132
+#: src\commands\deck.ts:93
 msgctxt "command-option"
 msgid "file"
 msgstr ""
 
-#: src\commands\deck.ts:138
-#: src\commands\deck.ts:144
+#: src\commands\deck.ts:99
+#: src\commands\deck.ts:105
 msgctxt "command-option"
 msgid "deck"
 msgstr ""
 
-#: src\commands\deck.ts:150
+#: src\commands\deck.ts:111
 msgctxt "command-option"
 msgid "public"
 msgstr ""
 
-#: src\commands\deck.ts:157
+#: src\commands\deck.ts:118
 msgctxt "command-option"
 msgid "stacked"
 msgstr ""
 
-#: src\locale.ts:142
+#: src\locale.ts:151
 msgctxt "command-option"
 msgid "name"
 msgstr ""
 
-#: src\locale.ts:160
+#: src\locale.ts:169
 msgctxt "command-option"
 msgid "password"
 msgstr ""
 
-#: src\commands\rush-duel.ts:73
-#: src\events\message-search.ts:293
-#: src\locale.ts:176
+#: src\commands\rush-duel.ts:72
+#: src\events\message-search.ts:301
+#: src\locale.ts:185
 msgctxt "command-option"
 msgid "konami-id"
 msgstr ""
 
+#: src\commands\locale-user.ts:36
 #: src\commands\locale.ts:30
 msgctxt "command-option"
 msgid "get"
 msgstr ""
 
+#: src\commands\locale-user.ts:41
 #: src\commands\locale.ts:35
 msgctxt "command-option"
 msgid "set"
@@ -967,42 +955,64 @@ msgctxt "command-option"
 msgid "scope"
 msgstr ""
 
+#: src\commands\locale-user.ts:46
 #: src\commands\locale.ts:48
 msgctxt "command-option"
 msgid "locale"
 msgstr ""
 
-#: src\commands\price.ts:94
+#: src\commands\price.ts:95
 msgctxt "command-option"
 msgid "vendor"
 msgstr ""
 
-#: src\commands\rush-duel.ts:63
+#: src\commands\rush-duel.ts:62
 msgctxt "command-option"
 msgid "search"
 msgstr ""
 
-#: src\commands\rush-duel.ts:85
+#: src\commands\rush-duel.ts:84
 msgctxt "command-option"
 msgid "random"
 msgstr ""
 
-#: src\commands\rush-duel.ts:90
+#: src\commands\rush-duel.ts:89
 msgctxt "command-option"
 msgid "art"
 msgstr ""
 
-#: src\commands\query.ts:36
+#: src\commands\query.ts:35
 msgctxt "command-option"
 msgid "lucene"
 msgstr ""
 
-#: src\locale.ts:74
+#: src\commands\metagame.ts:209
+msgctxt "command-option"
+msgid "strategies"
+msgstr ""
+
+#: src\commands\metagame.ts:234
+#: src\commands\metagame.ts:274
+msgctxt "command-option"
+msgid "format"
+msgstr ""
+
+#: src\commands\metagame.ts:240
+msgctxt "command-option"
+msgid "cards"
+msgstr ""
+
+#: src\commands\metagame.ts:310
+msgctxt "command-option"
+msgid "date-range"
+msgstr ""
+
+#: src\locale.ts:77
 msgctxt "command-option-description"
 msgid "The output language for the card embed, overriding other settings."
 msgstr ""
 
-#: src\locale.ts:132
+#: src\locale.ts:141
 msgctxt "command-option-description"
 msgid "The language to search in, defaulting to the result language."
 msgstr "O idioma no qual procurar, tendo como padrão o idioma do resultado"
@@ -1012,37 +1022,37 @@ msgctxt "command-option-description"
 msgid "The name of the Yugipedia page you want to search for."
 msgstr "O nome da página da Yugipedia que você gostaria de procurar"
 
-#: src\commands\help.ts:55
+#: src\commands\help.ts:58
 msgctxt "command-option-description"
 msgid "The name of a specific Slash Command."
 msgstr ""
 
-#: src\commands\deck.ts:129
+#: src\commands\deck.ts:90
 msgctxt "command-option-description"
 msgid "View a deck by entering a ydke:// URL."
 msgstr ""
 
-#: src\commands\deck.ts:135
+#: src\commands\deck.ts:96
 msgctxt "command-option-description"
 msgid "View a deck by uploading a .ydk file."
 msgstr ""
 
-#: src\commands\deck.ts:141
+#: src\commands\deck.ts:102
 msgctxt "command-option-description"
 msgid "The ydke:// URL of the deck you want to view."
 msgstr ""
 
-#: src\commands\deck.ts:147
+#: src\commands\deck.ts:108
 msgctxt "command-option-description"
 msgid "The .ydk file of the deck you want to view."
 msgstr ""
 
-#: src\commands\deck.ts:153
+#: src\commands\deck.ts:114
 msgctxt "command-option-description"
 msgid "Whether to display the deck details publicly in chat. This is false by default."
 msgstr ""
 
-#: src\commands\deck.ts:160
+#: src\commands\deck.ts:121
 msgctxt "command-option-description"
 msgid "Whether to display the deck sections as one stacked column. This is false (side-by-side) by default."
 msgstr ""
@@ -1052,8 +1062,8 @@ msgctxt "command-option-description"
 msgid "Display the art for the card with this name."
 msgstr ""
 
-#: src\commands\rush-duel.ts:69
-#: src\locale.ts:148
+#: src\commands\rush-duel.ts:68
+#: src\locale.ts:157
 msgctxt "command-option-description"
 msgid "Card name, fuzzy matching supported."
 msgstr ""
@@ -1063,7 +1073,7 @@ msgctxt "command-option-description"
 msgid "Display the art for the card with this password."
 msgstr ""
 
-#: src\locale.ts:167
+#: src\locale.ts:176
 msgctxt "command-option-description"
 msgid "Card password, the eight-digit number printed on the bottom left corner."
 msgstr ""
@@ -1073,8 +1083,8 @@ msgctxt "command-option-description"
 msgid "Display the art for the card with this official database ID."
 msgstr ""
 
-#: src\commands\rush-duel.ts:81
-#: src\locale.ts:182
+#: src\commands\rush-duel.ts:80
+#: src\locale.ts:191
 msgctxt "command-option-description"
 msgid "Konami's official card database identifier."
 msgstr ""
@@ -1114,22 +1124,22 @@ msgctxt "command-option-description"
 msgid "The new default language to use in this channel or server."
 msgstr ""
 
-#: src\commands\price.ts:98
+#: src\commands\price.ts:99
 msgctxt "command-option-description"
 msgid "Display the price for the card with this name."
 msgstr ""
 
-#: src\commands\price.ts:102
+#: src\commands\price.ts:103
 msgctxt "command-option-description"
 msgid "Display the price for the card with this password."
 msgstr ""
 
-#: src\commands\price.ts:105
+#: src\commands\price.ts:106
 msgctxt "command-option-description"
 msgid "Display the price for the card with this official database ID."
 msgstr ""
 
-#: src\commands\price.ts:95
+#: src\commands\price.ts:96
 msgctxt "command-option-description"
 msgid "The vendor to fetch the price data from."
 msgstr ""
@@ -1139,29 +1149,70 @@ msgctxt "command-option-description"
 msgid "The English name of the card you're looking for."
 msgstr ""
 
-#: src\commands\rush-duel.ts:64
+#: src\commands\rush-duel.ts:63
 msgctxt "command-option-description"
 msgid "Find all information for the Rush Duel card with this name."
 msgstr ""
 
-#: src\commands\rush-duel.ts:75
+#: src\commands\rush-duel.ts:74
 msgctxt "command-option-description"
 msgid "Find all information for the Rush Duel card with this official database ID."
 msgstr ""
 
-#: src\commands\rush-duel.ts:86
+#: src\commands\rush-duel.ts:85
 msgctxt "command-option-description"
 msgid "Get a random Rush Duel card."
 msgstr ""
 
-#: src\commands\rush-duel.ts:91
+#: src\commands\rush-duel.ts:90
 msgctxt "command-option-description"
 msgid "Display just the art for the Rush Duel card with this name."
 msgstr ""
 
-#: src\commands\query.ts:37
+#: src\commands\query.ts:36
 msgctxt "command-option-description"
 msgid "Lucene query on YAML Yugi"
+msgstr ""
+
+#: src\commands\locale-user.ts:37
+msgctxt "command-option-description"
+msgid "Check your user-installed Bastion's locale."
+msgstr ""
+
+#: src\commands\locale-user.ts:42
+msgctxt "command-option-description"
+msgid "Configure your user-installed Bastion's locale."
+msgstr ""
+
+#: src\commands\locale-user.ts:47
+msgctxt "command-option-description"
+msgid "The new default language to use for user-installed Bastion."
+msgstr ""
+
+#: src\commands\metagame.ts:212
+msgctxt "command-option-description"
+msgid "Show the top competitive strategies in tournaments and the Master Duel ranked ladder."
+msgstr ""
+
+#: src\commands\metagame.ts:214
+msgctxt "command-option-description"
+msgid "Show the top competitive strategies in tournaments."
+msgstr ""
+
+#: src\commands\metagame.ts:235
+#: src\commands\metagame.ts:275
+msgctxt "command-option-description"
+msgid "Game region."
+msgstr ""
+
+#: src\commands\metagame.ts:242
+msgctxt "command-option-description"
+msgid "Show the most popular cards in tournaments and the Master Duel ranked ladder."
+msgstr ""
+
+#: src\commands\metagame.ts:312
+msgctxt "command-option-description"
+msgid "Limit card usage statistics to this date range. Has no effect for Master Duel."
 msgstr ""
 
 #: src\commands\art.ts:36
@@ -1169,7 +1220,7 @@ msgctxt "command-name"
 msgid "art"
 msgstr "arte"
 
-#: src\commands\ping.ts:23
+#: src\commands\ping.ts:25
 msgctxt "command-name"
 msgid "ping"
 msgstr "ping"
@@ -1184,12 +1235,12 @@ msgctxt "command-name"
 msgid "yugipedia"
 msgstr "yugipedia"
 
-#: src\commands\help.ts:49
+#: src\commands\help.ts:52
 msgctxt "command-name"
 msgid "help"
 msgstr ""
 
-#: src\commands\deck.ts:119
+#: src\commands\deck.ts:80
 msgctxt "command-name"
 msgid "deck"
 msgstr ""
@@ -1204,24 +1255,34 @@ msgctxt "command-name"
 msgid "locale"
 msgstr ""
 
-#: src\commands\random.ts:44
+#: src\commands\random.ts:43
 msgctxt "command-name"
 msgid "random"
 msgstr ""
 
-#: src\commands\price.ts:89
+#: src\commands\price.ts:90
 msgctxt "command-name"
 msgid "price"
 msgstr ""
 
-#: src\commands\rush-duel.ts:58
+#: src\commands\rush-duel.ts:57
 msgctxt "command-name"
 msgid "rush-duel"
 msgstr ""
 
-#: src\commands\query.ts:30
+#: src\commands\query.ts:29
 msgctxt "command-name"
 msgid "query"
+msgstr ""
+
+#: src\commands\locale-user.ts:31
+msgctxt "command-name"
+msgid "locale-user"
+msgstr ""
+
+#: src\commands\metagame.ts:204
+msgctxt "command-name"
+msgid "metagame"
 msgstr ""
 
 #: src\commands\art.ts:37
@@ -1229,7 +1290,7 @@ msgctxt "command-description"
 msgid "Display the art for a card!"
 msgstr "Mostra a arte de uma carta!"
 
-#: src\commands\ping.ts:24
+#: src\commands\ping.ts:26
 msgctxt "command-description"
 msgid "Test latency to the new bot instance."
 msgstr "Testa a latência para uma nova instância do bot"
@@ -1244,12 +1305,12 @@ msgctxt "command-description"
 msgid "Search the Yugipedia wiki for a page and link to it."
 msgstr "Procura uma página da wiki da Yugipedia e a linka"
 
-#: src\commands\help.ts:50
+#: src\commands\help.ts:53
 msgctxt "command-description"
 msgid "Get help with a Slash Command."
 msgstr ""
 
-#: src\commands\deck.ts:122
+#: src\commands\deck.ts:83
 msgctxt "command-description"
 msgid "Display a deck list from ydke:// or .ydk format, exported from a number of deck building programs."
 msgstr ""
@@ -1264,24 +1325,34 @@ msgctxt "command-description"
 msgid "Check or set Bastion's locale for this channel or server."
 msgstr ""
 
-#: src\commands\random.ts:45
+#: src\commands\random.ts:44
 msgctxt "command-description"
 msgid "Get a random Yu-Gi-Oh! card."
 msgstr ""
 
-#: src\commands\price.ts:90
+#: src\commands\price.ts:91
 msgctxt "command-description"
 msgid "Display the price for a card!"
 msgstr ""
 
-#: src\commands\rush-duel.ts:59
+#: src\commands\rush-duel.ts:58
 msgctxt "command-description"
 msgid "Find information on Rush Duel cards."
 msgstr ""
 
-#: src\commands\query.ts:31
+#: src\commands\query.ts:30
 msgctxt "command-description"
 msgid "Advanced search prototype"
+msgstr ""
+
+#: src\commands\locale-user.ts:32
+msgctxt "command-description"
+msgid "Check or set user-installed Bastion's locale."
+msgstr ""
+
+#: src\commands\metagame.ts:205
+msgctxt "command-description"
+msgid "Show statistics on the current competitive state of play."
 msgstr ""
 
 #: src\commands\locale.ts:43
@@ -1294,7 +1365,71 @@ msgctxt "command-option-choice"
 msgid "server"
 msgstr ""
 
+#: src\commands\locale-user.ts:49
 #: src\commands\locale.ts:51
 msgctxt "command-option-choice"
 msgid "Discord default"
+msgstr ""
+
+#: src\commands\metagame.ts:219
+#: src\commands\metagame.ts:251
+msgctxt "command-option-choice"
+msgid "TCG"
+msgstr ""
+
+#: src\commands\metagame.ts:220
+#: src\commands\metagame.ts:255
+msgctxt "command-option-choice"
+msgid "OCG"
+msgstr ""
+
+#: src\commands\metagame.ts:221
+#: src\commands\metagame.ts:259
+msgctxt "command-option-choice"
+msgid "OCG (Asian-English)"
+msgstr ""
+
+#: src\commands\metagame.ts:228
+msgctxt "command-option-choice"
+msgid "Master Duel Diamond+ tier list"
+msgstr ""
+
+#: src\commands\metagame.ts:261
+msgctxt "command-option-choice"
+msgid "Master Duel ranked ladder"
+msgstr ""
+
+#: src\commands\metagame.ts:283
+msgctxt "command-option-choice"
+msgid "Current format"
+msgstr ""
+
+#: src\commands\metagame.ts:287
+msgctxt "command-option-choice"
+msgid "Since last Forbidden/Limited List"
+msgstr ""
+
+#: src\commands\metagame.ts:291
+msgctxt "command-option-choice"
+msgid "Last 7 days"
+msgstr ""
+
+#: src\commands\metagame.ts:295
+msgctxt "command-option-choice"
+msgid "Last 14 days"
+msgstr ""
+
+#: src\commands\metagame.ts:299
+msgctxt "command-option-choice"
+msgid "Last 30 days"
+msgstr ""
+
+#: src\commands\metagame.ts:303
+msgctxt "command-option-choice"
+msgid "Last three months"
+msgstr ""
+
+#: src\commands\metagame.ts:307
+msgctxt "command-option-choice"
+msgid "Last six months"
 msgstr ""

--- a/translations/pt.po
+++ b/translations/pt.po
@@ -6,33 +6,50 @@ msgstr ""
 "MIME-Version: 1.0\n"
 "Content-Transfer-Encoding: 8bit\n"
 
-#: src\card.ts:412
-#: src\rush-duel.ts:48
+#: src\card.ts:416
+#: src\rush-duel.ts:39
 msgid "🔗 Links"
 msgstr ""
 
-#: src\card.ts:413
+#: src\card.ts:417
 #, javascript-format
 msgid "[Official Konami DB](${ official }) | [OCG Rulings](${ rulings }) | [Yugipedia](${ yugipedia }) | [YGOPRODECK](${ ygoprodeck })"
 msgstr "[Database oficial da Konami](${ official }) | [Regras no OCG](${ rulings }) | [Yugipedia](${ yugipedia }) | [YGOPRODECK](${ ygoprodeck })"
 
-#: src\card.ts:416
+#: src\card.ts:420
 #, javascript-format
 msgid "[Yugipedia](${ yugipedia }) | [YGOPRODECK](${ ygoprodeck })"
 msgstr ""
 
-#: src\card.ts:490
-#: src\rush-duel.ts:103
+#: src\card.ts:489
+#: src\rush-duel.ts:92
 #, javascript-format
 msgid "**Type**: ${ raceIcon } ${ localizedMonsterTypeLine }"
 msgstr "**Tipo**: ${ raceIcon } ${ localizedMonsterTypeLine }"
 
-#: src\card.ts:500
+#: src\card.ts:491
+#: src\rush-duel.ts:94
+#, javascript-format
+msgid "**Attribute**: ${ AttributeIcon[card.attribute] } ${ localizedAttribute }"
+msgstr "**Atributo**: ${ AttributeIcon[card.attribute] } ${ localizedAttribute }"
+
+#: src\card.ts:495
+#, javascript-format
+msgid "**Rank**: ${ Icon.Rank } ${ card.rank } **ATK**: ${ card.atk } **DEF**: ${ card.def }"
+msgstr "**Classe**: ${ Icon.Rank } ${ card.rank } **ATK**: ${ card.atk } **DEF**: ${ card.def }"
+
+#: src\card.ts:498
 #, javascript-format
 msgid "**Link Rating**: ${ card.link_arrows.length } **ATK**: ${ card.atk } **Link Arrows**: ${ arrows }"
 msgstr "**Valor Link**: ${ card.link_arrows.length } **ATK**: ${ card.atk } **Link Flechas Link**: ${ arrows }"
 
-#: src\card.ts:511
+#: src\card.ts:500
+#: src\rush-duel.ts:96
+#, javascript-format
+msgid "**Level**: ${ Icon.Level } ${ card.level } **ATK**: ${ card.atk } **DEF**: ${ card.def }"
+msgstr "**Nível**: ${ Icon.Level } ${ card.level } **ATK**: ${ card.atk } **DEF**: ${ card.def }"
+
+#: src\card.ts:507
 #, javascript-format
 msgid "**Pendulum Scale**: ${ formattedScale }"
 msgstr "**Escala Pêndulo**: ${ formattedScale }"
@@ -53,7 +70,7 @@ msgid "Password: ${ card.password } | Not yet released"
 msgstr "Senha: ${ card.password } | Not yet released"
 
 #: src\card.ts:351
-#: src\rush-duel.ts:158
+#: src\rush-duel.ts:146
 msgid "Not yet released"
 msgstr ""
 
@@ -62,64 +79,64 @@ msgstr ""
 msgid "Placeholder ID: ${ card.fake_password }"
 msgstr ""
 
-#: src\utils.ts:44
+#: src\utils.ts:41
 msgid "🛠️ This command is in development."
 msgstr "🛠️ Este comando está em desenvolvimento."
 
-#: src\utils.ts:45
+#: src\utils.ts:42
 msgid "📨 Please send feedback to [our issue tracker](https://github.com/DawnbrandBots/bastion-bot) or the [support server](https://discord.gg/4aFuPyuE96)!"
 msgstr "📨 Por favor, envie um feedback para o [nosso Github](https://github.com/DawnbrandBots/bastion-bot)ou no nosso [servidor no Discord](https://discord.gg/4aFuPyuE96)!"
 
-#: src\utils.ts:56
+#: src\utils.ts:53
 msgid "Please consider supporting us!"
 msgstr "Por favor, considere nos apoiar!"
 
-#: src\utils.ts:57
+#: src\utils.ts:54
 msgid "Help keep Bastion online!"
 msgstr "Ajude a manter o Bastion online!"
 
-#: src\utils.ts:58
+#: src\utils.ts:55
 msgid "Please help keep Bastion online!"
 msgstr "Por favor, ajude a manter o Bastion online!"
 
-#: src\utils.ts:59
+#: src\utils.ts:56
 msgid "Was Bastion helpful? Consider supporting us!"
 msgstr ""
 
-#: src\utils.ts:60
+#: src\utils.ts:57
 msgid "Was Bastion helpful? We need your support!"
 msgstr "Bastion foi útil? Nós precisamos do seu apoio!"
 
-#: src\utils.ts:61
+#: src\utils.ts:58
 msgid "Did you find Bastion useful? Consider supporting us!"
 msgstr "Você acha que o Bastion foi útil? Conside nos apoiar!"
 
-#: src\utils.ts:62
+#: src\utils.ts:59
 msgid "Did you find Bastion useful? Help keep it online!"
 msgstr "Você acha que o Bastion foi útil? Ajude a mantê-lo online!"
 
-#: src\utils.ts:63
+#: src\utils.ts:60
 msgid "Did you find Bastion useful? We need your support!"
 msgstr "Você acha que o Bastion foi útil? Nós precisamos do seu apoio!"
 
-#: src\utils.ts:64
+#: src\utils.ts:61
 msgid "Enjoy Bastion? Help keep it online!"
 msgstr "Você está gostando do Bastion? Ajude a mantê-lo online!"
 
-#: src\utils.ts:65
+#: src\utils.ts:62
 msgid "Enjoy Bastion? Consider supporting us!"
 msgstr "Você está gostando do Bastion? Considere nos apoiar!"
 
-#: src\utils.ts:66
+#: src\utils.ts:63
 msgid "Found what you were looking for? Consider supporting us!"
 msgstr "Você encontrou o que procurava? Considere nos apoiar!"
 
 #: src\commands\art.ts:63
-#: src\commands\price.ts:132
-#: src\commands\rush-duel.ts:171
-#: src\commands\rush-duel.ts:202
+#: src\commands\price.ts:131
+#: src\commands\rush-duel.ts:172
+#: src\commands\rush-duel.ts:203
 #: src\commands\search.ts:64
-#: src\events\message-search.ts:265
+#: src\events\message-search.ts:258
 #, javascript-format
 msgid "Could not find a card matching `${ input }`!"
 msgstr "Não foi possível encontrar uma carta compatível com `${ input }`!"
@@ -130,51 +147,51 @@ msgstr "Não foi possível encontrar uma carta compatível com `${ input }`!"
 msgid "Could not find art for `${ name }`!"
 msgstr "Não foi possível encontrar uma arte para `${ name }`!"
 
-#: src\commands\deck.ts:205
+#: src\commands\deck.ts:244
 #, javascript-format
 msgid "${ counts.Monster } Monster"
 msgid_plural "${ counts.Monster } Monsters"
 msgstr[0] "${ counts.Monster } Monstro"
 msgstr[1] "${ counts.Monster } Monstros"
 
-#: src\commands\deck.ts:208
+#: src\commands\deck.ts:247
 #, javascript-format
 msgid "${ counts.Spell } Spell"
 msgid_plural "${ counts.Spell } Spells"
 msgstr[0] "${ counts.Spell } Magia"
 msgstr[1] "${ counts.Spell } Magias"
 
-#: src\commands\deck.ts:211
+#: src\commands\deck.ts:250
 #, javascript-format
 msgid "${ counts.Trap } Trap"
 msgid_plural "${ counts.Trap } Traps"
 msgstr[0] "${ counts.Trap } Armadilha"
 msgstr[1] "${ counts.Trap } Armadilhas"
 
-#: src\commands\deck.ts:239
+#: src\commands\deck.ts:278
 msgid "Your Deck"
 msgstr "Seu Deck"
 
-#: src\commands\deck.ts:244
+#: src\commands\deck.ts:283
 #, javascript-format
 msgid "Main Deck (${ deck.main.length } card — ${ countDetail })"
 msgid_plural "Main Deck (${ deck.main.length } cards — ${ countDetail })"
 msgstr[0] "Deck Principal (${ deck.main.length } carta — ${ countDetail })"
 msgstr[1] "Deck Principal (${ deck.main.length } cartas — ${ countDetail })"
 
-#: src\commands\deck.ts:251
+#: src\commands\deck.ts:290
 msgid "Main Deck (continued)"
 msgstr "Deck Principal (continuação)"
 
-#: src\commands\deck.ts:265
+#: src\commands\deck.ts:304
 msgid "Extra Deck (continued)"
 msgstr "Deck Adicional (continuação)"
 
-#: src\commands\deck.ts:279
+#: src\commands\deck.ts:318
 msgid "Side Deck (continued)"
 msgstr "Deck Auxiliar (continuação)"
 
-#: src\commands\deck.ts:347
+#: src\commands\deck.ts:407
 msgid "Error: Your deck is empty."
 msgstr "Erro: Seu deck está vazio"
 
@@ -194,7 +211,11 @@ msgstr ""
 msgid "Discord Community locale for this server: ${ interaction.guildLocale }"
 msgstr ""
 
-#: src\commands\locale-user.ts:76
+#: src\commands\locale.ts:89
+#, javascript-format
+msgid "Locale override for this direct message: ${ override }"
+msgstr ""
+
 #: src\commands\locale.ts:92
 #, javascript-format
 msgid "Your Discord locale: ${ interaction.locale }"
@@ -232,14 +253,24 @@ msgstr ""
 msgid "Sorry, you must have the Manage Server permission to do this. If you think this is an error, contact your server admin or report a bug."
 msgstr ""
 
-#: src\commands\ping.ts:38
-#: src\events\message-ping.ts:45
+#: src\commands\locale.ts:146
+#, javascript-format
+msgid "Locale for this direct message overridden with ${ locale }. Your Discord setting is ${ interaction.locale }."
+msgstr ""
+
+#: src\commands\locale.ts:150
+#, javascript-format
+msgid "Locale for this direct message reset to Discord default. Your Discord setting is ${ interaction.locale }."
+msgstr ""
+
+#: src\commands\ping.ts:36
+#: src\events\message-ping.ts:47
 #, javascript-format
 msgid "Average WebSocket ping (new instance): ${ ping } ms"
 msgstr ""
 
-#: src\commands\ping.ts:42
-#: src\events\message-ping.ts:110
+#: src\commands\ping.ts:40
+#: src\events\message-ping.ts:112
 #, javascript-format
 msgid "Total latency: ${ latency } ms"
 msgstr "Latência total: ${ latency } ms"
@@ -249,69 +280,86 @@ msgstr "Latência total: ${ latency } ms"
 msgid "Could not find a Yugipedia page named `${ page }`."
 msgstr "Não foi possível encontrar uma página na Yugipedia chamada `${ page }`."
 
-#: src\events\message-ping.ts:47
+#: src\events\message-ping.ts:49
 msgid "Free and open source _Yu-Gi-Oh!_ bot"
 msgstr "Um bot de _Yu-Gi-Oh!_ gratuito e de código aberto"
 
-#: src\events\message-ping.ts:70
+#: src\events\message-ping.ts:72
 #, javascript-format
 msgid "Revision: ${ process.env.BOT_REVISION }."
 msgstr "Revisão: ${ process.env.BOT_REVISION }."
 
-#: src\commands\deck.ts:289
+#: src\commands\deck.ts:328
 msgid ".ydk files must have the .ydk extension!"
 msgstr ""
 
-#: src\commands\deck.ts:292
+#: src\commands\deck.ts:331
 msgid ".ydk files should not be larger than 1 KB!"
 msgstr ""
 
-#: src\commands\deck.ts:282
+#: src\commands\deck.ts:321
 msgid "ydke URL"
 msgstr ""
 
 #: src\card.ts:455
-#: src\rush-duel.ts:75
+#: src\rush-duel.ts:61
 #. Forbidden/Limited Lists or Limit Regulations in the OCG
 #, javascript-format
 msgid "**Limit**: ${ limitRegulationDisplay }"
 msgstr ""
 
-#: src\commands\price.ts:70
+#: src\commands\price.ts:69
 msgid "TCGPlayer"
 msgstr ""
 
-#: src\commands\price.ts:71
+#: src\commands\price.ts:70
 msgid "Cardmarket"
 msgstr ""
 
-#: src\commands\price.ts:148
+#: src\commands\price.ts:147
 msgid "No market price"
 msgstr ""
 
-#: src\commands\price.ts:156
+#: src\commands\price.ts:155
 #, javascript-format
 msgid "Prices for ${ card.name[resultLanguage] } - ${ vendorName }"
 msgstr ""
 
-#: src\commands\price.ts:170
+#: src\commands\price.ts:169
 #, javascript-format
 msgid "Could not find prices for `${ name }`!"
 msgstr ""
 
-#: src\commands\deck.ts:363
+#: src\commands\deck.ts:425
+#. prepare interaction button for FTP upload
 msgid "Upload to YGOPRODECK"
 msgstr ""
 
-#: src\events\message-search.ts:271
+#: src\commands\deck.ts:483
+#. disable original button
+#. prepare row to disable button on original message
+msgid "Upload Complete"
+msgstr ""
+
+#: src\commands\deck.ts:470
+msgid "Deck upload failed!"
+msgstr ""
+
+#: src\commands\deck.ts:491
+#. reply in affirmation
+#, javascript-format
+msgid "Deck successfully uploaded to <${ url }>!"
+msgstr ""
+
+#: src\events\message-search.ts:264
 msgid "💬 Translations missing?"
 msgstr ""
 
-#: src\events\message-search.ts:272
+#: src\events\message-search.ts:265
 msgid "Help translate Bastion at the links above."
 msgstr ""
 
-#: src\events\message-ping.ts:48
+#: src\events\message-ping.ts:50
 msgid ""
 "❓ Help documentation on [GitHub](https://github.com/DawnbrandBots/bastion-bot), or use `.commands` and `.help`.\n"
 "🟢 Licence: [GNU AGPL 3.0+](https://choosealicense.com/licenses/agpl-3.0/).\n"
@@ -327,38 +375,38 @@ msgid ""
 "💬 Translations missing? Help translate Bastion on [GitHub](https://github.com/DawnbrandBots/bastion-bot)."
 msgstr ""
 
-#: src\events\message-search.ts:263
-#: src\events\message-search.ts:302
+#: src\events\message-search.ts:256
+#: src\events\message-search.ts:294
 #, javascript-format
 msgid "Search type: ${ localisedType }"
 msgstr ""
 
-#: src\events\message-search.ts:242
+#: src\events\message-search.ts:236
 #, javascript-format
 msgid "Search language: **${ localisedInputLanguage }** (${ inputLanguage }). Check defaults with </locale get:${ id }> and configure with </locale set:${ id }>"
 msgstr ""
 
-#: src\events\message-ping.ts:93
+#: src\events\message-ping.ts:95
 msgid "⚠️ You pinged me, but I am missing permissions in the channel!"
 msgstr ""
 
-#: src\events\message-ping.ts:96
-#: src\events\message-search.ts:340
+#: src\events\message-ping.ts:98
+#: src\events\message-search.ts:332
 msgid "Please have a server administrator [fix this](https://github.com/DawnbrandBots/bastion-bot#discord-permissions)."
 msgstr ""
 
-#: src\events\message-search.ts:337
+#: src\events\message-search.ts:329
 msgid "⚠️ I am missing permissions in the channel!"
 msgstr ""
 
-#: src\commands\deck.ts:258
+#: src\commands\deck.ts:297
 #, javascript-format
 msgid "Extra Deck (${ deck.extra.length } card — ${ countDetail })"
 msgid_plural "Extra Deck (${ deck.extra.length } cards — ${ countDetail })"
 msgstr[0] "Deck Adicional (${ deck.extra.length } carta — ${ countDetail })"
 msgstr[1] "Deck Adicional (${ deck.extra.length } cartas — ${ countDetail })"
 
-#: src\commands\deck.ts:272
+#: src\commands\deck.ts:311
 #, javascript-format
 msgid "Side Deck (${ deck.side.length } card — ${ countDetail })"
 msgid_plural "Side Deck (${ deck.side.length } cards — ${ countDetail })"
@@ -380,82 +428,48 @@ msgstr ""
 msgid "Something went wrong searching Yugipedia for `${ page }`."
 msgstr ""
 
-#: src\rush-duel.ts:49
+#: src\rush-duel.ts:40
 #, javascript-format
 msgid "[Official Konami DB](${ official }) | [Rulings (Japanese)](${ rulings }) | [Yugipedia](${ yugipedia }) | [RushCard](${ rushcard })"
 msgstr "[Database oficial da Konami](${ official }) | [Regras no OCG](${ rulings }) | [Yugipedia](${ yugipedia }) | [RushCard](${ rushcard })"
 
-#: src\rush-duel.ts:52
+#: src\rush-duel.ts:43
 #, javascript-format
 msgid "[Yugipedia](${ yugipedia }) | [RushCard](${ rushcard })"
 msgstr ""
 
-#: src\rush-duel.ts:71
+#: src\rush-duel.ts:57
 msgid "__**LEGEND**__"
 msgstr ""
 
-#: src\rush-duel.ts:110
+#: src\rush-duel.ts:99
 #, javascript-format
 msgid "**MAXIMUM ATK**: ${ card.maximum_atk }"
 msgstr ""
 
-#: src\rush-duel.ts:158
+#: src\rush-duel.ts:146
 #, javascript-format
 msgid "Konami ID #${ card.konami_id }"
 msgstr ""
 
 #: src\art.ts:129
+#: src\commands\deck.ts:451
 msgid "Buttons can only be used by the user who called Bastion."
-msgstr ""
-
-#: src\rush-duel.ts:217
-#, javascript-format
-msgid "Using ${ searchTrigger }, you can search for Rush Duel cards directly in messages without autocomplete"
-msgstr ""
-
-#: src\events\message-search.ts:304
-#, javascript-format
-msgid "Could not find a Rush Duel card matching `${ input }`!"
 msgstr ""
 
 #: src\card.ts:462
 #, javascript-format
-msgid "**Master Duel rarity**: ${ rarityIcon } ${ localizedRarity }"
+msgid "**Master Duel rarity**: ${ rarity_icon } ${ localized_rarity }"
 msgstr ""
 
-#: src\card.ts:492
-#: src\rush-duel.ts:105
+#: src\rush-duel.ts:205
 #, javascript-format
-msgid "**Attribute**: ${ attributeIcon } ${ localizedAttribute }"
+msgid "Using ${ searchTrigger }, you can search for Rush Duel cards directly in messages without autocomplete"
 msgstr ""
 
-#: src\card.ts:497
+#: src\events\message-search.ts:296
 #, javascript-format
-msgid "**Rank**: ${ rankIcon } ${ card.rank } **ATK**: ${ card.atk } **DEF**: ${ card.def }"
-msgstr ""
-
-#: src\card.ts:503
-#: src\rush-duel.ts:107
-#, javascript-format
-msgid "**Level**: ${ levelIcon } ${ card.level } **ATK**: ${ card.atk } **DEF**: ${ card.def }"
-msgstr ""
-
-#: src\commands\locale-user.ts:73
-#: src\commands\locale.ts:89
-#, javascript-format
-msgid "Locale override for your direct messages: ${ override }"
-msgstr ""
-
-#: src\commands\locale-user.ts:83
-#: src\commands\locale.ts:146
-#, javascript-format
-msgid "Locale for your direct messages overridden with ${ locale }. Your Discord setting is ${ interaction.locale }."
-msgstr ""
-
-#: src\commands\locale-user.ts:87
-#: src\commands\locale.ts:150
-#, javascript-format
-msgid "Locale for your direct messages reset to Discord default. Your Discord setting is ${ interaction.locale }."
+msgid "Could not find a Rush Duel card matching `${ input }`!"
 msgstr ""
 
 #: src\card.ts:40
@@ -822,60 +836,60 @@ msgctxt "master-duel-rarity"
 msgid "Ultra Rare (UR)"
 msgstr "Ultra Raro (UR)"
 
-#: src\card.ts:517
-#: src\card.ts:528
-#: src\rush-duel.ts:138
+#: src\card.ts:513
+#: src\card.ts:524
+#: src\rush-duel.ts:127
 msgctxt "card-embed"
 msgid "Card Text"
 msgstr "Texto da carta"
 
-#: src\card.ts:522
+#: src\card.ts:518
 msgctxt "card-embed"
 msgid "Pendulum Effect"
 msgstr "Efeito Pêndulo"
 
-#: src\card.ts:545
+#: src\card.ts:539
 msgctxt "card-embed"
 msgid "Card Effect"
 msgstr "Efeito da Carta"
 
-#: src\rush-duel.ts:129
-#: src\rush-duel.ts:151
+#: src\rush-duel.ts:118
+#: src\rush-duel.ts:139
 msgctxt "card-embed"
 msgid "[REQUIREMENT]"
 msgstr ""
 
-#: src\rush-duel.ts:130
-#: src\rush-duel.ts:152
+#: src\rush-duel.ts:119
+#: src\rush-duel.ts:140
 msgctxt "card-embed"
 msgid "[EFFECT]"
 msgstr ""
 
-#: src\rush-duel.ts:132
+#: src\rush-duel.ts:121
 msgctxt "card-embed"
 msgid "[CONTINUOUS EFFECT]"
 msgstr ""
 
-#: src\rush-duel.ts:134
+#: src\rush-duel.ts:123
 msgctxt "card-embed"
 msgid "[MULTI-CHOICE EFFECT]"
 msgstr ""
 
-#: src\locale.ts:74
+#: src\locale.ts:71
 msgctxt "command-option"
 msgid "result-language"
 msgstr ""
 
-#: src\locale.ts:140
+#: src\locale.ts:131
 msgctxt "command-option"
 msgid "input-language"
 msgstr "idioma-de-entrada"
 
-#: src\commands\rush-duel.ts:67
-#: src\commands\rush-duel.ts:79
-#: src\locale.ts:156
-#: src\locale.ts:174
-#: src\locale.ts:190
+#: src\commands\rush-duel.ts:68
+#: src\commands\rush-duel.ts:80
+#: src\locale.ts:147
+#: src\locale.ts:165
+#: src\locale.ts:181
 msgctxt "command-option"
 msgid "input"
 msgstr "entrada"
@@ -890,61 +904,59 @@ msgctxt "command-option"
 msgid "page"
 msgstr "página"
 
-#: src\commands\help.ts:55
+#: src\commands\help.ts:52
 msgctxt "command-option"
 msgid "command"
 msgstr ""
 
-#: src\commands\deck.ts:87
+#: src\commands\deck.ts:126
 msgctxt "command-option"
 msgid "url"
 msgstr ""
 
-#: src\commands\deck.ts:93
+#: src\commands\deck.ts:132
 msgctxt "command-option"
 msgid "file"
 msgstr ""
 
-#: src\commands\deck.ts:99
-#: src\commands\deck.ts:105
+#: src\commands\deck.ts:138
+#: src\commands\deck.ts:144
 msgctxt "command-option"
 msgid "deck"
 msgstr ""
 
-#: src\commands\deck.ts:111
+#: src\commands\deck.ts:150
 msgctxt "command-option"
 msgid "public"
 msgstr ""
 
-#: src\commands\deck.ts:118
+#: src\commands\deck.ts:157
 msgctxt "command-option"
 msgid "stacked"
 msgstr ""
 
-#: src\locale.ts:151
+#: src\locale.ts:142
 msgctxt "command-option"
 msgid "name"
 msgstr ""
 
-#: src\locale.ts:169
+#: src\locale.ts:160
 msgctxt "command-option"
 msgid "password"
 msgstr ""
 
-#: src\commands\rush-duel.ts:72
-#: src\events\message-search.ts:301
-#: src\locale.ts:185
+#: src\commands\rush-duel.ts:73
+#: src\events\message-search.ts:293
+#: src\locale.ts:176
 msgctxt "command-option"
 msgid "konami-id"
 msgstr ""
 
-#: src\commands\locale-user.ts:36
 #: src\commands\locale.ts:30
 msgctxt "command-option"
 msgid "get"
 msgstr ""
 
-#: src\commands\locale-user.ts:41
 #: src\commands\locale.ts:35
 msgctxt "command-option"
 msgid "set"
@@ -955,64 +967,42 @@ msgctxt "command-option"
 msgid "scope"
 msgstr ""
 
-#: src\commands\locale-user.ts:46
 #: src\commands\locale.ts:48
 msgctxt "command-option"
 msgid "locale"
 msgstr ""
 
-#: src\commands\price.ts:95
+#: src\commands\price.ts:94
 msgctxt "command-option"
 msgid "vendor"
 msgstr ""
 
-#: src\commands\rush-duel.ts:62
+#: src\commands\rush-duel.ts:63
 msgctxt "command-option"
 msgid "search"
 msgstr ""
 
-#: src\commands\rush-duel.ts:84
+#: src\commands\rush-duel.ts:85
 msgctxt "command-option"
 msgid "random"
 msgstr ""
 
-#: src\commands\rush-duel.ts:89
+#: src\commands\rush-duel.ts:90
 msgctxt "command-option"
 msgid "art"
 msgstr ""
 
-#: src\commands\query.ts:35
+#: src\commands\query.ts:36
 msgctxt "command-option"
 msgid "lucene"
 msgstr ""
 
-#: src\commands\metagame.ts:209
-msgctxt "command-option"
-msgid "strategies"
-msgstr ""
-
-#: src\commands\metagame.ts:234
-#: src\commands\metagame.ts:274
-msgctxt "command-option"
-msgid "format"
-msgstr ""
-
-#: src\commands\metagame.ts:240
-msgctxt "command-option"
-msgid "cards"
-msgstr ""
-
-#: src\commands\metagame.ts:310
-msgctxt "command-option"
-msgid "date-range"
-msgstr ""
-
-#: src\locale.ts:77
+#: src\locale.ts:74
 msgctxt "command-option-description"
 msgid "The output language for the card embed, overriding other settings."
 msgstr ""
 
-#: src\locale.ts:141
+#: src\locale.ts:132
 msgctxt "command-option-description"
 msgid "The language to search in, defaulting to the result language."
 msgstr "O idioma no qual procurar, tendo como padrão o idioma do resultado"
@@ -1022,37 +1012,37 @@ msgctxt "command-option-description"
 msgid "The name of the Yugipedia page you want to search for."
 msgstr "O nome da página da Yugipedia que você gostaria de procurar"
 
-#: src\commands\help.ts:58
+#: src\commands\help.ts:55
 msgctxt "command-option-description"
 msgid "The name of a specific Slash Command."
 msgstr ""
 
-#: src\commands\deck.ts:90
+#: src\commands\deck.ts:129
 msgctxt "command-option-description"
 msgid "View a deck by entering a ydke:// URL."
 msgstr ""
 
-#: src\commands\deck.ts:96
+#: src\commands\deck.ts:135
 msgctxt "command-option-description"
 msgid "View a deck by uploading a .ydk file."
 msgstr ""
 
-#: src\commands\deck.ts:102
+#: src\commands\deck.ts:141
 msgctxt "command-option-description"
 msgid "The ydke:// URL of the deck you want to view."
 msgstr ""
 
-#: src\commands\deck.ts:108
+#: src\commands\deck.ts:147
 msgctxt "command-option-description"
 msgid "The .ydk file of the deck you want to view."
 msgstr ""
 
-#: src\commands\deck.ts:114
+#: src\commands\deck.ts:153
 msgctxt "command-option-description"
 msgid "Whether to display the deck details publicly in chat. This is false by default."
 msgstr ""
 
-#: src\commands\deck.ts:121
+#: src\commands\deck.ts:160
 msgctxt "command-option-description"
 msgid "Whether to display the deck sections as one stacked column. This is false (side-by-side) by default."
 msgstr ""
@@ -1062,8 +1052,8 @@ msgctxt "command-option-description"
 msgid "Display the art for the card with this name."
 msgstr ""
 
-#: src\commands\rush-duel.ts:68
-#: src\locale.ts:157
+#: src\commands\rush-duel.ts:69
+#: src\locale.ts:148
 msgctxt "command-option-description"
 msgid "Card name, fuzzy matching supported."
 msgstr ""
@@ -1073,7 +1063,7 @@ msgctxt "command-option-description"
 msgid "Display the art for the card with this password."
 msgstr ""
 
-#: src\locale.ts:176
+#: src\locale.ts:167
 msgctxt "command-option-description"
 msgid "Card password, the eight-digit number printed on the bottom left corner."
 msgstr ""
@@ -1083,8 +1073,8 @@ msgctxt "command-option-description"
 msgid "Display the art for the card with this official database ID."
 msgstr ""
 
-#: src\commands\rush-duel.ts:80
-#: src\locale.ts:191
+#: src\commands\rush-duel.ts:81
+#: src\locale.ts:182
 msgctxt "command-option-description"
 msgid "Konami's official card database identifier."
 msgstr ""
@@ -1124,22 +1114,22 @@ msgctxt "command-option-description"
 msgid "The new default language to use in this channel or server."
 msgstr ""
 
-#: src\commands\price.ts:99
+#: src\commands\price.ts:98
 msgctxt "command-option-description"
 msgid "Display the price for the card with this name."
 msgstr ""
 
-#: src\commands\price.ts:103
+#: src\commands\price.ts:102
 msgctxt "command-option-description"
 msgid "Display the price for the card with this password."
 msgstr ""
 
-#: src\commands\price.ts:106
+#: src\commands\price.ts:105
 msgctxt "command-option-description"
 msgid "Display the price for the card with this official database ID."
 msgstr ""
 
-#: src\commands\price.ts:96
+#: src\commands\price.ts:95
 msgctxt "command-option-description"
 msgid "The vendor to fetch the price data from."
 msgstr ""
@@ -1149,70 +1139,29 @@ msgctxt "command-option-description"
 msgid "The English name of the card you're looking for."
 msgstr ""
 
-#: src\commands\rush-duel.ts:63
+#: src\commands\rush-duel.ts:64
 msgctxt "command-option-description"
 msgid "Find all information for the Rush Duel card with this name."
 msgstr ""
 
-#: src\commands\rush-duel.ts:74
+#: src\commands\rush-duel.ts:75
 msgctxt "command-option-description"
 msgid "Find all information for the Rush Duel card with this official database ID."
 msgstr ""
 
-#: src\commands\rush-duel.ts:85
+#: src\commands\rush-duel.ts:86
 msgctxt "command-option-description"
 msgid "Get a random Rush Duel card."
 msgstr ""
 
-#: src\commands\rush-duel.ts:90
+#: src\commands\rush-duel.ts:91
 msgctxt "command-option-description"
 msgid "Display just the art for the Rush Duel card with this name."
 msgstr ""
 
-#: src\commands\query.ts:36
+#: src\commands\query.ts:37
 msgctxt "command-option-description"
 msgid "Lucene query on YAML Yugi"
-msgstr ""
-
-#: src\commands\locale-user.ts:37
-msgctxt "command-option-description"
-msgid "Check your user-installed Bastion's locale."
-msgstr ""
-
-#: src\commands\locale-user.ts:42
-msgctxt "command-option-description"
-msgid "Configure your user-installed Bastion's locale."
-msgstr ""
-
-#: src\commands\locale-user.ts:47
-msgctxt "command-option-description"
-msgid "The new default language to use for user-installed Bastion."
-msgstr ""
-
-#: src\commands\metagame.ts:212
-msgctxt "command-option-description"
-msgid "Show the top competitive strategies in tournaments and the Master Duel ranked ladder."
-msgstr ""
-
-#: src\commands\metagame.ts:214
-msgctxt "command-option-description"
-msgid "Show the top competitive strategies in tournaments."
-msgstr ""
-
-#: src\commands\metagame.ts:235
-#: src\commands\metagame.ts:275
-msgctxt "command-option-description"
-msgid "Game region."
-msgstr ""
-
-#: src\commands\metagame.ts:242
-msgctxt "command-option-description"
-msgid "Show the most popular cards in tournaments and the Master Duel ranked ladder."
-msgstr ""
-
-#: src\commands\metagame.ts:312
-msgctxt "command-option-description"
-msgid "Limit card usage statistics to this date range. Has no effect for Master Duel."
 msgstr ""
 
 #: src\commands\art.ts:36
@@ -1220,7 +1169,7 @@ msgctxt "command-name"
 msgid "art"
 msgstr "arte"
 
-#: src\commands\ping.ts:25
+#: src\commands\ping.ts:23
 msgctxt "command-name"
 msgid "ping"
 msgstr "ping"
@@ -1235,12 +1184,12 @@ msgctxt "command-name"
 msgid "yugipedia"
 msgstr "yugipedia"
 
-#: src\commands\help.ts:52
+#: src\commands\help.ts:49
 msgctxt "command-name"
 msgid "help"
 msgstr ""
 
-#: src\commands\deck.ts:80
+#: src\commands\deck.ts:119
 msgctxt "command-name"
 msgid "deck"
 msgstr ""
@@ -1255,34 +1204,24 @@ msgctxt "command-name"
 msgid "locale"
 msgstr ""
 
-#: src\commands\random.ts:43
+#: src\commands\random.ts:44
 msgctxt "command-name"
 msgid "random"
 msgstr ""
 
-#: src\commands\price.ts:90
+#: src\commands\price.ts:89
 msgctxt "command-name"
 msgid "price"
 msgstr ""
 
-#: src\commands\rush-duel.ts:57
+#: src\commands\rush-duel.ts:58
 msgctxt "command-name"
 msgid "rush-duel"
 msgstr ""
 
-#: src\commands\query.ts:29
+#: src\commands\query.ts:30
 msgctxt "command-name"
 msgid "query"
-msgstr ""
-
-#: src\commands\locale-user.ts:31
-msgctxt "command-name"
-msgid "locale-user"
-msgstr ""
-
-#: src\commands\metagame.ts:204
-msgctxt "command-name"
-msgid "metagame"
 msgstr ""
 
 #: src\commands\art.ts:37
@@ -1290,7 +1229,7 @@ msgctxt "command-description"
 msgid "Display the art for a card!"
 msgstr "Mostra a arte de uma carta!"
 
-#: src\commands\ping.ts:26
+#: src\commands\ping.ts:24
 msgctxt "command-description"
 msgid "Test latency to the new bot instance."
 msgstr "Testa a latência para uma nova instância do bot"
@@ -1305,12 +1244,12 @@ msgctxt "command-description"
 msgid "Search the Yugipedia wiki for a page and link to it."
 msgstr "Procura uma página da wiki da Yugipedia e a linka"
 
-#: src\commands\help.ts:53
+#: src\commands\help.ts:50
 msgctxt "command-description"
 msgid "Get help with a Slash Command."
 msgstr ""
 
-#: src\commands\deck.ts:83
+#: src\commands\deck.ts:122
 msgctxt "command-description"
 msgid "Display a deck list from ydke:// or .ydk format, exported from a number of deck building programs."
 msgstr ""
@@ -1325,34 +1264,24 @@ msgctxt "command-description"
 msgid "Check or set Bastion's locale for this channel or server."
 msgstr ""
 
-#: src\commands\random.ts:44
+#: src\commands\random.ts:45
 msgctxt "command-description"
 msgid "Get a random Yu-Gi-Oh! card."
 msgstr ""
 
-#: src\commands\price.ts:91
+#: src\commands\price.ts:90
 msgctxt "command-description"
 msgid "Display the price for a card!"
 msgstr ""
 
-#: src\commands\rush-duel.ts:58
+#: src\commands\rush-duel.ts:59
 msgctxt "command-description"
 msgid "Find information on Rush Duel cards."
 msgstr ""
 
-#: src\commands\query.ts:30
+#: src\commands\query.ts:31
 msgctxt "command-description"
 msgid "Advanced search prototype"
-msgstr ""
-
-#: src\commands\locale-user.ts:32
-msgctxt "command-description"
-msgid "Check or set user-installed Bastion's locale."
-msgstr ""
-
-#: src\commands\metagame.ts:205
-msgctxt "command-description"
-msgid "Show statistics on the current competitive state of play."
 msgstr ""
 
 #: src\commands\locale.ts:43
@@ -1365,71 +1294,7 @@ msgctxt "command-option-choice"
 msgid "server"
 msgstr ""
 
-#: src\commands\locale-user.ts:49
 #: src\commands\locale.ts:51
 msgctxt "command-option-choice"
 msgid "Discord default"
-msgstr ""
-
-#: src\commands\metagame.ts:219
-#: src\commands\metagame.ts:251
-msgctxt "command-option-choice"
-msgid "TCG"
-msgstr ""
-
-#: src\commands\metagame.ts:220
-#: src\commands\metagame.ts:255
-msgctxt "command-option-choice"
-msgid "OCG"
-msgstr ""
-
-#: src\commands\metagame.ts:221
-#: src\commands\metagame.ts:259
-msgctxt "command-option-choice"
-msgid "OCG (Asian-English)"
-msgstr ""
-
-#: src\commands\metagame.ts:228
-msgctxt "command-option-choice"
-msgid "Master Duel Diamond+ tier list"
-msgstr ""
-
-#: src\commands\metagame.ts:261
-msgctxt "command-option-choice"
-msgid "Master Duel ranked ladder"
-msgstr ""
-
-#: src\commands\metagame.ts:283
-msgctxt "command-option-choice"
-msgid "Current format"
-msgstr ""
-
-#: src\commands\metagame.ts:287
-msgctxt "command-option-choice"
-msgid "Since last Forbidden/Limited List"
-msgstr ""
-
-#: src\commands\metagame.ts:291
-msgctxt "command-option-choice"
-msgid "Last 7 days"
-msgstr ""
-
-#: src\commands\metagame.ts:295
-msgctxt "command-option-choice"
-msgid "Last 14 days"
-msgstr ""
-
-#: src\commands\metagame.ts:299
-msgctxt "command-option-choice"
-msgid "Last 30 days"
-msgstr ""
-
-#: src\commands\metagame.ts:303
-msgctxt "command-option-choice"
-msgid "Last three months"
-msgstr ""
-
-#: src\commands\metagame.ts:307
-msgctxt "command-option-choice"
-msgid "Last six months"
 msgstr ""

--- a/translations/zh-CN.po
+++ b/translations/zh-CN.po
@@ -6,33 +6,50 @@ msgstr ""
 "MIME-Version: 1.0\n"
 "Content-Transfer-Encoding: 8bit\n"
 
-#: src\card.ts:412
-#: src\rush-duel.ts:48
+#: src\card.ts:416
+#: src\rush-duel.ts:39
 msgid "🔗 Links"
 msgstr "🔗 链接"
 
-#: src\card.ts:413
+#: src\card.ts:417
 #, javascript-format
 msgid "[Official Konami DB](${ official }) | [OCG Rulings](${ rulings }) | [Yugipedia](${ yugipedia }) | [YGOPRODECK](${ ygoprodeck })"
 msgstr "[K社官方数据库](${ official }) | [事务局FAQ](${ rulings }) | [Yugipedia](${ yugipedia }) | [YGOPRODECK](${ ygoprodeck })"
 
-#: src\card.ts:416
+#: src\card.ts:420
 #, javascript-format
 msgid "[Yugipedia](${ yugipedia }) | [YGOPRODECK](${ ygoprodeck })"
 msgstr "[Yugipedia](${ yugipedia }) | [YGOPRODECK](${ ygoprodeck })"
 
-#: src\card.ts:490
-#: src\rush-duel.ts:103
+#: src\card.ts:489
+#: src\rush-duel.ts:92
 #, javascript-format
 msgid "**Type**: ${ raceIcon } ${ localizedMonsterTypeLine }"
 msgstr "**种族**: ${ raceIcon } ${ localizedMonsterTypeLine }"
 
-#: src\card.ts:500
+#: src\card.ts:491
+#: src\rush-duel.ts:94
+#, javascript-format
+msgid "**Attribute**: ${ AttributeIcon[card.attribute] } ${ localizedAttribute }"
+msgstr "**属性**: ${ AttributeIcon[card.attribute] } ${ localizedAttribute }"
+
+#: src\card.ts:495
+#, javascript-format
+msgid "**Rank**: ${ Icon.Rank } ${ card.rank } **ATK**: ${ card.atk } **DEF**: ${ card.def }"
+msgstr "**阶级**: ${ Icon.Rank } ${ card.rank } **攻击力**: ${ card.atk } **守备力**: ${ card.def }"
+
+#: src\card.ts:498
 #, javascript-format
 msgid "**Link Rating**: ${ card.link_arrows.length } **ATK**: ${ card.atk } **Link Arrows**: ${ arrows }"
 msgstr "**连接数值**: ${ card.link_arrows.length } **攻击力**: ${ card.atk } **连接标记**: ${ arrows }"
 
-#: src\card.ts:511
+#: src\card.ts:500
+#: src\rush-duel.ts:96
+#, javascript-format
+msgid "**Level**: ${ Icon.Level } ${ card.level } **ATK**: ${ card.atk } **DEF**: ${ card.def }"
+msgstr "**等级**: ${ Icon.Level } ${ card.level } **攻击力**: ${ card.atk } **守备力**: ${ card.def }"
+
+#: src\card.ts:507
 #, javascript-format
 msgid "**Pendulum Scale**: ${ formattedScale }"
 msgstr "**灵摆刻度**: ${ formattedScale }"
@@ -53,7 +70,7 @@ msgid "Password: ${ card.password } | Not yet released"
 msgstr "卡片密码: ${ card.password } | 未发行"
 
 #: src\card.ts:351
-#: src\rush-duel.ts:158
+#: src\rush-duel.ts:146
 msgid "Not yet released"
 msgstr "未发行"
 
@@ -62,64 +79,64 @@ msgstr "未发行"
 msgid "Placeholder ID: ${ card.fake_password }"
 msgstr "假卡密: ${ card.fake_password }"
 
-#: src\utils.ts:44
+#: src\utils.ts:41
 msgid "🛠️ This command is in development."
 msgstr "🛠️ 这个指令正在开发中"
 
-#: src\utils.ts:45
+#: src\utils.ts:42
 msgid "📨 Please send feedback to [our issue tracker](https://github.com/DawnbrandBots/bastion-bot) or the [support server](https://discord.gg/4aFuPyuE96)!"
 msgstr "📨 如有意见或建议请反馈至[GitHub issue](https://github.com/DawnbrandBots/bastion-bot)或者[Discord服务器](https://discord.gg/4aFuPyuE96)!"
 
-#: src\utils.ts:56
+#: src\utils.ts:53
 msgid "Please consider supporting us!"
 msgstr "请考虑捐助我们！"
 
-#: src\utils.ts:57
+#: src\utils.ts:54
 msgid "Help keep Bastion online!"
 msgstr "帮帮Bastion吧，宝宝快饿死了"
 
-#: src\utils.ts:58
+#: src\utils.ts:55
 msgid "Please help keep Bastion online!"
 msgstr "请帮帮Bastion吧，宝宝真的快饿死了"
 
-#: src\utils.ts:59
+#: src\utils.ts:56
 msgid "Was Bastion helpful? Consider supporting us!"
 msgstr "Bastion有用么？请考虑捐助我们！"
 
-#: src\utils.ts:60
+#: src\utils.ts:57
 msgid "Was Bastion helpful? We need your support!"
 msgstr "Bastion有用么？我们需要你的支持！"
 
-#: src\utils.ts:61
+#: src\utils.ts:58
 msgid "Did you find Bastion useful? Consider supporting us!"
 msgstr "你觉得Bastion好用么？请考虑捐助我们！"
 
-#: src\utils.ts:62
+#: src\utils.ts:59
 msgid "Did you find Bastion useful? Help keep it online!"
 msgstr "你觉得Bastion好用么？那帮帮TA吧，孩子快饿死了"
 
-#: src\utils.ts:63
+#: src\utils.ts:60
 msgid "Did you find Bastion useful? We need your support!"
 msgstr "你觉得Bastion好用么？我们需要你的支持！"
 
-#: src\utils.ts:64
+#: src\utils.ts:61
 msgid "Enjoy Bastion? Help keep it online!"
 msgstr "你觉得Bastion好用么？那帮帮TA吧，孩子快饿死了"
 
-#: src\utils.ts:65
+#: src\utils.ts:62
 msgid "Enjoy Bastion? Consider supporting us!"
 msgstr "觉得Bastion怎么样？请考虑捐助我们！"
 
-#: src\utils.ts:66
+#: src\utils.ts:63
 msgid "Found what you were looking for? Consider supporting us!"
 msgstr "找到你要的东西了吗？请考虑捐助我们！"
 
 #: src\commands\art.ts:63
-#: src\commands\price.ts:132
-#: src\commands\rush-duel.ts:171
-#: src\commands\rush-duel.ts:202
+#: src\commands\price.ts:131
+#: src\commands\rush-duel.ts:172
+#: src\commands\rush-duel.ts:203
 #: src\commands\search.ts:64
-#: src\events\message-search.ts:265
+#: src\events\message-search.ts:258
 #, javascript-format
 msgid "Could not find a card matching `${ input }`!"
 msgstr "查无此卡：`${ input }`"
@@ -146,7 +163,11 @@ msgstr ""
 msgid "Discord Community locale for this server: ${ interaction.guildLocale }"
 msgstr ""
 
-#: src\commands\locale-user.ts:76
+#: src\commands\locale.ts:89
+#, javascript-format
+msgid "Locale override for this direct message: ${ override }"
+msgstr ""
+
 #: src\commands\locale.ts:92
 #, javascript-format
 msgid "Your Discord locale: ${ interaction.locale }"
@@ -184,8 +205,18 @@ msgstr ""
 msgid "Sorry, you must have the Manage Server permission to do this. If you think this is an error, contact your server admin or report a bug."
 msgstr ""
 
-#: src\commands\ping.ts:42
-#: src\events\message-ping.ts:110
+#: src\commands\locale.ts:146
+#, javascript-format
+msgid "Locale for this direct message overridden with ${ locale }. Your Discord setting is ${ interaction.locale }."
+msgstr ""
+
+#: src\commands\locale.ts:150
+#, javascript-format
+msgid "Locale for this direct message reset to Discord default. Your Discord setting is ${ interaction.locale }."
+msgstr ""
+
+#: src\commands\ping.ts:40
+#: src\events\message-ping.ts:112
 #, javascript-format
 msgid "Total latency: ${ latency } ms"
 msgstr "延迟${ latency }ms"
@@ -195,131 +226,148 @@ msgstr "延迟${ latency }ms"
 msgid "Could not find a Yugipedia page named `${ page }`."
 msgstr "Yugipedia上找不到`${ page }`"
 
-#: src\commands\deck.ts:205
+#: src\commands\deck.ts:244
 #, javascript-format
 msgid "${ counts.Monster } Monster"
 msgid_plural "${ counts.Monster } Monsters"
 msgstr[0] "${ counts.Monster }张怪兽卡"
 
-#: src\commands\deck.ts:208
+#: src\commands\deck.ts:247
 #, javascript-format
 msgid "${ counts.Spell } Spell"
 msgid_plural "${ counts.Spell } Spells"
 msgstr[0] "${ counts.Spell }张魔法卡"
 
-#: src\commands\deck.ts:211
+#: src\commands\deck.ts:250
 #, javascript-format
 msgid "${ counts.Trap } Trap"
 msgid_plural "${ counts.Trap } Traps"
 msgstr[0] "${ counts.Trap }张陷阱卡"
 
-#: src\commands\deck.ts:239
+#: src\commands\deck.ts:278
 msgid "Your Deck"
 msgstr "你的卡组"
 
-#: src\commands\deck.ts:244
+#: src\commands\deck.ts:283
 #, javascript-format
 msgid "Main Deck (${ deck.main.length } card — ${ countDetail })"
 msgid_plural "Main Deck (${ deck.main.length } cards — ${ countDetail })"
 msgstr[0] "牌组（${ deck.main.length }张 — ${ countDetail }）"
 
-#: src\commands\deck.ts:258
+#: src\commands\deck.ts:297
 #, javascript-format
 msgid "Extra Deck (${ deck.extra.length } card — ${ countDetail })"
 msgid_plural "Extra Deck (${ deck.extra.length } cards — ${ countDetail })"
 msgstr[0] "额外卡组（${ deck.extra.length }张 — ${ countDetail }）"
 
-#: src\commands\deck.ts:272
+#: src\commands\deck.ts:311
 #, javascript-format
 msgid "Side Deck (${ deck.side.length } card — ${ countDetail })"
 msgid_plural "Side Deck (${ deck.side.length } cards — ${ countDetail })"
 msgstr[0] "备牌（${ deck.side.length }张 — ${ countDetail }）"
 
-#: src\commands\deck.ts:251
+#: src\commands\deck.ts:290
 msgid "Main Deck (continued)"
 msgstr "牌组（续）"
 
-#: src\commands\deck.ts:265
+#: src\commands\deck.ts:304
 msgid "Extra Deck (continued)"
 msgstr "额外卡组（续）"
 
-#: src\commands\deck.ts:279
+#: src\commands\deck.ts:318
 msgid "Side Deck (continued)"
 msgstr "备牌（续）"
 
-#: src\commands\deck.ts:347
+#: src\commands\deck.ts:407
 msgid "Error: Your deck is empty."
 msgstr "错误：卡组是空的。"
 
-#: src\commands\ping.ts:38
-#: src\events\message-ping.ts:45
+#: src\commands\ping.ts:36
+#: src\events\message-ping.ts:47
 #, javascript-format
 msgid "Average WebSocket ping (new instance): ${ ping } ms"
 msgstr ""
 
-#: src\events\message-ping.ts:47
+#: src\events\message-ping.ts:49
 msgid "Free and open source _Yu-Gi-Oh!_ bot"
 msgstr "自由开源游戏王聊天机器人"
 
-#: src\events\message-ping.ts:70
+#: src\events\message-ping.ts:72
 #, javascript-format
 msgid "Revision: ${ process.env.BOT_REVISION }."
 msgstr "修订：${ process.env.BOT_REVISION }"
 
-#: src\commands\deck.ts:289
+#: src\commands\deck.ts:328
 msgid ".ydk files must have the .ydk extension!"
 msgstr ""
 
-#: src\commands\deck.ts:292
+#: src\commands\deck.ts:331
 msgid ".ydk files should not be larger than 1 KB!"
 msgstr ""
 
-#: src\commands\deck.ts:282
+#: src\commands\deck.ts:321
 msgid "ydke URL"
 msgstr ""
 
 #: src\card.ts:455
-#: src\rush-duel.ts:75
+#: src\rush-duel.ts:61
 #. Forbidden/Limited Lists or Limit Regulations in the OCG
 #, javascript-format
 msgid "**Limit**: ${ limitRegulationDisplay }"
 msgstr "**限制**: ${ limitRegulationDisplay }"
 
-#: src\commands\price.ts:70
+#: src\commands\price.ts:69
 msgid "TCGPlayer"
 msgstr ""
 
-#: src\commands\price.ts:71
+#: src\commands\price.ts:70
 msgid "Cardmarket"
 msgstr ""
 
-#: src\commands\price.ts:148
+#: src\commands\price.ts:147
 msgid "No market price"
 msgstr ""
 
-#: src\commands\price.ts:156
+#: src\commands\price.ts:155
 #, javascript-format
 msgid "Prices for ${ card.name[resultLanguage] } - ${ vendorName }"
 msgstr ""
 
-#: src\commands\price.ts:170
+#: src\commands\price.ts:169
 #, javascript-format
 msgid "Could not find prices for `${ name }`!"
 msgstr ""
 
-#: src\commands\deck.ts:363
+#: src\commands\deck.ts:425
+#. prepare interaction button for FTP upload
 msgid "Upload to YGOPRODECK"
 msgstr "上传至YGOPRODECK"
 
-#: src\events\message-search.ts:271
+#: src\commands\deck.ts:483
+#. disable original button
+#. prepare row to disable button on original message
+msgid "Upload Complete"
+msgstr "上传成功"
+
+#: src\commands\deck.ts:470
+msgid "Deck upload failed!"
+msgstr "上传失败"
+
+#: src\commands\deck.ts:491
+#. reply in affirmation
+#, javascript-format
+msgid "Deck successfully uploaded to <${ url }>!"
+msgstr "卡组成功上传到<${ url }>!"
+
+#: src\events\message-search.ts:264
 msgid "💬 Translations missing?"
 msgstr "💬缺少翻译？"
 
-#: src\events\message-search.ts:272
+#: src\events\message-search.ts:265
 msgid "Help translate Bastion at the links above."
 msgstr "在以上的网址帮忙翻译Bastion"
 
-#: src\events\message-ping.ts:48
+#: src\events\message-ping.ts:50
 msgid ""
 "❓ Help documentation on [GitHub](https://github.com/DawnbrandBots/bastion-bot), or use `.commands` and `.help`.\n"
 "🟢 Licence: [GNU AGPL 3.0+](https://choosealicense.com/licenses/agpl-3.0/).\n"
@@ -335,27 +383,27 @@ msgid ""
 "💬 Translations missing? Help translate Bastion on [GitHub](https://github.com/DawnbrandBots/bastion-bot)."
 msgstr ""
 
-#: src\events\message-search.ts:263
-#: src\events\message-search.ts:302
+#: src\events\message-search.ts:256
+#: src\events\message-search.ts:294
 #, javascript-format
 msgid "Search type: ${ localisedType }"
 msgstr "搜索类型：${ localisedType }"
 
-#: src\events\message-search.ts:242
+#: src\events\message-search.ts:236
 #, javascript-format
 msgid "Search language: **${ localisedInputLanguage }** (${ inputLanguage }). Check defaults with </locale get:${ id }> and configure with </locale set:${ id }>"
 msgstr ""
 
-#: src\events\message-ping.ts:93
+#: src\events\message-ping.ts:95
 msgid "⚠️ You pinged me, but I am missing permissions in the channel!"
 msgstr ""
 
-#: src\events\message-ping.ts:96
-#: src\events\message-search.ts:340
+#: src\events\message-ping.ts:98
+#: src\events\message-search.ts:332
 msgid "Please have a server administrator [fix this](https://github.com/DawnbrandBots/bastion-bot#discord-permissions)."
 msgstr ""
 
-#: src\events\message-search.ts:337
+#: src\events\message-search.ts:329
 msgid "⚠️ I am missing permissions in the channel!"
 msgstr ""
 
@@ -374,82 +422,48 @@ msgstr ""
 msgid "Something went wrong searching Yugipedia for `${ page }`."
 msgstr ""
 
-#: src\rush-duel.ts:49
+#: src\rush-duel.ts:40
 #, javascript-format
 msgid "[Official Konami DB](${ official }) | [Rulings (Japanese)](${ rulings }) | [Yugipedia](${ yugipedia }) | [RushCard](${ rushcard })"
 msgstr "[K社官方数据库](${ official }) | [事务局FAQ](${ rulings }) | [Yugipedia](${ yugipedia }) | [RushCard](${ rushcard })"
 
-#: src\rush-duel.ts:52
+#: src\rush-duel.ts:43
 #, javascript-format
 msgid "[Yugipedia](${ yugipedia }) | [RushCard](${ rushcard })"
 msgstr "[Yugipedia](${ yugipedia }) | [RushCard](${ rushcard })"
 
-#: src\rush-duel.ts:71
+#: src\rush-duel.ts:57
 msgid "__**LEGEND**__"
 msgstr ""
 
-#: src\rush-duel.ts:110
+#: src\rush-duel.ts:99
 #, javascript-format
 msgid "**MAXIMUM ATK**: ${ card.maximum_atk }"
 msgstr ""
 
-#: src\rush-duel.ts:158
+#: src\rush-duel.ts:146
 #, javascript-format
 msgid "Konami ID #${ card.konami_id }"
 msgstr "官方编号${ card.konami_id }"
 
 #: src\art.ts:129
+#: src\commands\deck.ts:451
 msgid "Buttons can only be used by the user who called Bastion."
-msgstr ""
-
-#: src\rush-duel.ts:217
-#, javascript-format
-msgid "Using ${ searchTrigger }, you can search for Rush Duel cards directly in messages without autocomplete"
-msgstr ""
-
-#: src\events\message-search.ts:304
-#, javascript-format
-msgid "Could not find a Rush Duel card matching `${ input }`!"
 msgstr ""
 
 #: src\card.ts:462
 #, javascript-format
-msgid "**Master Duel rarity**: ${ rarityIcon } ${ localizedRarity }"
+msgid "**Master Duel rarity**: ${ rarity_icon } ${ localized_rarity }"
+msgstr "**稀有度 (Master Duel)**: ${ rarity_icon } ${ localized_rarity }"
+
+#: src\rush-duel.ts:205
+#, javascript-format
+msgid "Using ${ searchTrigger }, you can search for Rush Duel cards directly in messages without autocomplete"
 msgstr ""
 
-#: src\card.ts:492
-#: src\rush-duel.ts:105
+#: src\events\message-search.ts:296
 #, javascript-format
-msgid "**Attribute**: ${ attributeIcon } ${ localizedAttribute }"
-msgstr ""
-
-#: src\card.ts:497
-#, javascript-format
-msgid "**Rank**: ${ rankIcon } ${ card.rank } **ATK**: ${ card.atk } **DEF**: ${ card.def }"
-msgstr ""
-
-#: src\card.ts:503
-#: src\rush-duel.ts:107
-#, javascript-format
-msgid "**Level**: ${ levelIcon } ${ card.level } **ATK**: ${ card.atk } **DEF**: ${ card.def }"
-msgstr ""
-
-#: src\commands\locale-user.ts:73
-#: src\commands\locale.ts:89
-#, javascript-format
-msgid "Locale override for your direct messages: ${ override }"
-msgstr ""
-
-#: src\commands\locale-user.ts:83
-#: src\commands\locale.ts:146
-#, javascript-format
-msgid "Locale for your direct messages overridden with ${ locale }. Your Discord setting is ${ interaction.locale }."
-msgstr ""
-
-#: src\commands\locale-user.ts:87
-#: src\commands\locale.ts:150
-#, javascript-format
-msgid "Locale for your direct messages reset to Discord default. Your Discord setting is ${ interaction.locale }."
+msgid "Could not find a Rush Duel card matching `${ input }`!"
 msgstr ""
 
 #: src\card.ts:40
@@ -816,60 +830,60 @@ msgctxt "master-duel-rarity"
 msgid "Ultra Rare (UR)"
 msgstr "金闪稀有（ＵＲ）"
 
-#: src\card.ts:517
-#: src\card.ts:528
-#: src\rush-duel.ts:138
+#: src\card.ts:513
+#: src\card.ts:524
+#: src\rush-duel.ts:127
 msgctxt "card-embed"
 msgid "Card Text"
 msgstr "卡片文本"
 
-#: src\card.ts:522
+#: src\card.ts:518
 msgctxt "card-embed"
 msgid "Pendulum Effect"
 msgstr "灵摆效果"
 
-#: src\card.ts:545
+#: src\card.ts:539
 msgctxt "card-embed"
 msgid "Card Effect"
 msgstr "卡片效果"
 
-#: src\rush-duel.ts:129
-#: src\rush-duel.ts:151
+#: src\rush-duel.ts:118
+#: src\rush-duel.ts:139
 msgctxt "card-embed"
 msgid "[REQUIREMENT]"
 msgstr "【条件】"
 
-#: src\rush-duel.ts:130
-#: src\rush-duel.ts:152
+#: src\rush-duel.ts:119
+#: src\rush-duel.ts:140
 msgctxt "card-embed"
 msgid "[EFFECT]"
 msgstr "【效果】"
 
-#: src\rush-duel.ts:132
+#: src\rush-duel.ts:121
 msgctxt "card-embed"
 msgid "[CONTINUOUS EFFECT]"
 msgstr "【永续效果】"
 
-#: src\rush-duel.ts:134
+#: src\rush-duel.ts:123
 msgctxt "card-embed"
 msgid "[MULTI-CHOICE EFFECT]"
 msgstr "【选择效果】"
 
-#: src\locale.ts:74
+#: src\locale.ts:71
 msgctxt "command-option"
 msgid "result-language"
 msgstr "查询结果语言"
 
-#: src\locale.ts:140
+#: src\locale.ts:131
 msgctxt "command-option"
 msgid "input-language"
 msgstr "输入语言"
 
-#: src\commands\rush-duel.ts:67
-#: src\commands\rush-duel.ts:79
-#: src\locale.ts:156
-#: src\locale.ts:174
-#: src\locale.ts:190
+#: src\commands\rush-duel.ts:68
+#: src\commands\rush-duel.ts:80
+#: src\locale.ts:147
+#: src\locale.ts:165
+#: src\locale.ts:181
 msgctxt "command-option"
 msgid "input"
 msgstr "输入"
@@ -884,61 +898,59 @@ msgctxt "command-option"
 msgid "page"
 msgstr ""
 
-#: src\commands\help.ts:55
+#: src\commands\help.ts:52
 msgctxt "command-option"
 msgid "command"
 msgstr ""
 
-#: src\commands\deck.ts:87
+#: src\commands\deck.ts:126
 msgctxt "command-option"
 msgid "url"
 msgstr ""
 
-#: src\commands\deck.ts:93
+#: src\commands\deck.ts:132
 msgctxt "command-option"
 msgid "file"
 msgstr ""
 
-#: src\commands\deck.ts:99
-#: src\commands\deck.ts:105
+#: src\commands\deck.ts:138
+#: src\commands\deck.ts:144
 msgctxt "command-option"
 msgid "deck"
 msgstr ""
 
-#: src\commands\deck.ts:111
+#: src\commands\deck.ts:150
 msgctxt "command-option"
 msgid "public"
 msgstr ""
 
-#: src\commands\deck.ts:118
+#: src\commands\deck.ts:157
 msgctxt "command-option"
 msgid "stacked"
 msgstr ""
 
-#: src\locale.ts:151
+#: src\locale.ts:142
 msgctxt "command-option"
 msgid "name"
 msgstr ""
 
-#: src\locale.ts:169
+#: src\locale.ts:160
 msgctxt "command-option"
 msgid "password"
 msgstr ""
 
-#: src\commands\rush-duel.ts:72
-#: src\events\message-search.ts:301
-#: src\locale.ts:185
+#: src\commands\rush-duel.ts:73
+#: src\events\message-search.ts:293
+#: src\locale.ts:176
 msgctxt "command-option"
 msgid "konami-id"
 msgstr ""
 
-#: src\commands\locale-user.ts:36
 #: src\commands\locale.ts:30
 msgctxt "command-option"
 msgid "get"
 msgstr ""
 
-#: src\commands\locale-user.ts:41
 #: src\commands\locale.ts:35
 msgctxt "command-option"
 msgid "set"
@@ -949,64 +961,42 @@ msgctxt "command-option"
 msgid "scope"
 msgstr ""
 
-#: src\commands\locale-user.ts:46
 #: src\commands\locale.ts:48
 msgctxt "command-option"
 msgid "locale"
 msgstr ""
 
-#: src\commands\price.ts:95
+#: src\commands\price.ts:94
 msgctxt "command-option"
 msgid "vendor"
 msgstr ""
 
-#: src\commands\rush-duel.ts:62
+#: src\commands\rush-duel.ts:63
 msgctxt "command-option"
 msgid "search"
 msgstr ""
 
-#: src\commands\rush-duel.ts:84
+#: src\commands\rush-duel.ts:85
 msgctxt "command-option"
 msgid "random"
 msgstr ""
 
-#: src\commands\rush-duel.ts:89
+#: src\commands\rush-duel.ts:90
 msgctxt "command-option"
 msgid "art"
 msgstr ""
 
-#: src\commands\query.ts:35
+#: src\commands\query.ts:36
 msgctxt "command-option"
 msgid "lucene"
 msgstr ""
 
-#: src\commands\metagame.ts:209
-msgctxt "command-option"
-msgid "strategies"
-msgstr ""
-
-#: src\commands\metagame.ts:234
-#: src\commands\metagame.ts:274
-msgctxt "command-option"
-msgid "format"
-msgstr ""
-
-#: src\commands\metagame.ts:240
-msgctxt "command-option"
-msgid "cards"
-msgstr ""
-
-#: src\commands\metagame.ts:310
-msgctxt "command-option"
-msgid "date-range"
-msgstr ""
-
-#: src\locale.ts:77
+#: src\locale.ts:74
 msgctxt "command-option-description"
 msgid "The output language for the card embed, overriding other settings."
 msgstr "卡片查询结果的语言，覆盖其他设置"
 
-#: src\locale.ts:141
+#: src\locale.ts:132
 msgctxt "command-option-description"
 msgid "The language to search in, defaulting to the result language."
 msgstr "查询用的语言，默认与查询结果语言相同"
@@ -1016,37 +1006,37 @@ msgctxt "command-option-description"
 msgid "The name of the Yugipedia page you want to search for."
 msgstr "你想要查询的Yugipedia页面的名字"
 
-#: src\commands\help.ts:58
+#: src\commands\help.ts:55
 msgctxt "command-option-description"
 msgid "The name of a specific Slash Command."
 msgstr ""
 
-#: src\commands\deck.ts:90
+#: src\commands\deck.ts:129
 msgctxt "command-option-description"
 msgid "View a deck by entering a ydke:// URL."
 msgstr ""
 
-#: src\commands\deck.ts:96
+#: src\commands\deck.ts:135
 msgctxt "command-option-description"
 msgid "View a deck by uploading a .ydk file."
 msgstr ""
 
-#: src\commands\deck.ts:102
+#: src\commands\deck.ts:141
 msgctxt "command-option-description"
 msgid "The ydke:// URL of the deck you want to view."
 msgstr ""
 
-#: src\commands\deck.ts:108
+#: src\commands\deck.ts:147
 msgctxt "command-option-description"
 msgid "The .ydk file of the deck you want to view."
 msgstr ""
 
-#: src\commands\deck.ts:114
+#: src\commands\deck.ts:153
 msgctxt "command-option-description"
 msgid "Whether to display the deck details publicly in chat. This is false by default."
 msgstr ""
 
-#: src\commands\deck.ts:121
+#: src\commands\deck.ts:160
 msgctxt "command-option-description"
 msgid "Whether to display the deck sections as one stacked column. This is false (side-by-side) by default."
 msgstr ""
@@ -1056,8 +1046,8 @@ msgctxt "command-option-description"
 msgid "Display the art for the card with this name."
 msgstr ""
 
-#: src\commands\rush-duel.ts:68
-#: src\locale.ts:157
+#: src\commands\rush-duel.ts:69
+#: src\locale.ts:148
 msgctxt "command-option-description"
 msgid "Card name, fuzzy matching supported."
 msgstr ""
@@ -1067,7 +1057,7 @@ msgctxt "command-option-description"
 msgid "Display the art for the card with this password."
 msgstr ""
 
-#: src\locale.ts:176
+#: src\locale.ts:167
 msgctxt "command-option-description"
 msgid "Card password, the eight-digit number printed on the bottom left corner."
 msgstr ""
@@ -1077,8 +1067,8 @@ msgctxt "command-option-description"
 msgid "Display the art for the card with this official database ID."
 msgstr ""
 
-#: src\commands\rush-duel.ts:80
-#: src\locale.ts:191
+#: src\commands\rush-duel.ts:81
+#: src\locale.ts:182
 msgctxt "command-option-description"
 msgid "Konami's official card database identifier."
 msgstr ""
@@ -1118,22 +1108,22 @@ msgctxt "command-option-description"
 msgid "The new default language to use in this channel or server."
 msgstr ""
 
-#: src\commands\price.ts:99
+#: src\commands\price.ts:98
 msgctxt "command-option-description"
 msgid "Display the price for the card with this name."
 msgstr ""
 
-#: src\commands\price.ts:103
+#: src\commands\price.ts:102
 msgctxt "command-option-description"
 msgid "Display the price for the card with this password."
 msgstr ""
 
-#: src\commands\price.ts:106
+#: src\commands\price.ts:105
 msgctxt "command-option-description"
 msgid "Display the price for the card with this official database ID."
 msgstr ""
 
-#: src\commands\price.ts:96
+#: src\commands\price.ts:95
 msgctxt "command-option-description"
 msgid "The vendor to fetch the price data from."
 msgstr ""
@@ -1143,70 +1133,29 @@ msgctxt "command-option-description"
 msgid "The English name of the card you're looking for."
 msgstr ""
 
-#: src\commands\rush-duel.ts:63
+#: src\commands\rush-duel.ts:64
 msgctxt "command-option-description"
 msgid "Find all information for the Rush Duel card with this name."
 msgstr ""
 
-#: src\commands\rush-duel.ts:74
+#: src\commands\rush-duel.ts:75
 msgctxt "command-option-description"
 msgid "Find all information for the Rush Duel card with this official database ID."
 msgstr ""
 
-#: src\commands\rush-duel.ts:85
+#: src\commands\rush-duel.ts:86
 msgctxt "command-option-description"
 msgid "Get a random Rush Duel card."
 msgstr ""
 
-#: src\commands\rush-duel.ts:90
+#: src\commands\rush-duel.ts:91
 msgctxt "command-option-description"
 msgid "Display just the art for the Rush Duel card with this name."
 msgstr ""
 
-#: src\commands\query.ts:36
+#: src\commands\query.ts:37
 msgctxt "command-option-description"
 msgid "Lucene query on YAML Yugi"
-msgstr ""
-
-#: src\commands\locale-user.ts:37
-msgctxt "command-option-description"
-msgid "Check your user-installed Bastion's locale."
-msgstr ""
-
-#: src\commands\locale-user.ts:42
-msgctxt "command-option-description"
-msgid "Configure your user-installed Bastion's locale."
-msgstr ""
-
-#: src\commands\locale-user.ts:47
-msgctxt "command-option-description"
-msgid "The new default language to use for user-installed Bastion."
-msgstr ""
-
-#: src\commands\metagame.ts:212
-msgctxt "command-option-description"
-msgid "Show the top competitive strategies in tournaments and the Master Duel ranked ladder."
-msgstr ""
-
-#: src\commands\metagame.ts:214
-msgctxt "command-option-description"
-msgid "Show the top competitive strategies in tournaments."
-msgstr ""
-
-#: src\commands\metagame.ts:235
-#: src\commands\metagame.ts:275
-msgctxt "command-option-description"
-msgid "Game region."
-msgstr ""
-
-#: src\commands\metagame.ts:242
-msgctxt "command-option-description"
-msgid "Show the most popular cards in tournaments and the Master Duel ranked ladder."
-msgstr ""
-
-#: src\commands\metagame.ts:312
-msgctxt "command-option-description"
-msgid "Limit card usage statistics to this date range. Has no effect for Master Duel."
 msgstr ""
 
 #: src\commands\art.ts:36
@@ -1214,7 +1163,7 @@ msgctxt "command-name"
 msgid "art"
 msgstr "卡图"
 
-#: src\commands\ping.ts:25
+#: src\commands\ping.ts:23
 msgctxt "command-name"
 msgid "ping"
 msgstr ""
@@ -1229,12 +1178,12 @@ msgctxt "command-name"
 msgid "yugipedia"
 msgstr ""
 
-#: src\commands\help.ts:52
+#: src\commands\help.ts:49
 msgctxt "command-name"
 msgid "help"
 msgstr ""
 
-#: src\commands\deck.ts:80
+#: src\commands\deck.ts:119
 msgctxt "command-name"
 msgid "deck"
 msgstr ""
@@ -1249,34 +1198,24 @@ msgctxt "command-name"
 msgid "locale"
 msgstr ""
 
-#: src\commands\random.ts:43
+#: src\commands\random.ts:44
 msgctxt "command-name"
 msgid "random"
 msgstr ""
 
-#: src\commands\price.ts:90
+#: src\commands\price.ts:89
 msgctxt "command-name"
 msgid "price"
 msgstr ""
 
-#: src\commands\rush-duel.ts:57
+#: src\commands\rush-duel.ts:58
 msgctxt "command-name"
 msgid "rush-duel"
 msgstr ""
 
-#: src\commands\query.ts:29
+#: src\commands\query.ts:30
 msgctxt "command-name"
 msgid "query"
-msgstr ""
-
-#: src\commands\locale-user.ts:31
-msgctxt "command-name"
-msgid "locale-user"
-msgstr ""
-
-#: src\commands\metagame.ts:204
-msgctxt "command-name"
-msgid "metagame"
 msgstr ""
 
 #: src\commands\art.ts:37
@@ -1284,7 +1223,7 @@ msgctxt "command-description"
 msgid "Display the art for a card!"
 msgstr "显示卡片图。"
 
-#: src\commands\ping.ts:26
+#: src\commands\ping.ts:24
 msgctxt "command-description"
 msgid "Test latency to the new bot instance."
 msgstr "测试新bot实例的延迟"
@@ -1299,12 +1238,12 @@ msgctxt "command-description"
 msgid "Search the Yugipedia wiki for a page and link to it."
 msgstr "搜索Yugipedia页面与链接"
 
-#: src\commands\help.ts:53
+#: src\commands\help.ts:50
 msgctxt "command-description"
 msgid "Get help with a Slash Command."
 msgstr ""
 
-#: src\commands\deck.ts:83
+#: src\commands\deck.ts:122
 msgctxt "command-description"
 msgid "Display a deck list from ydke:// or .ydk format, exported from a number of deck building programs."
 msgstr ""
@@ -1319,34 +1258,24 @@ msgctxt "command-description"
 msgid "Check or set Bastion's locale for this channel or server."
 msgstr ""
 
-#: src\commands\random.ts:44
+#: src\commands\random.ts:45
 msgctxt "command-description"
 msgid "Get a random Yu-Gi-Oh! card."
 msgstr ""
 
-#: src\commands\price.ts:91
+#: src\commands\price.ts:90
 msgctxt "command-description"
 msgid "Display the price for a card!"
 msgstr ""
 
-#: src\commands\rush-duel.ts:58
+#: src\commands\rush-duel.ts:59
 msgctxt "command-description"
 msgid "Find information on Rush Duel cards."
 msgstr ""
 
-#: src\commands\query.ts:30
+#: src\commands\query.ts:31
 msgctxt "command-description"
 msgid "Advanced search prototype"
-msgstr ""
-
-#: src\commands\locale-user.ts:32
-msgctxt "command-description"
-msgid "Check or set user-installed Bastion's locale."
-msgstr ""
-
-#: src\commands\metagame.ts:205
-msgctxt "command-description"
-msgid "Show statistics on the current competitive state of play."
 msgstr ""
 
 #: src\commands\locale.ts:43
@@ -1359,71 +1288,7 @@ msgctxt "command-option-choice"
 msgid "server"
 msgstr ""
 
-#: src\commands\locale-user.ts:49
 #: src\commands\locale.ts:51
 msgctxt "command-option-choice"
 msgid "Discord default"
-msgstr ""
-
-#: src\commands\metagame.ts:219
-#: src\commands\metagame.ts:251
-msgctxt "command-option-choice"
-msgid "TCG"
-msgstr ""
-
-#: src\commands\metagame.ts:220
-#: src\commands\metagame.ts:255
-msgctxt "command-option-choice"
-msgid "OCG"
-msgstr ""
-
-#: src\commands\metagame.ts:221
-#: src\commands\metagame.ts:259
-msgctxt "command-option-choice"
-msgid "OCG (Asian-English)"
-msgstr ""
-
-#: src\commands\metagame.ts:228
-msgctxt "command-option-choice"
-msgid "Master Duel Diamond+ tier list"
-msgstr ""
-
-#: src\commands\metagame.ts:261
-msgctxt "command-option-choice"
-msgid "Master Duel ranked ladder"
-msgstr ""
-
-#: src\commands\metagame.ts:283
-msgctxt "command-option-choice"
-msgid "Current format"
-msgstr ""
-
-#: src\commands\metagame.ts:287
-msgctxt "command-option-choice"
-msgid "Since last Forbidden/Limited List"
-msgstr ""
-
-#: src\commands\metagame.ts:291
-msgctxt "command-option-choice"
-msgid "Last 7 days"
-msgstr ""
-
-#: src\commands\metagame.ts:295
-msgctxt "command-option-choice"
-msgid "Last 14 days"
-msgstr ""
-
-#: src\commands\metagame.ts:299
-msgctxt "command-option-choice"
-msgid "Last 30 days"
-msgstr ""
-
-#: src\commands\metagame.ts:303
-msgctxt "command-option-choice"
-msgid "Last three months"
-msgstr ""
-
-#: src\commands\metagame.ts:307
-msgctxt "command-option-choice"
-msgid "Last six months"
 msgstr ""

--- a/translations/zh-CN.po
+++ b/translations/zh-CN.po
@@ -30,13 +30,13 @@ msgstr "**种族**: ${ raceIcon } ${ localizedMonsterTypeLine }"
 #: src\card.ts:491
 #: src\rush-duel.ts:94
 #, javascript-format
-msgid "**Attribute**: ${ AttributeIcon[card.attribute] } ${ localizedAttribute }"
-msgstr "**属性**: ${ AttributeIcon[card.attribute] } ${ localizedAttribute }"
+msgid "**Attribute**: ${ attributeIcon } ${ localizedAttribute }"
+msgstr "**属性**: ${ attributeIcon } ${ localizedAttribute }"
 
 #: src\card.ts:495
 #, javascript-format
-msgid "**Rank**: ${ Icon.Rank } ${ card.rank } **ATK**: ${ card.atk } **DEF**: ${ card.def }"
-msgstr "**阶级**: ${ Icon.Rank } ${ card.rank } **攻击力**: ${ card.atk } **守备力**: ${ card.def }"
+msgid "**Rank**: ${ rankIcon } ${ card.rank } **ATK**: ${ card.atk } **DEF**: ${ card.def }"
+msgstr "**阶级**: ${ rankIcon } ${ card.rank } **攻击力**: ${ card.atk } **守备力**: ${ card.def }"
 
 #: src\card.ts:498
 #, javascript-format
@@ -46,8 +46,8 @@ msgstr "**连接数值**: ${ card.link_arrows.length } **攻击力**: ${ card.at
 #: src\card.ts:500
 #: src\rush-duel.ts:96
 #, javascript-format
-msgid "**Level**: ${ Icon.Level } ${ card.level } **ATK**: ${ card.atk } **DEF**: ${ card.def }"
-msgstr "**等级**: ${ Icon.Level } ${ card.level } **攻击力**: ${ card.atk } **守备力**: ${ card.def }"
+msgid "**Level**: ${ levelIcon } ${ card.level } **ATK**: ${ card.atk } **DEF**: ${ card.def }"
+msgstr "**等级**: ${ levelIcon } ${ card.level } **攻击力**: ${ card.atk } **守备力**: ${ card.def }"
 
 #: src\card.ts:507
 #, javascript-format
@@ -453,8 +453,8 @@ msgstr ""
 
 #: src\card.ts:462
 #, javascript-format
-msgid "**Master Duel rarity**: ${ rarity_icon } ${ localized_rarity }"
-msgstr "**稀有度 (Master Duel)**: ${ rarity_icon } ${ localized_rarity }"
+msgid "**Master Duel rarity**: ${ rarityIcon } ${ localizedRarity }"
+msgstr "**稀有度 (Master Duel)**: ${ rarityIcon } ${ localizedRarity }"
 
 #: src\rush-duel.ts:205
 #, javascript-format

--- a/translations/zh-CN.po
+++ b/translations/zh-CN.po
@@ -6,50 +6,50 @@ msgstr ""
 "MIME-Version: 1.0\n"
 "Content-Transfer-Encoding: 8bit\n"
 
-#: src\card.ts:416
-#: src\rush-duel.ts:39
+#: src\card.ts:412
+#: src\rush-duel.ts:48
 msgid "🔗 Links"
 msgstr "🔗 链接"
 
-#: src\card.ts:417
+#: src\card.ts:413
 #, javascript-format
 msgid "[Official Konami DB](${ official }) | [OCG Rulings](${ rulings }) | [Yugipedia](${ yugipedia }) | [YGOPRODECK](${ ygoprodeck })"
 msgstr "[K社官方数据库](${ official }) | [事务局FAQ](${ rulings }) | [Yugipedia](${ yugipedia }) | [YGOPRODECK](${ ygoprodeck })"
 
-#: src\card.ts:420
+#: src\card.ts:416
 #, javascript-format
 msgid "[Yugipedia](${ yugipedia }) | [YGOPRODECK](${ ygoprodeck })"
 msgstr "[Yugipedia](${ yugipedia }) | [YGOPRODECK](${ ygoprodeck })"
 
-#: src\card.ts:489
-#: src\rush-duel.ts:92
+#: src\card.ts:490
+#: src\rush-duel.ts:103
 #, javascript-format
 msgid "**Type**: ${ raceIcon } ${ localizedMonsterTypeLine }"
 msgstr "**种族**: ${ raceIcon } ${ localizedMonsterTypeLine }"
 
-#: src\card.ts:491
-#: src\rush-duel.ts:94
+#: src\card.ts:492
+#: src\rush-duel.ts:105
 #, javascript-format
 msgid "**Attribute**: ${ attributeIcon } ${ localizedAttribute }"
 msgstr "**属性**: ${ attributeIcon } ${ localizedAttribute }"
 
-#: src\card.ts:495
+#: src\card.ts:497
 #, javascript-format
 msgid "**Rank**: ${ rankIcon } ${ card.rank } **ATK**: ${ card.atk } **DEF**: ${ card.def }"
 msgstr "**阶级**: ${ rankIcon } ${ card.rank } **攻击力**: ${ card.atk } **守备力**: ${ card.def }"
 
-#: src\card.ts:498
+#: src\card.ts:500
 #, javascript-format
 msgid "**Link Rating**: ${ card.link_arrows.length } **ATK**: ${ card.atk } **Link Arrows**: ${ arrows }"
 msgstr "**连接数值**: ${ card.link_arrows.length } **攻击力**: ${ card.atk } **连接标记**: ${ arrows }"
 
-#: src\card.ts:500
-#: src\rush-duel.ts:96
+#: src\card.ts:503
+#: src\rush-duel.ts:107
 #, javascript-format
 msgid "**Level**: ${ levelIcon } ${ card.level } **ATK**: ${ card.atk } **DEF**: ${ card.def }"
 msgstr "**等级**: ${ levelIcon } ${ card.level } **攻击力**: ${ card.atk } **守备力**: ${ card.def }"
 
-#: src\card.ts:507
+#: src\card.ts:511
 #, javascript-format
 msgid "**Pendulum Scale**: ${ formattedScale }"
 msgstr "**灵摆刻度**: ${ formattedScale }"
@@ -70,7 +70,7 @@ msgid "Password: ${ card.password } | Not yet released"
 msgstr "卡片密码: ${ card.password } | 未发行"
 
 #: src\card.ts:351
-#: src\rush-duel.ts:146
+#: src\rush-duel.ts:158
 msgid "Not yet released"
 msgstr "未发行"
 
@@ -79,64 +79,64 @@ msgstr "未发行"
 msgid "Placeholder ID: ${ card.fake_password }"
 msgstr "假卡密: ${ card.fake_password }"
 
-#: src\utils.ts:41
+#: src\utils.ts:44
 msgid "🛠️ This command is in development."
 msgstr "🛠️ 这个指令正在开发中"
 
-#: src\utils.ts:42
+#: src\utils.ts:45
 msgid "📨 Please send feedback to [our issue tracker](https://github.com/DawnbrandBots/bastion-bot) or the [support server](https://discord.gg/4aFuPyuE96)!"
 msgstr "📨 如有意见或建议请反馈至[GitHub issue](https://github.com/DawnbrandBots/bastion-bot)或者[Discord服务器](https://discord.gg/4aFuPyuE96)!"
 
-#: src\utils.ts:53
+#: src\utils.ts:56
 msgid "Please consider supporting us!"
 msgstr "请考虑捐助我们！"
 
-#: src\utils.ts:54
+#: src\utils.ts:57
 msgid "Help keep Bastion online!"
 msgstr "帮帮Bastion吧，宝宝快饿死了"
 
-#: src\utils.ts:55
+#: src\utils.ts:58
 msgid "Please help keep Bastion online!"
 msgstr "请帮帮Bastion吧，宝宝真的快饿死了"
 
-#: src\utils.ts:56
+#: src\utils.ts:59
 msgid "Was Bastion helpful? Consider supporting us!"
 msgstr "Bastion有用么？请考虑捐助我们！"
 
-#: src\utils.ts:57
+#: src\utils.ts:60
 msgid "Was Bastion helpful? We need your support!"
 msgstr "Bastion有用么？我们需要你的支持！"
 
-#: src\utils.ts:58
+#: src\utils.ts:61
 msgid "Did you find Bastion useful? Consider supporting us!"
 msgstr "你觉得Bastion好用么？请考虑捐助我们！"
 
-#: src\utils.ts:59
+#: src\utils.ts:62
 msgid "Did you find Bastion useful? Help keep it online!"
 msgstr "你觉得Bastion好用么？那帮帮TA吧，孩子快饿死了"
 
-#: src\utils.ts:60
+#: src\utils.ts:63
 msgid "Did you find Bastion useful? We need your support!"
 msgstr "你觉得Bastion好用么？我们需要你的支持！"
 
-#: src\utils.ts:61
+#: src\utils.ts:64
 msgid "Enjoy Bastion? Help keep it online!"
 msgstr "你觉得Bastion好用么？那帮帮TA吧，孩子快饿死了"
 
-#: src\utils.ts:62
+#: src\utils.ts:65
 msgid "Enjoy Bastion? Consider supporting us!"
 msgstr "觉得Bastion怎么样？请考虑捐助我们！"
 
-#: src\utils.ts:63
+#: src\utils.ts:66
 msgid "Found what you were looking for? Consider supporting us!"
 msgstr "找到你要的东西了吗？请考虑捐助我们！"
 
 #: src\commands\art.ts:63
-#: src\commands\price.ts:131
-#: src\commands\rush-duel.ts:172
-#: src\commands\rush-duel.ts:203
+#: src\commands\price.ts:132
+#: src\commands\rush-duel.ts:171
+#: src\commands\rush-duel.ts:202
 #: src\commands\search.ts:64
-#: src\events\message-search.ts:258
+#: src\events\message-search.ts:265
 #, javascript-format
 msgid "Could not find a card matching `${ input }`!"
 msgstr "查无此卡：`${ input }`"
@@ -163,11 +163,7 @@ msgstr ""
 msgid "Discord Community locale for this server: ${ interaction.guildLocale }"
 msgstr ""
 
-#: src\commands\locale.ts:89
-#, javascript-format
-msgid "Locale override for this direct message: ${ override }"
-msgstr ""
-
+#: src\commands\locale-user.ts:76
 #: src\commands\locale.ts:92
 #, javascript-format
 msgid "Your Discord locale: ${ interaction.locale }"
@@ -205,18 +201,8 @@ msgstr ""
 msgid "Sorry, you must have the Manage Server permission to do this. If you think this is an error, contact your server admin or report a bug."
 msgstr ""
 
-#: src\commands\locale.ts:146
-#, javascript-format
-msgid "Locale for this direct message overridden with ${ locale }. Your Discord setting is ${ interaction.locale }."
-msgstr ""
-
-#: src\commands\locale.ts:150
-#, javascript-format
-msgid "Locale for this direct message reset to Discord default. Your Discord setting is ${ interaction.locale }."
-msgstr ""
-
-#: src\commands\ping.ts:40
-#: src\events\message-ping.ts:112
+#: src\commands\ping.ts:42
+#: src\events\message-ping.ts:110
 #, javascript-format
 msgid "Total latency: ${ latency } ms"
 msgstr "延迟${ latency }ms"
@@ -226,148 +212,131 @@ msgstr "延迟${ latency }ms"
 msgid "Could not find a Yugipedia page named `${ page }`."
 msgstr "Yugipedia上找不到`${ page }`"
 
-#: src\commands\deck.ts:244
+#: src\commands\deck.ts:205
 #, javascript-format
 msgid "${ counts.Monster } Monster"
 msgid_plural "${ counts.Monster } Monsters"
 msgstr[0] "${ counts.Monster }张怪兽卡"
 
-#: src\commands\deck.ts:247
+#: src\commands\deck.ts:208
 #, javascript-format
 msgid "${ counts.Spell } Spell"
 msgid_plural "${ counts.Spell } Spells"
 msgstr[0] "${ counts.Spell }张魔法卡"
 
-#: src\commands\deck.ts:250
+#: src\commands\deck.ts:211
 #, javascript-format
 msgid "${ counts.Trap } Trap"
 msgid_plural "${ counts.Trap } Traps"
 msgstr[0] "${ counts.Trap }张陷阱卡"
 
-#: src\commands\deck.ts:278
+#: src\commands\deck.ts:239
 msgid "Your Deck"
 msgstr "你的卡组"
 
-#: src\commands\deck.ts:283
+#: src\commands\deck.ts:244
 #, javascript-format
 msgid "Main Deck (${ deck.main.length } card — ${ countDetail })"
 msgid_plural "Main Deck (${ deck.main.length } cards — ${ countDetail })"
 msgstr[0] "牌组（${ deck.main.length }张 — ${ countDetail }）"
 
-#: src\commands\deck.ts:297
+#: src\commands\deck.ts:258
 #, javascript-format
 msgid "Extra Deck (${ deck.extra.length } card — ${ countDetail })"
 msgid_plural "Extra Deck (${ deck.extra.length } cards — ${ countDetail })"
 msgstr[0] "额外卡组（${ deck.extra.length }张 — ${ countDetail }）"
 
-#: src\commands\deck.ts:311
+#: src\commands\deck.ts:272
 #, javascript-format
 msgid "Side Deck (${ deck.side.length } card — ${ countDetail })"
 msgid_plural "Side Deck (${ deck.side.length } cards — ${ countDetail })"
 msgstr[0] "备牌（${ deck.side.length }张 — ${ countDetail }）"
 
-#: src\commands\deck.ts:290
+#: src\commands\deck.ts:251
 msgid "Main Deck (continued)"
 msgstr "牌组（续）"
 
-#: src\commands\deck.ts:304
+#: src\commands\deck.ts:265
 msgid "Extra Deck (continued)"
 msgstr "额外卡组（续）"
 
-#: src\commands\deck.ts:318
+#: src\commands\deck.ts:279
 msgid "Side Deck (continued)"
 msgstr "备牌（续）"
 
-#: src\commands\deck.ts:407
+#: src\commands\deck.ts:347
 msgid "Error: Your deck is empty."
 msgstr "错误：卡组是空的。"
 
-#: src\commands\ping.ts:36
-#: src\events\message-ping.ts:47
+#: src\commands\ping.ts:38
+#: src\events\message-ping.ts:45
 #, javascript-format
 msgid "Average WebSocket ping (new instance): ${ ping } ms"
 msgstr ""
 
-#: src\events\message-ping.ts:49
+#: src\events\message-ping.ts:47
 msgid "Free and open source _Yu-Gi-Oh!_ bot"
 msgstr "自由开源游戏王聊天机器人"
 
-#: src\events\message-ping.ts:72
+#: src\events\message-ping.ts:70
 #, javascript-format
 msgid "Revision: ${ process.env.BOT_REVISION }."
 msgstr "修订：${ process.env.BOT_REVISION }"
 
-#: src\commands\deck.ts:328
+#: src\commands\deck.ts:289
 msgid ".ydk files must have the .ydk extension!"
 msgstr ""
 
-#: src\commands\deck.ts:331
+#: src\commands\deck.ts:292
 msgid ".ydk files should not be larger than 1 KB!"
 msgstr ""
 
-#: src\commands\deck.ts:321
+#: src\commands\deck.ts:282
 msgid "ydke URL"
 msgstr ""
 
 #: src\card.ts:455
-#: src\rush-duel.ts:61
+#: src\rush-duel.ts:75
 #. Forbidden/Limited Lists or Limit Regulations in the OCG
 #, javascript-format
 msgid "**Limit**: ${ limitRegulationDisplay }"
 msgstr "**限制**: ${ limitRegulationDisplay }"
 
-#: src\commands\price.ts:69
+#: src\commands\price.ts:70
 msgid "TCGPlayer"
 msgstr ""
 
-#: src\commands\price.ts:70
+#: src\commands\price.ts:71
 msgid "Cardmarket"
 msgstr ""
 
-#: src\commands\price.ts:147
+#: src\commands\price.ts:148
 msgid "No market price"
 msgstr ""
 
-#: src\commands\price.ts:155
+#: src\commands\price.ts:156
 #, javascript-format
 msgid "Prices for ${ card.name[resultLanguage] } - ${ vendorName }"
 msgstr ""
 
-#: src\commands\price.ts:169
+#: src\commands\price.ts:170
 #, javascript-format
 msgid "Could not find prices for `${ name }`!"
 msgstr ""
 
-#: src\commands\deck.ts:425
-#. prepare interaction button for FTP upload
+#: src\commands\deck.ts:363
 msgid "Upload to YGOPRODECK"
 msgstr "上传至YGOPRODECK"
 
-#: src\commands\deck.ts:483
-#. disable original button
-#. prepare row to disable button on original message
-msgid "Upload Complete"
-msgstr "上传成功"
-
-#: src\commands\deck.ts:470
-msgid "Deck upload failed!"
-msgstr "上传失败"
-
-#: src\commands\deck.ts:491
-#. reply in affirmation
-#, javascript-format
-msgid "Deck successfully uploaded to <${ url }>!"
-msgstr "卡组成功上传到<${ url }>!"
-
-#: src\events\message-search.ts:264
+#: src\events\message-search.ts:271
 msgid "💬 Translations missing?"
 msgstr "💬缺少翻译？"
 
-#: src\events\message-search.ts:265
+#: src\events\message-search.ts:272
 msgid "Help translate Bastion at the links above."
 msgstr "在以上的网址帮忙翻译Bastion"
 
-#: src\events\message-ping.ts:50
+#: src\events\message-ping.ts:48
 msgid ""
 "❓ Help documentation on [GitHub](https://github.com/DawnbrandBots/bastion-bot), or use `.commands` and `.help`.\n"
 "🟢 Licence: [GNU AGPL 3.0+](https://choosealicense.com/licenses/agpl-3.0/).\n"
@@ -383,27 +352,27 @@ msgid ""
 "💬 Translations missing? Help translate Bastion on [GitHub](https://github.com/DawnbrandBots/bastion-bot)."
 msgstr ""
 
-#: src\events\message-search.ts:256
-#: src\events\message-search.ts:294
+#: src\events\message-search.ts:263
+#: src\events\message-search.ts:302
 #, javascript-format
 msgid "Search type: ${ localisedType }"
 msgstr "搜索类型：${ localisedType }"
 
-#: src\events\message-search.ts:236
+#: src\events\message-search.ts:242
 #, javascript-format
 msgid "Search language: **${ localisedInputLanguage }** (${ inputLanguage }). Check defaults with </locale get:${ id }> and configure with </locale set:${ id }>"
 msgstr ""
 
-#: src\events\message-ping.ts:95
+#: src\events\message-ping.ts:93
 msgid "⚠️ You pinged me, but I am missing permissions in the channel!"
 msgstr ""
 
-#: src\events\message-ping.ts:98
-#: src\events\message-search.ts:332
+#: src\events\message-ping.ts:96
+#: src\events\message-search.ts:340
 msgid "Please have a server administrator [fix this](https://github.com/DawnbrandBots/bastion-bot#discord-permissions)."
 msgstr ""
 
-#: src\events\message-search.ts:329
+#: src\events\message-search.ts:337
 msgid "⚠️ I am missing permissions in the channel!"
 msgstr ""
 
@@ -422,32 +391,31 @@ msgstr ""
 msgid "Something went wrong searching Yugipedia for `${ page }`."
 msgstr ""
 
-#: src\rush-duel.ts:40
+#: src\rush-duel.ts:49
 #, javascript-format
 msgid "[Official Konami DB](${ official }) | [Rulings (Japanese)](${ rulings }) | [Yugipedia](${ yugipedia }) | [RushCard](${ rushcard })"
 msgstr "[K社官方数据库](${ official }) | [事务局FAQ](${ rulings }) | [Yugipedia](${ yugipedia }) | [RushCard](${ rushcard })"
 
-#: src\rush-duel.ts:43
+#: src\rush-duel.ts:52
 #, javascript-format
 msgid "[Yugipedia](${ yugipedia }) | [RushCard](${ rushcard })"
 msgstr "[Yugipedia](${ yugipedia }) | [RushCard](${ rushcard })"
 
-#: src\rush-duel.ts:57
+#: src\rush-duel.ts:71
 msgid "__**LEGEND**__"
 msgstr ""
 
-#: src\rush-duel.ts:99
+#: src\rush-duel.ts:110
 #, javascript-format
 msgid "**MAXIMUM ATK**: ${ card.maximum_atk }"
 msgstr ""
 
-#: src\rush-duel.ts:146
+#: src\rush-duel.ts:158
 #, javascript-format
 msgid "Konami ID #${ card.konami_id }"
 msgstr "官方编号${ card.konami_id }"
 
 #: src\art.ts:129
-#: src\commands\deck.ts:451
 msgid "Buttons can only be used by the user who called Bastion."
 msgstr ""
 
@@ -456,14 +424,32 @@ msgstr ""
 msgid "**Master Duel rarity**: ${ rarityIcon } ${ localizedRarity }"
 msgstr "**稀有度 (Master Duel)**: ${ rarityIcon } ${ localizedRarity }"
 
-#: src\rush-duel.ts:205
+#: src\rush-duel.ts:217
 #, javascript-format
 msgid "Using ${ searchTrigger }, you can search for Rush Duel cards directly in messages without autocomplete"
 msgstr ""
 
-#: src\events\message-search.ts:296
+#: src\events\message-search.ts:304
 #, javascript-format
 msgid "Could not find a Rush Duel card matching `${ input }`!"
+msgstr ""
+
+#: src\commands\locale-user.ts:73
+#: src\commands\locale.ts:89
+#, javascript-format
+msgid "Locale override for your direct messages: ${ override }"
+msgstr ""
+
+#: src\commands\locale-user.ts:83
+#: src\commands\locale.ts:146
+#, javascript-format
+msgid "Locale for your direct messages overridden with ${ locale }. Your Discord setting is ${ interaction.locale }."
+msgstr ""
+
+#: src\commands\locale-user.ts:87
+#: src\commands\locale.ts:150
+#, javascript-format
+msgid "Locale for your direct messages reset to Discord default. Your Discord setting is ${ interaction.locale }."
 msgstr ""
 
 #: src\card.ts:40
@@ -830,60 +816,60 @@ msgctxt "master-duel-rarity"
 msgid "Ultra Rare (UR)"
 msgstr "金闪稀有（ＵＲ）"
 
-#: src\card.ts:513
-#: src\card.ts:524
-#: src\rush-duel.ts:127
+#: src\card.ts:517
+#: src\card.ts:528
+#: src\rush-duel.ts:138
 msgctxt "card-embed"
 msgid "Card Text"
 msgstr "卡片文本"
 
-#: src\card.ts:518
+#: src\card.ts:522
 msgctxt "card-embed"
 msgid "Pendulum Effect"
 msgstr "灵摆效果"
 
-#: src\card.ts:539
+#: src\card.ts:545
 msgctxt "card-embed"
 msgid "Card Effect"
 msgstr "卡片效果"
 
-#: src\rush-duel.ts:118
-#: src\rush-duel.ts:139
+#: src\rush-duel.ts:129
+#: src\rush-duel.ts:151
 msgctxt "card-embed"
 msgid "[REQUIREMENT]"
 msgstr "【条件】"
 
-#: src\rush-duel.ts:119
-#: src\rush-duel.ts:140
+#: src\rush-duel.ts:130
+#: src\rush-duel.ts:152
 msgctxt "card-embed"
 msgid "[EFFECT]"
 msgstr "【效果】"
 
-#: src\rush-duel.ts:121
+#: src\rush-duel.ts:132
 msgctxt "card-embed"
 msgid "[CONTINUOUS EFFECT]"
 msgstr "【永续效果】"
 
-#: src\rush-duel.ts:123
+#: src\rush-duel.ts:134
 msgctxt "card-embed"
 msgid "[MULTI-CHOICE EFFECT]"
 msgstr "【选择效果】"
 
-#: src\locale.ts:71
+#: src\locale.ts:74
 msgctxt "command-option"
 msgid "result-language"
 msgstr "查询结果语言"
 
-#: src\locale.ts:131
+#: src\locale.ts:140
 msgctxt "command-option"
 msgid "input-language"
 msgstr "输入语言"
 
-#: src\commands\rush-duel.ts:68
-#: src\commands\rush-duel.ts:80
-#: src\locale.ts:147
-#: src\locale.ts:165
-#: src\locale.ts:181
+#: src\commands\rush-duel.ts:67
+#: src\commands\rush-duel.ts:79
+#: src\locale.ts:156
+#: src\locale.ts:174
+#: src\locale.ts:190
 msgctxt "command-option"
 msgid "input"
 msgstr "输入"
@@ -898,59 +884,61 @@ msgctxt "command-option"
 msgid "page"
 msgstr ""
 
-#: src\commands\help.ts:52
+#: src\commands\help.ts:55
 msgctxt "command-option"
 msgid "command"
 msgstr ""
 
-#: src\commands\deck.ts:126
+#: src\commands\deck.ts:87
 msgctxt "command-option"
 msgid "url"
 msgstr ""
 
-#: src\commands\deck.ts:132
+#: src\commands\deck.ts:93
 msgctxt "command-option"
 msgid "file"
 msgstr ""
 
-#: src\commands\deck.ts:138
-#: src\commands\deck.ts:144
+#: src\commands\deck.ts:99
+#: src\commands\deck.ts:105
 msgctxt "command-option"
 msgid "deck"
 msgstr ""
 
-#: src\commands\deck.ts:150
+#: src\commands\deck.ts:111
 msgctxt "command-option"
 msgid "public"
 msgstr ""
 
-#: src\commands\deck.ts:157
+#: src\commands\deck.ts:118
 msgctxt "command-option"
 msgid "stacked"
 msgstr ""
 
-#: src\locale.ts:142
+#: src\locale.ts:151
 msgctxt "command-option"
 msgid "name"
 msgstr ""
 
-#: src\locale.ts:160
+#: src\locale.ts:169
 msgctxt "command-option"
 msgid "password"
 msgstr ""
 
-#: src\commands\rush-duel.ts:73
-#: src\events\message-search.ts:293
-#: src\locale.ts:176
+#: src\commands\rush-duel.ts:72
+#: src\events\message-search.ts:301
+#: src\locale.ts:185
 msgctxt "command-option"
 msgid "konami-id"
 msgstr ""
 
+#: src\commands\locale-user.ts:36
 #: src\commands\locale.ts:30
 msgctxt "command-option"
 msgid "get"
 msgstr ""
 
+#: src\commands\locale-user.ts:41
 #: src\commands\locale.ts:35
 msgctxt "command-option"
 msgid "set"
@@ -961,42 +949,64 @@ msgctxt "command-option"
 msgid "scope"
 msgstr ""
 
+#: src\commands\locale-user.ts:46
 #: src\commands\locale.ts:48
 msgctxt "command-option"
 msgid "locale"
 msgstr ""
 
-#: src\commands\price.ts:94
+#: src\commands\price.ts:95
 msgctxt "command-option"
 msgid "vendor"
 msgstr ""
 
-#: src\commands\rush-duel.ts:63
+#: src\commands\rush-duel.ts:62
 msgctxt "command-option"
 msgid "search"
 msgstr ""
 
-#: src\commands\rush-duel.ts:85
+#: src\commands\rush-duel.ts:84
 msgctxt "command-option"
 msgid "random"
 msgstr ""
 
-#: src\commands\rush-duel.ts:90
+#: src\commands\rush-duel.ts:89
 msgctxt "command-option"
 msgid "art"
 msgstr ""
 
-#: src\commands\query.ts:36
+#: src\commands\query.ts:35
 msgctxt "command-option"
 msgid "lucene"
 msgstr ""
 
-#: src\locale.ts:74
+#: src\commands\metagame.ts:209
+msgctxt "command-option"
+msgid "strategies"
+msgstr ""
+
+#: src\commands\metagame.ts:234
+#: src\commands\metagame.ts:274
+msgctxt "command-option"
+msgid "format"
+msgstr ""
+
+#: src\commands\metagame.ts:240
+msgctxt "command-option"
+msgid "cards"
+msgstr ""
+
+#: src\commands\metagame.ts:310
+msgctxt "command-option"
+msgid "date-range"
+msgstr ""
+
+#: src\locale.ts:77
 msgctxt "command-option-description"
 msgid "The output language for the card embed, overriding other settings."
 msgstr "卡片查询结果的语言，覆盖其他设置"
 
-#: src\locale.ts:132
+#: src\locale.ts:141
 msgctxt "command-option-description"
 msgid "The language to search in, defaulting to the result language."
 msgstr "查询用的语言，默认与查询结果语言相同"
@@ -1006,37 +1016,37 @@ msgctxt "command-option-description"
 msgid "The name of the Yugipedia page you want to search for."
 msgstr "你想要查询的Yugipedia页面的名字"
 
-#: src\commands\help.ts:55
+#: src\commands\help.ts:58
 msgctxt "command-option-description"
 msgid "The name of a specific Slash Command."
 msgstr ""
 
-#: src\commands\deck.ts:129
+#: src\commands\deck.ts:90
 msgctxt "command-option-description"
 msgid "View a deck by entering a ydke:// URL."
 msgstr ""
 
-#: src\commands\deck.ts:135
+#: src\commands\deck.ts:96
 msgctxt "command-option-description"
 msgid "View a deck by uploading a .ydk file."
 msgstr ""
 
-#: src\commands\deck.ts:141
+#: src\commands\deck.ts:102
 msgctxt "command-option-description"
 msgid "The ydke:// URL of the deck you want to view."
 msgstr ""
 
-#: src\commands\deck.ts:147
+#: src\commands\deck.ts:108
 msgctxt "command-option-description"
 msgid "The .ydk file of the deck you want to view."
 msgstr ""
 
-#: src\commands\deck.ts:153
+#: src\commands\deck.ts:114
 msgctxt "command-option-description"
 msgid "Whether to display the deck details publicly in chat. This is false by default."
 msgstr ""
 
-#: src\commands\deck.ts:160
+#: src\commands\deck.ts:121
 msgctxt "command-option-description"
 msgid "Whether to display the deck sections as one stacked column. This is false (side-by-side) by default."
 msgstr ""
@@ -1046,8 +1056,8 @@ msgctxt "command-option-description"
 msgid "Display the art for the card with this name."
 msgstr ""
 
-#: src\commands\rush-duel.ts:69
-#: src\locale.ts:148
+#: src\commands\rush-duel.ts:68
+#: src\locale.ts:157
 msgctxt "command-option-description"
 msgid "Card name, fuzzy matching supported."
 msgstr ""
@@ -1057,7 +1067,7 @@ msgctxt "command-option-description"
 msgid "Display the art for the card with this password."
 msgstr ""
 
-#: src\locale.ts:167
+#: src\locale.ts:176
 msgctxt "command-option-description"
 msgid "Card password, the eight-digit number printed on the bottom left corner."
 msgstr ""
@@ -1067,8 +1077,8 @@ msgctxt "command-option-description"
 msgid "Display the art for the card with this official database ID."
 msgstr ""
 
-#: src\commands\rush-duel.ts:81
-#: src\locale.ts:182
+#: src\commands\rush-duel.ts:80
+#: src\locale.ts:191
 msgctxt "command-option-description"
 msgid "Konami's official card database identifier."
 msgstr ""
@@ -1108,22 +1118,22 @@ msgctxt "command-option-description"
 msgid "The new default language to use in this channel or server."
 msgstr ""
 
-#: src\commands\price.ts:98
+#: src\commands\price.ts:99
 msgctxt "command-option-description"
 msgid "Display the price for the card with this name."
 msgstr ""
 
-#: src\commands\price.ts:102
+#: src\commands\price.ts:103
 msgctxt "command-option-description"
 msgid "Display the price for the card with this password."
 msgstr ""
 
-#: src\commands\price.ts:105
+#: src\commands\price.ts:106
 msgctxt "command-option-description"
 msgid "Display the price for the card with this official database ID."
 msgstr ""
 
-#: src\commands\price.ts:95
+#: src\commands\price.ts:96
 msgctxt "command-option-description"
 msgid "The vendor to fetch the price data from."
 msgstr ""
@@ -1133,29 +1143,70 @@ msgctxt "command-option-description"
 msgid "The English name of the card you're looking for."
 msgstr ""
 
-#: src\commands\rush-duel.ts:64
+#: src\commands\rush-duel.ts:63
 msgctxt "command-option-description"
 msgid "Find all information for the Rush Duel card with this name."
 msgstr ""
 
-#: src\commands\rush-duel.ts:75
+#: src\commands\rush-duel.ts:74
 msgctxt "command-option-description"
 msgid "Find all information for the Rush Duel card with this official database ID."
 msgstr ""
 
-#: src\commands\rush-duel.ts:86
+#: src\commands\rush-duel.ts:85
 msgctxt "command-option-description"
 msgid "Get a random Rush Duel card."
 msgstr ""
 
-#: src\commands\rush-duel.ts:91
+#: src\commands\rush-duel.ts:90
 msgctxt "command-option-description"
 msgid "Display just the art for the Rush Duel card with this name."
 msgstr ""
 
-#: src\commands\query.ts:37
+#: src\commands\query.ts:36
 msgctxt "command-option-description"
 msgid "Lucene query on YAML Yugi"
+msgstr ""
+
+#: src\commands\locale-user.ts:37
+msgctxt "command-option-description"
+msgid "Check your user-installed Bastion's locale."
+msgstr ""
+
+#: src\commands\locale-user.ts:42
+msgctxt "command-option-description"
+msgid "Configure your user-installed Bastion's locale."
+msgstr ""
+
+#: src\commands\locale-user.ts:47
+msgctxt "command-option-description"
+msgid "The new default language to use for user-installed Bastion."
+msgstr ""
+
+#: src\commands\metagame.ts:212
+msgctxt "command-option-description"
+msgid "Show the top competitive strategies in tournaments and the Master Duel ranked ladder."
+msgstr ""
+
+#: src\commands\metagame.ts:214
+msgctxt "command-option-description"
+msgid "Show the top competitive strategies in tournaments."
+msgstr ""
+
+#: src\commands\metagame.ts:235
+#: src\commands\metagame.ts:275
+msgctxt "command-option-description"
+msgid "Game region."
+msgstr ""
+
+#: src\commands\metagame.ts:242
+msgctxt "command-option-description"
+msgid "Show the most popular cards in tournaments and the Master Duel ranked ladder."
+msgstr ""
+
+#: src\commands\metagame.ts:312
+msgctxt "command-option-description"
+msgid "Limit card usage statistics to this date range. Has no effect for Master Duel."
 msgstr ""
 
 #: src\commands\art.ts:36
@@ -1163,7 +1214,7 @@ msgctxt "command-name"
 msgid "art"
 msgstr "卡图"
 
-#: src\commands\ping.ts:23
+#: src\commands\ping.ts:25
 msgctxt "command-name"
 msgid "ping"
 msgstr ""
@@ -1178,12 +1229,12 @@ msgctxt "command-name"
 msgid "yugipedia"
 msgstr ""
 
-#: src\commands\help.ts:49
+#: src\commands\help.ts:52
 msgctxt "command-name"
 msgid "help"
 msgstr ""
 
-#: src\commands\deck.ts:119
+#: src\commands\deck.ts:80
 msgctxt "command-name"
 msgid "deck"
 msgstr ""
@@ -1198,24 +1249,34 @@ msgctxt "command-name"
 msgid "locale"
 msgstr ""
 
-#: src\commands\random.ts:44
+#: src\commands\random.ts:43
 msgctxt "command-name"
 msgid "random"
 msgstr ""
 
-#: src\commands\price.ts:89
+#: src\commands\price.ts:90
 msgctxt "command-name"
 msgid "price"
 msgstr ""
 
-#: src\commands\rush-duel.ts:58
+#: src\commands\rush-duel.ts:57
 msgctxt "command-name"
 msgid "rush-duel"
 msgstr ""
 
-#: src\commands\query.ts:30
+#: src\commands\query.ts:29
 msgctxt "command-name"
 msgid "query"
+msgstr ""
+
+#: src\commands\locale-user.ts:31
+msgctxt "command-name"
+msgid "locale-user"
+msgstr ""
+
+#: src\commands\metagame.ts:204
+msgctxt "command-name"
+msgid "metagame"
 msgstr ""
 
 #: src\commands\art.ts:37
@@ -1223,7 +1284,7 @@ msgctxt "command-description"
 msgid "Display the art for a card!"
 msgstr "显示卡片图。"
 
-#: src\commands\ping.ts:24
+#: src\commands\ping.ts:26
 msgctxt "command-description"
 msgid "Test latency to the new bot instance."
 msgstr "测试新bot实例的延迟"
@@ -1238,12 +1299,12 @@ msgctxt "command-description"
 msgid "Search the Yugipedia wiki for a page and link to it."
 msgstr "搜索Yugipedia页面与链接"
 
-#: src\commands\help.ts:50
+#: src\commands\help.ts:53
 msgctxt "command-description"
 msgid "Get help with a Slash Command."
 msgstr ""
 
-#: src\commands\deck.ts:122
+#: src\commands\deck.ts:83
 msgctxt "command-description"
 msgid "Display a deck list from ydke:// or .ydk format, exported from a number of deck building programs."
 msgstr ""
@@ -1258,24 +1319,34 @@ msgctxt "command-description"
 msgid "Check or set Bastion's locale for this channel or server."
 msgstr ""
 
-#: src\commands\random.ts:45
+#: src\commands\random.ts:44
 msgctxt "command-description"
 msgid "Get a random Yu-Gi-Oh! card."
 msgstr ""
 
-#: src\commands\price.ts:90
+#: src\commands\price.ts:91
 msgctxt "command-description"
 msgid "Display the price for a card!"
 msgstr ""
 
-#: src\commands\rush-duel.ts:59
+#: src\commands\rush-duel.ts:58
 msgctxt "command-description"
 msgid "Find information on Rush Duel cards."
 msgstr ""
 
-#: src\commands\query.ts:31
+#: src\commands\query.ts:30
 msgctxt "command-description"
 msgid "Advanced search prototype"
+msgstr ""
+
+#: src\commands\locale-user.ts:32
+msgctxt "command-description"
+msgid "Check or set user-installed Bastion's locale."
+msgstr ""
+
+#: src\commands\metagame.ts:205
+msgctxt "command-description"
+msgid "Show statistics on the current competitive state of play."
 msgstr ""
 
 #: src\commands\locale.ts:43
@@ -1288,7 +1359,71 @@ msgctxt "command-option-choice"
 msgid "server"
 msgstr ""
 
+#: src\commands\locale-user.ts:49
 #: src\commands\locale.ts:51
 msgctxt "command-option-choice"
 msgid "Discord default"
+msgstr ""
+
+#: src\commands\metagame.ts:219
+#: src\commands\metagame.ts:251
+msgctxt "command-option-choice"
+msgid "TCG"
+msgstr ""
+
+#: src\commands\metagame.ts:220
+#: src\commands\metagame.ts:255
+msgctxt "command-option-choice"
+msgid "OCG"
+msgstr ""
+
+#: src\commands\metagame.ts:221
+#: src\commands\metagame.ts:259
+msgctxt "command-option-choice"
+msgid "OCG (Asian-English)"
+msgstr ""
+
+#: src\commands\metagame.ts:228
+msgctxt "command-option-choice"
+msgid "Master Duel Diamond+ tier list"
+msgstr ""
+
+#: src\commands\metagame.ts:261
+msgctxt "command-option-choice"
+msgid "Master Duel ranked ladder"
+msgstr ""
+
+#: src\commands\metagame.ts:283
+msgctxt "command-option-choice"
+msgid "Current format"
+msgstr ""
+
+#: src\commands\metagame.ts:287
+msgctxt "command-option-choice"
+msgid "Since last Forbidden/Limited List"
+msgstr ""
+
+#: src\commands\metagame.ts:291
+msgctxt "command-option-choice"
+msgid "Last 7 days"
+msgstr ""
+
+#: src\commands\metagame.ts:295
+msgctxt "command-option-choice"
+msgid "Last 14 days"
+msgstr ""
+
+#: src\commands\metagame.ts:299
+msgctxt "command-option-choice"
+msgid "Last 30 days"
+msgstr ""
+
+#: src\commands\metagame.ts:303
+msgctxt "command-option-choice"
+msgid "Last three months"
+msgstr ""
+
+#: src\commands\metagame.ts:307
+msgctxt "command-option-choice"
+msgid "Last six months"
 msgstr ""

--- a/translations/zh-CN.po
+++ b/translations/zh-CN.po
@@ -6,50 +6,33 @@ msgstr ""
 "MIME-Version: 1.0\n"
 "Content-Transfer-Encoding: 8bit\n"
 
-#: src\card.ts:416
-#: src\rush-duel.ts:39
+#: src\card.ts:412
+#: src\rush-duel.ts:48
 msgid "🔗 Links"
 msgstr "🔗 链接"
 
-#: src\card.ts:417
+#: src\card.ts:413
 #, javascript-format
 msgid "[Official Konami DB](${ official }) | [OCG Rulings](${ rulings }) | [Yugipedia](${ yugipedia }) | [YGOPRODECK](${ ygoprodeck })"
 msgstr "[K社官方数据库](${ official }) | [事务局FAQ](${ rulings }) | [Yugipedia](${ yugipedia }) | [YGOPRODECK](${ ygoprodeck })"
 
-#: src\card.ts:420
+#: src\card.ts:416
 #, javascript-format
 msgid "[Yugipedia](${ yugipedia }) | [YGOPRODECK](${ ygoprodeck })"
 msgstr "[Yugipedia](${ yugipedia }) | [YGOPRODECK](${ ygoprodeck })"
 
-#: src\card.ts:489
-#: src\rush-duel.ts:92
+#: src\card.ts:490
+#: src\rush-duel.ts:103
 #, javascript-format
 msgid "**Type**: ${ raceIcon } ${ localizedMonsterTypeLine }"
 msgstr "**种族**: ${ raceIcon } ${ localizedMonsterTypeLine }"
 
-#: src\card.ts:491
-#: src\rush-duel.ts:94
-#, javascript-format
-msgid "**Attribute**: ${ AttributeIcon[card.attribute] } ${ localizedAttribute }"
-msgstr "**属性**: ${ AttributeIcon[card.attribute] } ${ localizedAttribute }"
-
-#: src\card.ts:495
-#, javascript-format
-msgid "**Rank**: ${ Icon.Rank } ${ card.rank } **ATK**: ${ card.atk } **DEF**: ${ card.def }"
-msgstr "**阶级**: ${ Icon.Rank } ${ card.rank } **攻击力**: ${ card.atk } **守备力**: ${ card.def }"
-
-#: src\card.ts:498
+#: src\card.ts:500
 #, javascript-format
 msgid "**Link Rating**: ${ card.link_arrows.length } **ATK**: ${ card.atk } **Link Arrows**: ${ arrows }"
 msgstr "**连接数值**: ${ card.link_arrows.length } **攻击力**: ${ card.atk } **连接标记**: ${ arrows }"
 
-#: src\card.ts:500
-#: src\rush-duel.ts:96
-#, javascript-format
-msgid "**Level**: ${ Icon.Level } ${ card.level } **ATK**: ${ card.atk } **DEF**: ${ card.def }"
-msgstr "**等级**: ${ Icon.Level } ${ card.level } **攻击力**: ${ card.atk } **守备力**: ${ card.def }"
-
-#: src\card.ts:507
+#: src\card.ts:511
 #, javascript-format
 msgid "**Pendulum Scale**: ${ formattedScale }"
 msgstr "**灵摆刻度**: ${ formattedScale }"
@@ -70,7 +53,7 @@ msgid "Password: ${ card.password } | Not yet released"
 msgstr "卡片密码: ${ card.password } | 未发行"
 
 #: src\card.ts:351
-#: src\rush-duel.ts:146
+#: src\rush-duel.ts:158
 msgid "Not yet released"
 msgstr "未发行"
 
@@ -79,64 +62,64 @@ msgstr "未发行"
 msgid "Placeholder ID: ${ card.fake_password }"
 msgstr "假卡密: ${ card.fake_password }"
 
-#: src\utils.ts:41
+#: src\utils.ts:44
 msgid "🛠️ This command is in development."
 msgstr "🛠️ 这个指令正在开发中"
 
-#: src\utils.ts:42
+#: src\utils.ts:45
 msgid "📨 Please send feedback to [our issue tracker](https://github.com/DawnbrandBots/bastion-bot) or the [support server](https://discord.gg/4aFuPyuE96)!"
 msgstr "📨 如有意见或建议请反馈至[GitHub issue](https://github.com/DawnbrandBots/bastion-bot)或者[Discord服务器](https://discord.gg/4aFuPyuE96)!"
 
-#: src\utils.ts:53
+#: src\utils.ts:56
 msgid "Please consider supporting us!"
 msgstr "请考虑捐助我们！"
 
-#: src\utils.ts:54
+#: src\utils.ts:57
 msgid "Help keep Bastion online!"
 msgstr "帮帮Bastion吧，宝宝快饿死了"
 
-#: src\utils.ts:55
+#: src\utils.ts:58
 msgid "Please help keep Bastion online!"
 msgstr "请帮帮Bastion吧，宝宝真的快饿死了"
 
-#: src\utils.ts:56
+#: src\utils.ts:59
 msgid "Was Bastion helpful? Consider supporting us!"
 msgstr "Bastion有用么？请考虑捐助我们！"
 
-#: src\utils.ts:57
+#: src\utils.ts:60
 msgid "Was Bastion helpful? We need your support!"
 msgstr "Bastion有用么？我们需要你的支持！"
 
-#: src\utils.ts:58
+#: src\utils.ts:61
 msgid "Did you find Bastion useful? Consider supporting us!"
 msgstr "你觉得Bastion好用么？请考虑捐助我们！"
 
-#: src\utils.ts:59
+#: src\utils.ts:62
 msgid "Did you find Bastion useful? Help keep it online!"
 msgstr "你觉得Bastion好用么？那帮帮TA吧，孩子快饿死了"
 
-#: src\utils.ts:60
+#: src\utils.ts:63
 msgid "Did you find Bastion useful? We need your support!"
 msgstr "你觉得Bastion好用么？我们需要你的支持！"
 
-#: src\utils.ts:61
+#: src\utils.ts:64
 msgid "Enjoy Bastion? Help keep it online!"
 msgstr "你觉得Bastion好用么？那帮帮TA吧，孩子快饿死了"
 
-#: src\utils.ts:62
+#: src\utils.ts:65
 msgid "Enjoy Bastion? Consider supporting us!"
 msgstr "觉得Bastion怎么样？请考虑捐助我们！"
 
-#: src\utils.ts:63
+#: src\utils.ts:66
 msgid "Found what you were looking for? Consider supporting us!"
 msgstr "找到你要的东西了吗？请考虑捐助我们！"
 
 #: src\commands\art.ts:63
-#: src\commands\price.ts:131
-#: src\commands\rush-duel.ts:172
-#: src\commands\rush-duel.ts:203
+#: src\commands\price.ts:132
+#: src\commands\rush-duel.ts:171
+#: src\commands\rush-duel.ts:202
 #: src\commands\search.ts:64
-#: src\events\message-search.ts:258
+#: src\events\message-search.ts:265
 #, javascript-format
 msgid "Could not find a card matching `${ input }`!"
 msgstr "查无此卡：`${ input }`"
@@ -163,11 +146,7 @@ msgstr ""
 msgid "Discord Community locale for this server: ${ interaction.guildLocale }"
 msgstr ""
 
-#: src\commands\locale.ts:89
-#, javascript-format
-msgid "Locale override for this direct message: ${ override }"
-msgstr ""
-
+#: src\commands\locale-user.ts:76
 #: src\commands\locale.ts:92
 #, javascript-format
 msgid "Your Discord locale: ${ interaction.locale }"
@@ -205,18 +184,8 @@ msgstr ""
 msgid "Sorry, you must have the Manage Server permission to do this. If you think this is an error, contact your server admin or report a bug."
 msgstr ""
 
-#: src\commands\locale.ts:146
-#, javascript-format
-msgid "Locale for this direct message overridden with ${ locale }. Your Discord setting is ${ interaction.locale }."
-msgstr ""
-
-#: src\commands\locale.ts:150
-#, javascript-format
-msgid "Locale for this direct message reset to Discord default. Your Discord setting is ${ interaction.locale }."
-msgstr ""
-
-#: src\commands\ping.ts:40
-#: src\events\message-ping.ts:112
+#: src\commands\ping.ts:42
+#: src\events\message-ping.ts:110
 #, javascript-format
 msgid "Total latency: ${ latency } ms"
 msgstr "延迟${ latency }ms"
@@ -226,148 +195,131 @@ msgstr "延迟${ latency }ms"
 msgid "Could not find a Yugipedia page named `${ page }`."
 msgstr "Yugipedia上找不到`${ page }`"
 
-#: src\commands\deck.ts:244
+#: src\commands\deck.ts:205
 #, javascript-format
 msgid "${ counts.Monster } Monster"
 msgid_plural "${ counts.Monster } Monsters"
 msgstr[0] "${ counts.Monster }张怪兽卡"
 
-#: src\commands\deck.ts:247
+#: src\commands\deck.ts:208
 #, javascript-format
 msgid "${ counts.Spell } Spell"
 msgid_plural "${ counts.Spell } Spells"
 msgstr[0] "${ counts.Spell }张魔法卡"
 
-#: src\commands\deck.ts:250
+#: src\commands\deck.ts:211
 #, javascript-format
 msgid "${ counts.Trap } Trap"
 msgid_plural "${ counts.Trap } Traps"
 msgstr[0] "${ counts.Trap }张陷阱卡"
 
-#: src\commands\deck.ts:278
+#: src\commands\deck.ts:239
 msgid "Your Deck"
 msgstr "你的卡组"
 
-#: src\commands\deck.ts:283
+#: src\commands\deck.ts:244
 #, javascript-format
 msgid "Main Deck (${ deck.main.length } card — ${ countDetail })"
 msgid_plural "Main Deck (${ deck.main.length } cards — ${ countDetail })"
 msgstr[0] "牌组（${ deck.main.length }张 — ${ countDetail }）"
 
-#: src\commands\deck.ts:297
+#: src\commands\deck.ts:258
 #, javascript-format
 msgid "Extra Deck (${ deck.extra.length } card — ${ countDetail })"
 msgid_plural "Extra Deck (${ deck.extra.length } cards — ${ countDetail })"
 msgstr[0] "额外卡组（${ deck.extra.length }张 — ${ countDetail }）"
 
-#: src\commands\deck.ts:311
+#: src\commands\deck.ts:272
 #, javascript-format
 msgid "Side Deck (${ deck.side.length } card — ${ countDetail })"
 msgid_plural "Side Deck (${ deck.side.length } cards — ${ countDetail })"
 msgstr[0] "备牌（${ deck.side.length }张 — ${ countDetail }）"
 
-#: src\commands\deck.ts:290
+#: src\commands\deck.ts:251
 msgid "Main Deck (continued)"
 msgstr "牌组（续）"
 
-#: src\commands\deck.ts:304
+#: src\commands\deck.ts:265
 msgid "Extra Deck (continued)"
 msgstr "额外卡组（续）"
 
-#: src\commands\deck.ts:318
+#: src\commands\deck.ts:279
 msgid "Side Deck (continued)"
 msgstr "备牌（续）"
 
-#: src\commands\deck.ts:407
+#: src\commands\deck.ts:347
 msgid "Error: Your deck is empty."
 msgstr "错误：卡组是空的。"
 
-#: src\commands\ping.ts:36
-#: src\events\message-ping.ts:47
+#: src\commands\ping.ts:38
+#: src\events\message-ping.ts:45
 #, javascript-format
 msgid "Average WebSocket ping (new instance): ${ ping } ms"
 msgstr ""
 
-#: src\events\message-ping.ts:49
+#: src\events\message-ping.ts:47
 msgid "Free and open source _Yu-Gi-Oh!_ bot"
 msgstr "自由开源游戏王聊天机器人"
 
-#: src\events\message-ping.ts:72
+#: src\events\message-ping.ts:70
 #, javascript-format
 msgid "Revision: ${ process.env.BOT_REVISION }."
 msgstr "修订：${ process.env.BOT_REVISION }"
 
-#: src\commands\deck.ts:328
+#: src\commands\deck.ts:289
 msgid ".ydk files must have the .ydk extension!"
 msgstr ""
 
-#: src\commands\deck.ts:331
+#: src\commands\deck.ts:292
 msgid ".ydk files should not be larger than 1 KB!"
 msgstr ""
 
-#: src\commands\deck.ts:321
+#: src\commands\deck.ts:282
 msgid "ydke URL"
 msgstr ""
 
 #: src\card.ts:455
-#: src\rush-duel.ts:61
+#: src\rush-duel.ts:75
 #. Forbidden/Limited Lists or Limit Regulations in the OCG
 #, javascript-format
 msgid "**Limit**: ${ limitRegulationDisplay }"
 msgstr "**限制**: ${ limitRegulationDisplay }"
 
-#: src\commands\price.ts:69
+#: src\commands\price.ts:70
 msgid "TCGPlayer"
 msgstr ""
 
-#: src\commands\price.ts:70
+#: src\commands\price.ts:71
 msgid "Cardmarket"
 msgstr ""
 
-#: src\commands\price.ts:147
+#: src\commands\price.ts:148
 msgid "No market price"
 msgstr ""
 
-#: src\commands\price.ts:155
+#: src\commands\price.ts:156
 #, javascript-format
 msgid "Prices for ${ card.name[resultLanguage] } - ${ vendorName }"
 msgstr ""
 
-#: src\commands\price.ts:169
+#: src\commands\price.ts:170
 #, javascript-format
 msgid "Could not find prices for `${ name }`!"
 msgstr ""
 
-#: src\commands\deck.ts:425
-#. prepare interaction button for FTP upload
+#: src\commands\deck.ts:363
 msgid "Upload to YGOPRODECK"
 msgstr "上传至YGOPRODECK"
 
-#: src\commands\deck.ts:483
-#. disable original button
-#. prepare row to disable button on original message
-msgid "Upload Complete"
-msgstr "上传成功"
-
-#: src\commands\deck.ts:470
-msgid "Deck upload failed!"
-msgstr "上传失败"
-
-#: src\commands\deck.ts:491
-#. reply in affirmation
-#, javascript-format
-msgid "Deck successfully uploaded to <${ url }>!"
-msgstr "卡组成功上传到<${ url }>!"
-
-#: src\events\message-search.ts:264
+#: src\events\message-search.ts:271
 msgid "💬 Translations missing?"
 msgstr "💬缺少翻译？"
 
-#: src\events\message-search.ts:265
+#: src\events\message-search.ts:272
 msgid "Help translate Bastion at the links above."
 msgstr "在以上的网址帮忙翻译Bastion"
 
-#: src\events\message-ping.ts:50
+#: src\events\message-ping.ts:48
 msgid ""
 "❓ Help documentation on [GitHub](https://github.com/DawnbrandBots/bastion-bot), or use `.commands` and `.help`.\n"
 "🟢 Licence: [GNU AGPL 3.0+](https://choosealicense.com/licenses/agpl-3.0/).\n"
@@ -383,27 +335,27 @@ msgid ""
 "💬 Translations missing? Help translate Bastion on [GitHub](https://github.com/DawnbrandBots/bastion-bot)."
 msgstr ""
 
-#: src\events\message-search.ts:256
-#: src\events\message-search.ts:294
+#: src\events\message-search.ts:263
+#: src\events\message-search.ts:302
 #, javascript-format
 msgid "Search type: ${ localisedType }"
 msgstr "搜索类型：${ localisedType }"
 
-#: src\events\message-search.ts:236
+#: src\events\message-search.ts:242
 #, javascript-format
 msgid "Search language: **${ localisedInputLanguage }** (${ inputLanguage }). Check defaults with </locale get:${ id }> and configure with </locale set:${ id }>"
 msgstr ""
 
-#: src\events\message-ping.ts:95
+#: src\events\message-ping.ts:93
 msgid "⚠️ You pinged me, but I am missing permissions in the channel!"
 msgstr ""
 
-#: src\events\message-ping.ts:98
-#: src\events\message-search.ts:332
+#: src\events\message-ping.ts:96
+#: src\events\message-search.ts:340
 msgid "Please have a server administrator [fix this](https://github.com/DawnbrandBots/bastion-bot#discord-permissions)."
 msgstr ""
 
-#: src\events\message-search.ts:329
+#: src\events\message-search.ts:337
 msgid "⚠️ I am missing permissions in the channel!"
 msgstr ""
 
@@ -422,48 +374,82 @@ msgstr ""
 msgid "Something went wrong searching Yugipedia for `${ page }`."
 msgstr ""
 
-#: src\rush-duel.ts:40
+#: src\rush-duel.ts:49
 #, javascript-format
 msgid "[Official Konami DB](${ official }) | [Rulings (Japanese)](${ rulings }) | [Yugipedia](${ yugipedia }) | [RushCard](${ rushcard })"
 msgstr "[K社官方数据库](${ official }) | [事务局FAQ](${ rulings }) | [Yugipedia](${ yugipedia }) | [RushCard](${ rushcard })"
 
-#: src\rush-duel.ts:43
+#: src\rush-duel.ts:52
 #, javascript-format
 msgid "[Yugipedia](${ yugipedia }) | [RushCard](${ rushcard })"
 msgstr "[Yugipedia](${ yugipedia }) | [RushCard](${ rushcard })"
 
-#: src\rush-duel.ts:57
+#: src\rush-duel.ts:71
 msgid "__**LEGEND**__"
 msgstr ""
 
-#: src\rush-duel.ts:99
+#: src\rush-duel.ts:110
 #, javascript-format
 msgid "**MAXIMUM ATK**: ${ card.maximum_atk }"
 msgstr ""
 
-#: src\rush-duel.ts:146
+#: src\rush-duel.ts:158
 #, javascript-format
 msgid "Konami ID #${ card.konami_id }"
 msgstr "官方编号${ card.konami_id }"
 
 #: src\art.ts:129
-#: src\commands\deck.ts:451
 msgid "Buttons can only be used by the user who called Bastion."
 msgstr ""
 
-#: src\card.ts:462
-#, javascript-format
-msgid "**Master Duel rarity**: ${ rarity_icon } ${ localized_rarity }"
-msgstr "**稀有度 (Master Duel)**: ${ rarity_icon } ${ localized_rarity }"
-
-#: src\rush-duel.ts:205
+#: src\rush-duel.ts:217
 #, javascript-format
 msgid "Using ${ searchTrigger }, you can search for Rush Duel cards directly in messages without autocomplete"
 msgstr ""
 
-#: src\events\message-search.ts:296
+#: src\events\message-search.ts:304
 #, javascript-format
 msgid "Could not find a Rush Duel card matching `${ input }`!"
+msgstr ""
+
+#: src\card.ts:462
+#, javascript-format
+msgid "**Master Duel rarity**: ${ rarityIcon } ${ localizedRarity }"
+msgstr ""
+
+#: src\card.ts:492
+#: src\rush-duel.ts:105
+#, javascript-format
+msgid "**Attribute**: ${ attributeIcon } ${ localizedAttribute }"
+msgstr ""
+
+#: src\card.ts:497
+#, javascript-format
+msgid "**Rank**: ${ rankIcon } ${ card.rank } **ATK**: ${ card.atk } **DEF**: ${ card.def }"
+msgstr ""
+
+#: src\card.ts:503
+#: src\rush-duel.ts:107
+#, javascript-format
+msgid "**Level**: ${ levelIcon } ${ card.level } **ATK**: ${ card.atk } **DEF**: ${ card.def }"
+msgstr ""
+
+#: src\commands\locale-user.ts:73
+#: src\commands\locale.ts:89
+#, javascript-format
+msgid "Locale override for your direct messages: ${ override }"
+msgstr ""
+
+#: src\commands\locale-user.ts:83
+#: src\commands\locale.ts:146
+#, javascript-format
+msgid "Locale for your direct messages overridden with ${ locale }. Your Discord setting is ${ interaction.locale }."
+msgstr ""
+
+#: src\commands\locale-user.ts:87
+#: src\commands\locale.ts:150
+#, javascript-format
+msgid "Locale for your direct messages reset to Discord default. Your Discord setting is ${ interaction.locale }."
 msgstr ""
 
 #: src\card.ts:40
@@ -830,60 +816,60 @@ msgctxt "master-duel-rarity"
 msgid "Ultra Rare (UR)"
 msgstr "金闪稀有（ＵＲ）"
 
-#: src\card.ts:513
-#: src\card.ts:524
-#: src\rush-duel.ts:127
+#: src\card.ts:517
+#: src\card.ts:528
+#: src\rush-duel.ts:138
 msgctxt "card-embed"
 msgid "Card Text"
 msgstr "卡片文本"
 
-#: src\card.ts:518
+#: src\card.ts:522
 msgctxt "card-embed"
 msgid "Pendulum Effect"
 msgstr "灵摆效果"
 
-#: src\card.ts:539
+#: src\card.ts:545
 msgctxt "card-embed"
 msgid "Card Effect"
 msgstr "卡片效果"
 
-#: src\rush-duel.ts:118
-#: src\rush-duel.ts:139
+#: src\rush-duel.ts:129
+#: src\rush-duel.ts:151
 msgctxt "card-embed"
 msgid "[REQUIREMENT]"
 msgstr "【条件】"
 
-#: src\rush-duel.ts:119
-#: src\rush-duel.ts:140
+#: src\rush-duel.ts:130
+#: src\rush-duel.ts:152
 msgctxt "card-embed"
 msgid "[EFFECT]"
 msgstr "【效果】"
 
-#: src\rush-duel.ts:121
+#: src\rush-duel.ts:132
 msgctxt "card-embed"
 msgid "[CONTINUOUS EFFECT]"
 msgstr "【永续效果】"
 
-#: src\rush-duel.ts:123
+#: src\rush-duel.ts:134
 msgctxt "card-embed"
 msgid "[MULTI-CHOICE EFFECT]"
 msgstr "【选择效果】"
 
-#: src\locale.ts:71
+#: src\locale.ts:74
 msgctxt "command-option"
 msgid "result-language"
 msgstr "查询结果语言"
 
-#: src\locale.ts:131
+#: src\locale.ts:140
 msgctxt "command-option"
 msgid "input-language"
 msgstr "输入语言"
 
-#: src\commands\rush-duel.ts:68
-#: src\commands\rush-duel.ts:80
-#: src\locale.ts:147
-#: src\locale.ts:165
-#: src\locale.ts:181
+#: src\commands\rush-duel.ts:67
+#: src\commands\rush-duel.ts:79
+#: src\locale.ts:156
+#: src\locale.ts:174
+#: src\locale.ts:190
 msgctxt "command-option"
 msgid "input"
 msgstr "输入"
@@ -898,59 +884,61 @@ msgctxt "command-option"
 msgid "page"
 msgstr ""
 
-#: src\commands\help.ts:52
+#: src\commands\help.ts:55
 msgctxt "command-option"
 msgid "command"
 msgstr ""
 
-#: src\commands\deck.ts:126
+#: src\commands\deck.ts:87
 msgctxt "command-option"
 msgid "url"
 msgstr ""
 
-#: src\commands\deck.ts:132
+#: src\commands\deck.ts:93
 msgctxt "command-option"
 msgid "file"
 msgstr ""
 
-#: src\commands\deck.ts:138
-#: src\commands\deck.ts:144
+#: src\commands\deck.ts:99
+#: src\commands\deck.ts:105
 msgctxt "command-option"
 msgid "deck"
 msgstr ""
 
-#: src\commands\deck.ts:150
+#: src\commands\deck.ts:111
 msgctxt "command-option"
 msgid "public"
 msgstr ""
 
-#: src\commands\deck.ts:157
+#: src\commands\deck.ts:118
 msgctxt "command-option"
 msgid "stacked"
 msgstr ""
 
-#: src\locale.ts:142
+#: src\locale.ts:151
 msgctxt "command-option"
 msgid "name"
 msgstr ""
 
-#: src\locale.ts:160
+#: src\locale.ts:169
 msgctxt "command-option"
 msgid "password"
 msgstr ""
 
-#: src\commands\rush-duel.ts:73
-#: src\events\message-search.ts:293
-#: src\locale.ts:176
+#: src\commands\rush-duel.ts:72
+#: src\events\message-search.ts:301
+#: src\locale.ts:185
 msgctxt "command-option"
 msgid "konami-id"
 msgstr ""
 
+#: src\commands\locale-user.ts:36
 #: src\commands\locale.ts:30
 msgctxt "command-option"
 msgid "get"
 msgstr ""
 
+#: src\commands\locale-user.ts:41
 #: src\commands\locale.ts:35
 msgctxt "command-option"
 msgid "set"
@@ -961,42 +949,64 @@ msgctxt "command-option"
 msgid "scope"
 msgstr ""
 
+#: src\commands\locale-user.ts:46
 #: src\commands\locale.ts:48
 msgctxt "command-option"
 msgid "locale"
 msgstr ""
 
-#: src\commands\price.ts:94
+#: src\commands\price.ts:95
 msgctxt "command-option"
 msgid "vendor"
 msgstr ""
 
-#: src\commands\rush-duel.ts:63
+#: src\commands\rush-duel.ts:62
 msgctxt "command-option"
 msgid "search"
 msgstr ""
 
-#: src\commands\rush-duel.ts:85
+#: src\commands\rush-duel.ts:84
 msgctxt "command-option"
 msgid "random"
 msgstr ""
 
-#: src\commands\rush-duel.ts:90
+#: src\commands\rush-duel.ts:89
 msgctxt "command-option"
 msgid "art"
 msgstr ""
 
-#: src\commands\query.ts:36
+#: src\commands\query.ts:35
 msgctxt "command-option"
 msgid "lucene"
 msgstr ""
 
-#: src\locale.ts:74
+#: src\commands\metagame.ts:209
+msgctxt "command-option"
+msgid "strategies"
+msgstr ""
+
+#: src\commands\metagame.ts:234
+#: src\commands\metagame.ts:274
+msgctxt "command-option"
+msgid "format"
+msgstr ""
+
+#: src\commands\metagame.ts:240
+msgctxt "command-option"
+msgid "cards"
+msgstr ""
+
+#: src\commands\metagame.ts:310
+msgctxt "command-option"
+msgid "date-range"
+msgstr ""
+
+#: src\locale.ts:77
 msgctxt "command-option-description"
 msgid "The output language for the card embed, overriding other settings."
 msgstr "卡片查询结果的语言，覆盖其他设置"
 
-#: src\locale.ts:132
+#: src\locale.ts:141
 msgctxt "command-option-description"
 msgid "The language to search in, defaulting to the result language."
 msgstr "查询用的语言，默认与查询结果语言相同"
@@ -1006,37 +1016,37 @@ msgctxt "command-option-description"
 msgid "The name of the Yugipedia page you want to search for."
 msgstr "你想要查询的Yugipedia页面的名字"
 
-#: src\commands\help.ts:55
+#: src\commands\help.ts:58
 msgctxt "command-option-description"
 msgid "The name of a specific Slash Command."
 msgstr ""
 
-#: src\commands\deck.ts:129
+#: src\commands\deck.ts:90
 msgctxt "command-option-description"
 msgid "View a deck by entering a ydke:// URL."
 msgstr ""
 
-#: src\commands\deck.ts:135
+#: src\commands\deck.ts:96
 msgctxt "command-option-description"
 msgid "View a deck by uploading a .ydk file."
 msgstr ""
 
-#: src\commands\deck.ts:141
+#: src\commands\deck.ts:102
 msgctxt "command-option-description"
 msgid "The ydke:// URL of the deck you want to view."
 msgstr ""
 
-#: src\commands\deck.ts:147
+#: src\commands\deck.ts:108
 msgctxt "command-option-description"
 msgid "The .ydk file of the deck you want to view."
 msgstr ""
 
-#: src\commands\deck.ts:153
+#: src\commands\deck.ts:114
 msgctxt "command-option-description"
 msgid "Whether to display the deck details publicly in chat. This is false by default."
 msgstr ""
 
-#: src\commands\deck.ts:160
+#: src\commands\deck.ts:121
 msgctxt "command-option-description"
 msgid "Whether to display the deck sections as one stacked column. This is false (side-by-side) by default."
 msgstr ""
@@ -1046,8 +1056,8 @@ msgctxt "command-option-description"
 msgid "Display the art for the card with this name."
 msgstr ""
 
-#: src\commands\rush-duel.ts:69
-#: src\locale.ts:148
+#: src\commands\rush-duel.ts:68
+#: src\locale.ts:157
 msgctxt "command-option-description"
 msgid "Card name, fuzzy matching supported."
 msgstr ""
@@ -1057,7 +1067,7 @@ msgctxt "command-option-description"
 msgid "Display the art for the card with this password."
 msgstr ""
 
-#: src\locale.ts:167
+#: src\locale.ts:176
 msgctxt "command-option-description"
 msgid "Card password, the eight-digit number printed on the bottom left corner."
 msgstr ""
@@ -1067,8 +1077,8 @@ msgctxt "command-option-description"
 msgid "Display the art for the card with this official database ID."
 msgstr ""
 
-#: src\commands\rush-duel.ts:81
-#: src\locale.ts:182
+#: src\commands\rush-duel.ts:80
+#: src\locale.ts:191
 msgctxt "command-option-description"
 msgid "Konami's official card database identifier."
 msgstr ""
@@ -1108,22 +1118,22 @@ msgctxt "command-option-description"
 msgid "The new default language to use in this channel or server."
 msgstr ""
 
-#: src\commands\price.ts:98
+#: src\commands\price.ts:99
 msgctxt "command-option-description"
 msgid "Display the price for the card with this name."
 msgstr ""
 
-#: src\commands\price.ts:102
+#: src\commands\price.ts:103
 msgctxt "command-option-description"
 msgid "Display the price for the card with this password."
 msgstr ""
 
-#: src\commands\price.ts:105
+#: src\commands\price.ts:106
 msgctxt "command-option-description"
 msgid "Display the price for the card with this official database ID."
 msgstr ""
 
-#: src\commands\price.ts:95
+#: src\commands\price.ts:96
 msgctxt "command-option-description"
 msgid "The vendor to fetch the price data from."
 msgstr ""
@@ -1133,29 +1143,70 @@ msgctxt "command-option-description"
 msgid "The English name of the card you're looking for."
 msgstr ""
 
-#: src\commands\rush-duel.ts:64
+#: src\commands\rush-duel.ts:63
 msgctxt "command-option-description"
 msgid "Find all information for the Rush Duel card with this name."
 msgstr ""
 
-#: src\commands\rush-duel.ts:75
+#: src\commands\rush-duel.ts:74
 msgctxt "command-option-description"
 msgid "Find all information for the Rush Duel card with this official database ID."
 msgstr ""
 
-#: src\commands\rush-duel.ts:86
+#: src\commands\rush-duel.ts:85
 msgctxt "command-option-description"
 msgid "Get a random Rush Duel card."
 msgstr ""
 
-#: src\commands\rush-duel.ts:91
+#: src\commands\rush-duel.ts:90
 msgctxt "command-option-description"
 msgid "Display just the art for the Rush Duel card with this name."
 msgstr ""
 
-#: src\commands\query.ts:37
+#: src\commands\query.ts:36
 msgctxt "command-option-description"
 msgid "Lucene query on YAML Yugi"
+msgstr ""
+
+#: src\commands\locale-user.ts:37
+msgctxt "command-option-description"
+msgid "Check your user-installed Bastion's locale."
+msgstr ""
+
+#: src\commands\locale-user.ts:42
+msgctxt "command-option-description"
+msgid "Configure your user-installed Bastion's locale."
+msgstr ""
+
+#: src\commands\locale-user.ts:47
+msgctxt "command-option-description"
+msgid "The new default language to use for user-installed Bastion."
+msgstr ""
+
+#: src\commands\metagame.ts:212
+msgctxt "command-option-description"
+msgid "Show the top competitive strategies in tournaments and the Master Duel ranked ladder."
+msgstr ""
+
+#: src\commands\metagame.ts:214
+msgctxt "command-option-description"
+msgid "Show the top competitive strategies in tournaments."
+msgstr ""
+
+#: src\commands\metagame.ts:235
+#: src\commands\metagame.ts:275
+msgctxt "command-option-description"
+msgid "Game region."
+msgstr ""
+
+#: src\commands\metagame.ts:242
+msgctxt "command-option-description"
+msgid "Show the most popular cards in tournaments and the Master Duel ranked ladder."
+msgstr ""
+
+#: src\commands\metagame.ts:312
+msgctxt "command-option-description"
+msgid "Limit card usage statistics to this date range. Has no effect for Master Duel."
 msgstr ""
 
 #: src\commands\art.ts:36
@@ -1163,7 +1214,7 @@ msgctxt "command-name"
 msgid "art"
 msgstr "卡图"
 
-#: src\commands\ping.ts:23
+#: src\commands\ping.ts:25
 msgctxt "command-name"
 msgid "ping"
 msgstr ""
@@ -1178,12 +1229,12 @@ msgctxt "command-name"
 msgid "yugipedia"
 msgstr ""
 
-#: src\commands\help.ts:49
+#: src\commands\help.ts:52
 msgctxt "command-name"
 msgid "help"
 msgstr ""
 
-#: src\commands\deck.ts:119
+#: src\commands\deck.ts:80
 msgctxt "command-name"
 msgid "deck"
 msgstr ""
@@ -1198,24 +1249,34 @@ msgctxt "command-name"
 msgid "locale"
 msgstr ""
 
-#: src\commands\random.ts:44
+#: src\commands\random.ts:43
 msgctxt "command-name"
 msgid "random"
 msgstr ""
 
-#: src\commands\price.ts:89
+#: src\commands\price.ts:90
 msgctxt "command-name"
 msgid "price"
 msgstr ""
 
-#: src\commands\rush-duel.ts:58
+#: src\commands\rush-duel.ts:57
 msgctxt "command-name"
 msgid "rush-duel"
 msgstr ""
 
-#: src\commands\query.ts:30
+#: src\commands\query.ts:29
 msgctxt "command-name"
 msgid "query"
+msgstr ""
+
+#: src\commands\locale-user.ts:31
+msgctxt "command-name"
+msgid "locale-user"
+msgstr ""
+
+#: src\commands\metagame.ts:204
+msgctxt "command-name"
+msgid "metagame"
 msgstr ""
 
 #: src\commands\art.ts:37
@@ -1223,7 +1284,7 @@ msgctxt "command-description"
 msgid "Display the art for a card!"
 msgstr "显示卡片图。"
 
-#: src\commands\ping.ts:24
+#: src\commands\ping.ts:26
 msgctxt "command-description"
 msgid "Test latency to the new bot instance."
 msgstr "测试新bot实例的延迟"
@@ -1238,12 +1299,12 @@ msgctxt "command-description"
 msgid "Search the Yugipedia wiki for a page and link to it."
 msgstr "搜索Yugipedia页面与链接"
 
-#: src\commands\help.ts:50
+#: src\commands\help.ts:53
 msgctxt "command-description"
 msgid "Get help with a Slash Command."
 msgstr ""
 
-#: src\commands\deck.ts:122
+#: src\commands\deck.ts:83
 msgctxt "command-description"
 msgid "Display a deck list from ydke:// or .ydk format, exported from a number of deck building programs."
 msgstr ""
@@ -1258,24 +1319,34 @@ msgctxt "command-description"
 msgid "Check or set Bastion's locale for this channel or server."
 msgstr ""
 
-#: src\commands\random.ts:45
+#: src\commands\random.ts:44
 msgctxt "command-description"
 msgid "Get a random Yu-Gi-Oh! card."
 msgstr ""
 
-#: src\commands\price.ts:90
+#: src\commands\price.ts:91
 msgctxt "command-description"
 msgid "Display the price for a card!"
 msgstr ""
 
-#: src\commands\rush-duel.ts:59
+#: src\commands\rush-duel.ts:58
 msgctxt "command-description"
 msgid "Find information on Rush Duel cards."
 msgstr ""
 
-#: src\commands\query.ts:31
+#: src\commands\query.ts:30
 msgctxt "command-description"
 msgid "Advanced search prototype"
+msgstr ""
+
+#: src\commands\locale-user.ts:32
+msgctxt "command-description"
+msgid "Check or set user-installed Bastion's locale."
+msgstr ""
+
+#: src\commands\metagame.ts:205
+msgctxt "command-description"
+msgid "Show statistics on the current competitive state of play."
 msgstr ""
 
 #: src\commands\locale.ts:43
@@ -1288,7 +1359,71 @@ msgctxt "command-option-choice"
 msgid "server"
 msgstr ""
 
+#: src\commands\locale-user.ts:49
 #: src\commands\locale.ts:51
 msgctxt "command-option-choice"
 msgid "Discord default"
+msgstr ""
+
+#: src\commands\metagame.ts:219
+#: src\commands\metagame.ts:251
+msgctxt "command-option-choice"
+msgid "TCG"
+msgstr ""
+
+#: src\commands\metagame.ts:220
+#: src\commands\metagame.ts:255
+msgctxt "command-option-choice"
+msgid "OCG"
+msgstr ""
+
+#: src\commands\metagame.ts:221
+#: src\commands\metagame.ts:259
+msgctxt "command-option-choice"
+msgid "OCG (Asian-English)"
+msgstr ""
+
+#: src\commands\metagame.ts:228
+msgctxt "command-option-choice"
+msgid "Master Duel Diamond+ tier list"
+msgstr ""
+
+#: src\commands\metagame.ts:261
+msgctxt "command-option-choice"
+msgid "Master Duel ranked ladder"
+msgstr ""
+
+#: src\commands\metagame.ts:283
+msgctxt "command-option-choice"
+msgid "Current format"
+msgstr ""
+
+#: src\commands\metagame.ts:287
+msgctxt "command-option-choice"
+msgid "Since last Forbidden/Limited List"
+msgstr ""
+
+#: src\commands\metagame.ts:291
+msgctxt "command-option-choice"
+msgid "Last 7 days"
+msgstr ""
+
+#: src\commands\metagame.ts:295
+msgctxt "command-option-choice"
+msgid "Last 14 days"
+msgstr ""
+
+#: src\commands\metagame.ts:299
+msgctxt "command-option-choice"
+msgid "Last 30 days"
+msgstr ""
+
+#: src\commands\metagame.ts:303
+msgctxt "command-option-choice"
+msgid "Last three months"
+msgstr ""
+
+#: src\commands\metagame.ts:307
+msgctxt "command-option-choice"
+msgid "Last six months"
 msgstr ""

--- a/translations/zh-TW.po
+++ b/translations/zh-TW.po
@@ -30,13 +30,13 @@ msgstr "**種族**: ${ raceIcon } ${ localizedMonsterTypeLine }"
 #: src\card.ts:491
 #: src\rush-duel.ts:94
 #, javascript-format
-msgid "**Attribute**: ${ AttributeIcon[card.attribute] } ${ localizedAttribute }"
-msgstr "**屬性**: ${ AttributeIcon[card.attribute] } ${ localizedAttribute }"
+msgid "**Attribute**: ${ attributeIcon } ${ localizedAttribute }"
+msgstr "**屬性**: ${ attributeIcon } ${ localizedAttribute }"
 
 #: src\card.ts:495
 #, javascript-format
-msgid "**Rank**: ${ Icon.Rank } ${ card.rank } **ATK**: ${ card.atk } **DEF**: ${ card.def }"
-msgstr "**階級**: ${ Icon.Rank } ${ card.rank } **攻擊力**: ${ card.atk } **守備力**: ${ card.def }"
+msgid "**Rank**: ${ rankIcon } ${ card.rank } **ATK**: ${ card.atk } **DEF**: ${ card.def }"
+msgstr "**階級**: ${ rankIcon } ${ card.rank } **攻擊力**: ${ card.atk } **守備力**: ${ card.def }"
 
 #: src\card.ts:498
 #, javascript-format
@@ -46,8 +46,8 @@ msgstr "**連接數值**: ${ card.link_arrows.length } **攻擊力**: ${ card.at
 #: src\card.ts:500
 #: src\rush-duel.ts:96
 #, javascript-format
-msgid "**Level**: ${ Icon.Level } ${ card.level } **ATK**: ${ card.atk } **DEF**: ${ card.def }"
-msgstr "**等級**: ${ Icon.Level } ${ card.level } **攻擊力**: ${ card.atk } **守備力**: ${ card.def }"
+msgid "**Level**: ${ levelIcon } ${ card.level } **ATK**: ${ card.atk } **DEF**: ${ card.def }"
+msgstr "**等級**: ${ levelIcon } ${ card.level } **攻擊力**: ${ card.atk } **守備力**: ${ card.def }"
 
 #: src\card.ts:507
 #, javascript-format
@@ -453,8 +453,8 @@ msgstr ""
 
 #: src\card.ts:462
 #, javascript-format
-msgid "**Master Duel rarity**: ${ rarity_icon } ${ localized_rarity }"
-msgstr "**稀有度 (Master Duel)**: ${ rarity_icon } ${ localized_rarity }"
+msgid "**Master Duel rarity**: ${ rarityIcon } ${ localizedRarity }"
+msgstr "**稀有度 (Master Duel)**: ${ rarityIcon } ${ localizedRarity }"
 
 #: src\rush-duel.ts:205
 #, javascript-format

--- a/translations/zh-TW.po
+++ b/translations/zh-TW.po
@@ -6,50 +6,50 @@ msgstr ""
 "MIME-Version: 1.0\n"
 "Content-Transfer-Encoding: 8bit\n"
 
-#: src\card.ts:416
-#: src\rush-duel.ts:39
+#: src\card.ts:412
+#: src\rush-duel.ts:48
 msgid "🔗 Links"
 msgstr "鏈接"
 
-#: src\card.ts:417
+#: src\card.ts:413
 #, javascript-format
 msgid "[Official Konami DB](${ official }) | [OCG Rulings](${ rulings }) | [Yugipedia](${ yugipedia }) | [YGOPRODECK](${ ygoprodeck })"
 msgstr "[K社官方數據庫](${ official }) | [事務局FAQ](${ rulings }) | [Yugipedia](${ yugipedia }) | [YGOPRODECK](${ ygoprodeck })"
 
-#: src\card.ts:420
+#: src\card.ts:416
 #, javascript-format
 msgid "[Yugipedia](${ yugipedia }) | [YGOPRODECK](${ ygoprodeck })"
 msgstr "[Yugipedia](${ yugipedia }) | [YGOPRODECK](${ ygoprodeck })"
 
-#: src\card.ts:489
-#: src\rush-duel.ts:92
+#: src\card.ts:490
+#: src\rush-duel.ts:103
 #, javascript-format
 msgid "**Type**: ${ raceIcon } ${ localizedMonsterTypeLine }"
 msgstr "**種族**: ${ raceIcon } ${ localizedMonsterTypeLine }"
 
-#: src\card.ts:491
-#: src\rush-duel.ts:94
+#: src\card.ts:492
+#: src\rush-duel.ts:105
 #, javascript-format
 msgid "**Attribute**: ${ attributeIcon } ${ localizedAttribute }"
 msgstr "**屬性**: ${ attributeIcon } ${ localizedAttribute }"
 
-#: src\card.ts:495
+#: src\card.ts:497
 #, javascript-format
 msgid "**Rank**: ${ rankIcon } ${ card.rank } **ATK**: ${ card.atk } **DEF**: ${ card.def }"
 msgstr "**階級**: ${ rankIcon } ${ card.rank } **攻擊力**: ${ card.atk } **守備力**: ${ card.def }"
 
-#: src\card.ts:498
+#: src\card.ts:500
 #, javascript-format
 msgid "**Link Rating**: ${ card.link_arrows.length } **ATK**: ${ card.atk } **Link Arrows**: ${ arrows }"
 msgstr "**連接數值**: ${ card.link_arrows.length } **攻擊力**: ${ card.atk } **連接標記**: ${ arrows }"
 
-#: src\card.ts:500
-#: src\rush-duel.ts:96
+#: src\card.ts:503
+#: src\rush-duel.ts:107
 #, javascript-format
 msgid "**Level**: ${ levelIcon } ${ card.level } **ATK**: ${ card.atk } **DEF**: ${ card.def }"
 msgstr "**等級**: ${ levelIcon } ${ card.level } **攻擊力**: ${ card.atk } **守備力**: ${ card.def }"
 
-#: src\card.ts:507
+#: src\card.ts:511
 #, javascript-format
 msgid "**Pendulum Scale**: ${ formattedScale }"
 msgstr "**靈擺刻度**: ${ formattedScale }"
@@ -70,7 +70,7 @@ msgid "Password: ${ card.password } | Not yet released"
 msgstr "卡片密碼: ${ card.password } | 未發行"
 
 #: src\card.ts:351
-#: src\rush-duel.ts:146
+#: src\rush-duel.ts:158
 msgid "Not yet released"
 msgstr "未發行"
 
@@ -79,64 +79,64 @@ msgstr "未發行"
 msgid "Placeholder ID: ${ card.fake_password }"
 msgstr "假卡密: ${ card.fake_password }"
 
-#: src\utils.ts:41
+#: src\utils.ts:44
 msgid "🛠️ This command is in development."
 msgstr "🛠️ 這個指令正在開發中"
 
-#: src\utils.ts:42
+#: src\utils.ts:45
 msgid "📨 Please send feedback to [our issue tracker](https://github.com/DawnbrandBots/bastion-bot) or the [support server](https://discord.gg/4aFuPyuE96)!"
 msgstr "📨 如有意見或建議請反饋至[GitHub issue](https://github.com/DawnbrandBots/bastion-bot)或者[Discord服務器](https://discord.gg/4aFuPyuE96)!"
 
-#: src\utils.ts:53
+#: src\utils.ts:56
 msgid "Please consider supporting us!"
 msgstr "請考慮捐助我們！"
 
-#: src\utils.ts:54
+#: src\utils.ts:57
 msgid "Help keep Bastion online!"
 msgstr "幫幫Bastion吧，寶寶快餓死了"
 
-#: src\utils.ts:55
+#: src\utils.ts:58
 msgid "Please help keep Bastion online!"
 msgstr "請幫幫Bastion吧，寶寶真的快餓死了"
 
-#: src\utils.ts:56
+#: src\utils.ts:59
 msgid "Was Bastion helpful? Consider supporting us!"
 msgstr "Bastion有用麼？請考慮捐助我們！"
 
-#: src\utils.ts:57
+#: src\utils.ts:60
 msgid "Was Bastion helpful? We need your support!"
 msgstr "Bastion有用麼？我們需要你的支持！"
 
-#: src\utils.ts:58
+#: src\utils.ts:61
 msgid "Did you find Bastion useful? Consider supporting us!"
 msgstr "你覺得Bastion好用麼？請考慮捐助我們！"
 
-#: src\utils.ts:59
+#: src\utils.ts:62
 msgid "Did you find Bastion useful? Help keep it online!"
 msgstr "你覺得Bastion好用麼？那幫幫TA吧，孩子快餓死了"
 
-#: src\utils.ts:60
+#: src\utils.ts:63
 msgid "Did you find Bastion useful? We need your support!"
 msgstr "你覺得Bastion好用麼？我們需要你的支持！"
 
-#: src\utils.ts:61
+#: src\utils.ts:64
 msgid "Enjoy Bastion? Help keep it online!"
 msgstr "你覺得Bastion好用麼？那幫幫TA吧，孩子快餓死了"
 
-#: src\utils.ts:62
+#: src\utils.ts:65
 msgid "Enjoy Bastion? Consider supporting us!"
 msgstr "覺得Bastion怎麼樣？請考慮捐助我們！"
 
-#: src\utils.ts:63
+#: src\utils.ts:66
 msgid "Found what you were looking for? Consider supporting us!"
 msgstr "找到你要的東西了嗎？請考慮捐助我們！"
 
 #: src\commands\art.ts:63
-#: src\commands\price.ts:131
-#: src\commands\rush-duel.ts:172
-#: src\commands\rush-duel.ts:203
+#: src\commands\price.ts:132
+#: src\commands\rush-duel.ts:171
+#: src\commands\rush-duel.ts:202
 #: src\commands\search.ts:64
-#: src\events\message-search.ts:258
+#: src\events\message-search.ts:265
 #, javascript-format
 msgid "Could not find a card matching `${ input }`!"
 msgstr "查無此卡：`${ input }`"
@@ -163,11 +163,7 @@ msgstr ""
 msgid "Discord Community locale for this server: ${ interaction.guildLocale }"
 msgstr ""
 
-#: src\commands\locale.ts:89
-#, javascript-format
-msgid "Locale override for this direct message: ${ override }"
-msgstr ""
-
+#: src\commands\locale-user.ts:76
 #: src\commands\locale.ts:92
 #, javascript-format
 msgid "Your Discord locale: ${ interaction.locale }"
@@ -205,18 +201,8 @@ msgstr ""
 msgid "Sorry, you must have the Manage Server permission to do this. If you think this is an error, contact your server admin or report a bug."
 msgstr ""
 
-#: src\commands\locale.ts:146
-#, javascript-format
-msgid "Locale for this direct message overridden with ${ locale }. Your Discord setting is ${ interaction.locale }."
-msgstr ""
-
-#: src\commands\locale.ts:150
-#, javascript-format
-msgid "Locale for this direct message reset to Discord default. Your Discord setting is ${ interaction.locale }."
-msgstr ""
-
-#: src\commands\ping.ts:40
-#: src\events\message-ping.ts:112
+#: src\commands\ping.ts:42
+#: src\events\message-ping.ts:110
 #, javascript-format
 msgid "Total latency: ${ latency } ms"
 msgstr "延遲${ latency }ms"
@@ -226,148 +212,131 @@ msgstr "延遲${ latency }ms"
 msgid "Could not find a Yugipedia page named `${ page }`."
 msgstr "Yugipedia上找不到`${ page }`"
 
-#: src\commands\deck.ts:244
+#: src\commands\deck.ts:205
 #, javascript-format
 msgid "${ counts.Monster } Monster"
 msgid_plural "${ counts.Monster } Monsters"
 msgstr[0] "${ counts.Monster }張怪獸卡"
 
-#: src\commands\deck.ts:247
+#: src\commands\deck.ts:208
 #, javascript-format
 msgid "${ counts.Spell } Spell"
 msgid_plural "${ counts.Spell } Spells"
 msgstr[0] "${ counts.Spell }張魔法卡"
 
-#: src\commands\deck.ts:250
+#: src\commands\deck.ts:211
 #, javascript-format
 msgid "${ counts.Trap } Trap"
 msgid_plural "${ counts.Trap } Traps"
 msgstr[0] "${ counts.Trap }張陷阱卡"
 
-#: src\commands\deck.ts:278
+#: src\commands\deck.ts:239
 msgid "Your Deck"
 msgstr "你的卡組"
 
-#: src\commands\deck.ts:283
+#: src\commands\deck.ts:244
 #, javascript-format
 msgid "Main Deck (${ deck.main.length } card — ${ countDetail })"
 msgid_plural "Main Deck (${ deck.main.length } cards — ${ countDetail })"
 msgstr[0] "牌組（${ deck.main.length })張 — ${ countDetail }）"
 
-#: src\commands\deck.ts:297
+#: src\commands\deck.ts:258
 #, javascript-format
 msgid "Extra Deck (${ deck.extra.length } card — ${ countDetail })"
 msgid_plural "Extra Deck (${ deck.extra.length } cards — ${ countDetail })"
 msgstr[0] "額外卡組（${ deck.extra.length }張 — ${ countDetail }）"
 
-#: src\commands\deck.ts:311
+#: src\commands\deck.ts:272
 #, javascript-format
 msgid "Side Deck (${ deck.side.length } card — ${ countDetail })"
 msgid_plural "Side Deck (${ deck.side.length } cards — ${ countDetail })"
 msgstr[0] "備牌（${ deck.side.length }張 — ${ countDetail }）"
 
-#: src\commands\deck.ts:290
+#: src\commands\deck.ts:251
 msgid "Main Deck (continued)"
 msgstr "牌組（續）"
 
-#: src\commands\deck.ts:304
+#: src\commands\deck.ts:265
 msgid "Extra Deck (continued)"
 msgstr "額外卡組（續）"
 
-#: src\commands\deck.ts:318
+#: src\commands\deck.ts:279
 msgid "Side Deck (continued)"
 msgstr "備牌（續）"
 
-#: src\commands\deck.ts:407
+#: src\commands\deck.ts:347
 msgid "Error: Your deck is empty."
 msgstr "錯誤：卡組是空的。"
 
-#: src\commands\ping.ts:36
-#: src\events\message-ping.ts:47
+#: src\commands\ping.ts:38
+#: src\events\message-ping.ts:45
 #, javascript-format
 msgid "Average WebSocket ping (new instance): ${ ping } ms"
 msgstr ""
 
-#: src\events\message-ping.ts:49
+#: src\events\message-ping.ts:47
 msgid "Free and open source _Yu-Gi-Oh!_ bot"
 msgstr "自由開源遊戲王聊天機器人"
 
-#: src\events\message-ping.ts:72
+#: src\events\message-ping.ts:70
 #, javascript-format
 msgid "Revision: ${ process.env.BOT_REVISION }."
 msgstr "修訂：${ process.env.BOT_REVISION }"
 
-#: src\commands\deck.ts:328
+#: src\commands\deck.ts:289
 msgid ".ydk files must have the .ydk extension!"
 msgstr ""
 
-#: src\commands\deck.ts:331
+#: src\commands\deck.ts:292
 msgid ".ydk files should not be larger than 1 KB!"
 msgstr ""
 
-#: src\commands\deck.ts:321
+#: src\commands\deck.ts:282
 msgid "ydke URL"
 msgstr ""
 
 #: src\card.ts:455
-#: src\rush-duel.ts:61
+#: src\rush-duel.ts:75
 #. Forbidden/Limited Lists or Limit Regulations in the OCG
 #, javascript-format
 msgid "**Limit**: ${ limitRegulationDisplay }"
 msgstr "**限制**: ${ limitRegulationDisplay }"
 
-#: src\commands\price.ts:69
+#: src\commands\price.ts:70
 msgid "TCGPlayer"
 msgstr ""
 
-#: src\commands\price.ts:70
+#: src\commands\price.ts:71
 msgid "Cardmarket"
 msgstr ""
 
-#: src\commands\price.ts:147
+#: src\commands\price.ts:148
 msgid "No market price"
 msgstr ""
 
-#: src\commands\price.ts:155
+#: src\commands\price.ts:156
 #, javascript-format
 msgid "Prices for ${ card.name[resultLanguage] } - ${ vendorName }"
 msgstr ""
 
-#: src\commands\price.ts:169
+#: src\commands\price.ts:170
 #, javascript-format
 msgid "Could not find prices for `${ name }`!"
 msgstr ""
 
-#: src\commands\deck.ts:425
-#. prepare interaction button for FTP upload
+#: src\commands\deck.ts:363
 msgid "Upload to YGOPRODECK"
 msgstr "上傳至YGOPRODECK"
 
-#: src\commands\deck.ts:483
-#. disable original button
-#. prepare row to disable button on original message
-msgid "Upload Complete"
-msgstr "上傳成功"
-
-#: src\commands\deck.ts:470
-msgid "Deck upload failed!"
-msgstr "上傳失敗"
-
-#: src\commands\deck.ts:491
-#. reply in affirmation
-#, javascript-format
-msgid "Deck successfully uploaded to <${ url }>!"
-msgstr "卡組成功上傳到<${ url }>!"
-
-#: src\events\message-search.ts:264
+#: src\events\message-search.ts:271
 msgid "💬 Translations missing?"
 msgstr "💬缺少翻譯？"
 
-#: src\events\message-search.ts:265
+#: src\events\message-search.ts:272
 msgid "Help translate Bastion at the links above."
 msgstr "在以上的網址幫忙翻譯Bastion"
 
-#: src\events\message-ping.ts:50
+#: src\events\message-ping.ts:48
 msgid ""
 "❓ Help documentation on [GitHub](https://github.com/DawnbrandBots/bastion-bot), or use `.commands` and `.help`.\n"
 "🟢 Licence: [GNU AGPL 3.0+](https://choosealicense.com/licenses/agpl-3.0/).\n"
@@ -383,27 +352,27 @@ msgid ""
 "💬 Translations missing? Help translate Bastion on [GitHub](https://github.com/DawnbrandBots/bastion-bot)."
 msgstr ""
 
-#: src\events\message-search.ts:256
-#: src\events\message-search.ts:294
+#: src\events\message-search.ts:263
+#: src\events\message-search.ts:302
 #, javascript-format
 msgid "Search type: ${ localisedType }"
 msgstr "搜索類型：${ localisedType }"
 
-#: src\events\message-search.ts:236
+#: src\events\message-search.ts:242
 #, javascript-format
 msgid "Search language: **${ localisedInputLanguage }** (${ inputLanguage }). Check defaults with </locale get:${ id }> and configure with </locale set:${ id }>"
 msgstr ""
 
-#: src\events\message-ping.ts:95
+#: src\events\message-ping.ts:93
 msgid "⚠️ You pinged me, but I am missing permissions in the channel!"
 msgstr ""
 
-#: src\events\message-ping.ts:98
-#: src\events\message-search.ts:332
+#: src\events\message-ping.ts:96
+#: src\events\message-search.ts:340
 msgid "Please have a server administrator [fix this](https://github.com/DawnbrandBots/bastion-bot#discord-permissions)."
 msgstr ""
 
-#: src\events\message-search.ts:329
+#: src\events\message-search.ts:337
 msgid "⚠️ I am missing permissions in the channel!"
 msgstr ""
 
@@ -422,32 +391,31 @@ msgstr ""
 msgid "Something went wrong searching Yugipedia for `${ page }`."
 msgstr ""
 
-#: src\rush-duel.ts:40
+#: src\rush-duel.ts:49
 #, javascript-format
 msgid "[Official Konami DB](${ official }) | [Rulings (Japanese)](${ rulings }) | [Yugipedia](${ yugipedia }) | [RushCard](${ rushcard })"
 msgstr "[K社官方數據庫](${ official }) | [事務局FAQ](${ rulings }) | [Yugipedia](${ yugipedia }) | [YGOPRODECK](${ ygoprodeck })"
 
-#: src\rush-duel.ts:43
+#: src\rush-duel.ts:52
 #, javascript-format
 msgid "[Yugipedia](${ yugipedia }) | [RushCard](${ rushcard })"
 msgstr "[Yugipedia](${ yugipedia }) | [RushCard](${ rushcard })"
 
-#: src\rush-duel.ts:57
+#: src\rush-duel.ts:71
 msgid "__**LEGEND**__"
 msgstr ""
 
-#: src\rush-duel.ts:99
+#: src\rush-duel.ts:110
 #, javascript-format
 msgid "**MAXIMUM ATK**: ${ card.maximum_atk }"
 msgstr ""
 
-#: src\rush-duel.ts:146
+#: src\rush-duel.ts:158
 #, javascript-format
 msgid "Konami ID #${ card.konami_id }"
 msgstr "官方編號${ card.konami_id }"
 
 #: src\art.ts:129
-#: src\commands\deck.ts:451
 msgid "Buttons can only be used by the user who called Bastion."
 msgstr ""
 
@@ -456,14 +424,32 @@ msgstr ""
 msgid "**Master Duel rarity**: ${ rarityIcon } ${ localizedRarity }"
 msgstr "**稀有度 (Master Duel)**: ${ rarityIcon } ${ localizedRarity }"
 
-#: src\rush-duel.ts:205
+#: src\rush-duel.ts:217
 #, javascript-format
 msgid "Using ${ searchTrigger }, you can search for Rush Duel cards directly in messages without autocomplete"
 msgstr ""
 
-#: src\events\message-search.ts:296
+#: src\events\message-search.ts:304
 #, javascript-format
 msgid "Could not find a Rush Duel card matching `${ input }`!"
+msgstr ""
+
+#: src\commands\locale-user.ts:73
+#: src\commands\locale.ts:89
+#, javascript-format
+msgid "Locale override for your direct messages: ${ override }"
+msgstr ""
+
+#: src\commands\locale-user.ts:83
+#: src\commands\locale.ts:146
+#, javascript-format
+msgid "Locale for your direct messages overridden with ${ locale }. Your Discord setting is ${ interaction.locale }."
+msgstr ""
+
+#: src\commands\locale-user.ts:87
+#: src\commands\locale.ts:150
+#, javascript-format
+msgid "Locale for your direct messages reset to Discord default. Your Discord setting is ${ interaction.locale }."
 msgstr ""
 
 #: src\card.ts:40
@@ -830,60 +816,60 @@ msgctxt "master-duel-rarity"
 msgid "Ultra Rare (UR)"
 msgstr "究極稀有（ＵＲ）"
 
-#: src\card.ts:513
-#: src\card.ts:524
-#: src\rush-duel.ts:127
+#: src\card.ts:517
+#: src\card.ts:528
+#: src\rush-duel.ts:138
 msgctxt "card-embed"
 msgid "Card Text"
 msgstr "卡片文本"
 
-#: src\card.ts:518
+#: src\card.ts:522
 msgctxt "card-embed"
 msgid "Pendulum Effect"
 msgstr "靈擺效果"
 
-#: src\card.ts:539
+#: src\card.ts:545
 msgctxt "card-embed"
 msgid "Card Effect"
 msgstr "卡片效果"
 
-#: src\rush-duel.ts:118
-#: src\rush-duel.ts:139
+#: src\rush-duel.ts:129
+#: src\rush-duel.ts:151
 msgctxt "card-embed"
 msgid "[REQUIREMENT]"
 msgstr "【條件】"
 
-#: src\rush-duel.ts:119
-#: src\rush-duel.ts:140
+#: src\rush-duel.ts:130
+#: src\rush-duel.ts:152
 msgctxt "card-embed"
 msgid "[EFFECT]"
 msgstr "【效果】"
 
-#: src\rush-duel.ts:121
+#: src\rush-duel.ts:132
 msgctxt "card-embed"
 msgid "[CONTINUOUS EFFECT]"
 msgstr "【永續效果】"
 
-#: src\rush-duel.ts:123
+#: src\rush-duel.ts:134
 msgctxt "card-embed"
 msgid "[MULTI-CHOICE EFFECT]"
 msgstr "【選擇效果】"
 
-#: src\locale.ts:71
+#: src\locale.ts:74
 msgctxt "command-option"
 msgid "result-language"
 msgstr "查詢結果語言"
 
-#: src\locale.ts:131
+#: src\locale.ts:140
 msgctxt "command-option"
 msgid "input-language"
 msgstr "輸入語言"
 
-#: src\commands\rush-duel.ts:68
-#: src\commands\rush-duel.ts:80
-#: src\locale.ts:147
-#: src\locale.ts:165
-#: src\locale.ts:181
+#: src\commands\rush-duel.ts:67
+#: src\commands\rush-duel.ts:79
+#: src\locale.ts:156
+#: src\locale.ts:174
+#: src\locale.ts:190
 msgctxt "command-option"
 msgid "input"
 msgstr "輸入"
@@ -898,59 +884,61 @@ msgctxt "command-option"
 msgid "page"
 msgstr ""
 
-#: src\commands\help.ts:52
+#: src\commands\help.ts:55
 msgctxt "command-option"
 msgid "command"
 msgstr ""
 
-#: src\commands\deck.ts:126
+#: src\commands\deck.ts:87
 msgctxt "command-option"
 msgid "url"
 msgstr ""
 
-#: src\commands\deck.ts:132
+#: src\commands\deck.ts:93
 msgctxt "command-option"
 msgid "file"
 msgstr ""
 
-#: src\commands\deck.ts:138
-#: src\commands\deck.ts:144
+#: src\commands\deck.ts:99
+#: src\commands\deck.ts:105
 msgctxt "command-option"
 msgid "deck"
 msgstr ""
 
-#: src\commands\deck.ts:150
+#: src\commands\deck.ts:111
 msgctxt "command-option"
 msgid "public"
 msgstr ""
 
-#: src\commands\deck.ts:157
+#: src\commands\deck.ts:118
 msgctxt "command-option"
 msgid "stacked"
 msgstr ""
 
-#: src\locale.ts:142
+#: src\locale.ts:151
 msgctxt "command-option"
 msgid "name"
 msgstr ""
 
-#: src\locale.ts:160
+#: src\locale.ts:169
 msgctxt "command-option"
 msgid "password"
 msgstr ""
 
-#: src\commands\rush-duel.ts:73
-#: src\events\message-search.ts:293
-#: src\locale.ts:176
+#: src\commands\rush-duel.ts:72
+#: src\events\message-search.ts:301
+#: src\locale.ts:185
 msgctxt "command-option"
 msgid "konami-id"
 msgstr ""
 
+#: src\commands\locale-user.ts:36
 #: src\commands\locale.ts:30
 msgctxt "command-option"
 msgid "get"
 msgstr ""
 
+#: src\commands\locale-user.ts:41
 #: src\commands\locale.ts:35
 msgctxt "command-option"
 msgid "set"
@@ -961,42 +949,64 @@ msgctxt "command-option"
 msgid "scope"
 msgstr ""
 
+#: src\commands\locale-user.ts:46
 #: src\commands\locale.ts:48
 msgctxt "command-option"
 msgid "locale"
 msgstr ""
 
-#: src\commands\price.ts:94
+#: src\commands\price.ts:95
 msgctxt "command-option"
 msgid "vendor"
 msgstr ""
 
-#: src\commands\rush-duel.ts:63
+#: src\commands\rush-duel.ts:62
 msgctxt "command-option"
 msgid "search"
 msgstr ""
 
-#: src\commands\rush-duel.ts:85
+#: src\commands\rush-duel.ts:84
 msgctxt "command-option"
 msgid "random"
 msgstr ""
 
-#: src\commands\rush-duel.ts:90
+#: src\commands\rush-duel.ts:89
 msgctxt "command-option"
 msgid "art"
 msgstr ""
 
-#: src\commands\query.ts:36
+#: src\commands\query.ts:35
 msgctxt "command-option"
 msgid "lucene"
 msgstr ""
 
-#: src\locale.ts:74
+#: src\commands\metagame.ts:209
+msgctxt "command-option"
+msgid "strategies"
+msgstr ""
+
+#: src\commands\metagame.ts:234
+#: src\commands\metagame.ts:274
+msgctxt "command-option"
+msgid "format"
+msgstr ""
+
+#: src\commands\metagame.ts:240
+msgctxt "command-option"
+msgid "cards"
+msgstr ""
+
+#: src\commands\metagame.ts:310
+msgctxt "command-option"
+msgid "date-range"
+msgstr ""
+
+#: src\locale.ts:77
 msgctxt "command-option-description"
 msgid "The output language for the card embed, overriding other settings."
 msgstr "卡片查詢結果的語言，覆蓋其他設置"
 
-#: src\locale.ts:132
+#: src\locale.ts:141
 msgctxt "command-option-description"
 msgid "The language to search in, defaulting to the result language."
 msgstr "查詢用的語言，默認與查詢結果語言相同"
@@ -1006,37 +1016,37 @@ msgctxt "command-option-description"
 msgid "The name of the Yugipedia page you want to search for."
 msgstr "你想要查詢的Yugipedia頁面的名字"
 
-#: src\commands\help.ts:55
+#: src\commands\help.ts:58
 msgctxt "command-option-description"
 msgid "The name of a specific Slash Command."
 msgstr ""
 
-#: src\commands\deck.ts:129
+#: src\commands\deck.ts:90
 msgctxt "command-option-description"
 msgid "View a deck by entering a ydke:// URL."
 msgstr ""
 
-#: src\commands\deck.ts:135
+#: src\commands\deck.ts:96
 msgctxt "command-option-description"
 msgid "View a deck by uploading a .ydk file."
 msgstr ""
 
-#: src\commands\deck.ts:141
+#: src\commands\deck.ts:102
 msgctxt "command-option-description"
 msgid "The ydke:// URL of the deck you want to view."
 msgstr ""
 
-#: src\commands\deck.ts:147
+#: src\commands\deck.ts:108
 msgctxt "command-option-description"
 msgid "The .ydk file of the deck you want to view."
 msgstr ""
 
-#: src\commands\deck.ts:153
+#: src\commands\deck.ts:114
 msgctxt "command-option-description"
 msgid "Whether to display the deck details publicly in chat. This is false by default."
 msgstr ""
 
-#: src\commands\deck.ts:160
+#: src\commands\deck.ts:121
 msgctxt "command-option-description"
 msgid "Whether to display the deck sections as one stacked column. This is false (side-by-side) by default."
 msgstr ""
@@ -1046,8 +1056,8 @@ msgctxt "command-option-description"
 msgid "Display the art for the card with this name."
 msgstr ""
 
-#: src\commands\rush-duel.ts:69
-#: src\locale.ts:148
+#: src\commands\rush-duel.ts:68
+#: src\locale.ts:157
 msgctxt "command-option-description"
 msgid "Card name, fuzzy matching supported."
 msgstr ""
@@ -1057,7 +1067,7 @@ msgctxt "command-option-description"
 msgid "Display the art for the card with this password."
 msgstr ""
 
-#: src\locale.ts:167
+#: src\locale.ts:176
 msgctxt "command-option-description"
 msgid "Card password, the eight-digit number printed on the bottom left corner."
 msgstr ""
@@ -1067,8 +1077,8 @@ msgctxt "command-option-description"
 msgid "Display the art for the card with this official database ID."
 msgstr ""
 
-#: src\commands\rush-duel.ts:81
-#: src\locale.ts:182
+#: src\commands\rush-duel.ts:80
+#: src\locale.ts:191
 msgctxt "command-option-description"
 msgid "Konami's official card database identifier."
 msgstr ""
@@ -1108,22 +1118,22 @@ msgctxt "command-option-description"
 msgid "The new default language to use in this channel or server."
 msgstr ""
 
-#: src\commands\price.ts:98
+#: src\commands\price.ts:99
 msgctxt "command-option-description"
 msgid "Display the price for the card with this name."
 msgstr ""
 
-#: src\commands\price.ts:102
+#: src\commands\price.ts:103
 msgctxt "command-option-description"
 msgid "Display the price for the card with this password."
 msgstr ""
 
-#: src\commands\price.ts:105
+#: src\commands\price.ts:106
 msgctxt "command-option-description"
 msgid "Display the price for the card with this official database ID."
 msgstr ""
 
-#: src\commands\price.ts:95
+#: src\commands\price.ts:96
 msgctxt "command-option-description"
 msgid "The vendor to fetch the price data from."
 msgstr ""
@@ -1133,29 +1143,70 @@ msgctxt "command-option-description"
 msgid "The English name of the card you're looking for."
 msgstr ""
 
-#: src\commands\rush-duel.ts:64
+#: src\commands\rush-duel.ts:63
 msgctxt "command-option-description"
 msgid "Find all information for the Rush Duel card with this name."
 msgstr ""
 
-#: src\commands\rush-duel.ts:75
+#: src\commands\rush-duel.ts:74
 msgctxt "command-option-description"
 msgid "Find all information for the Rush Duel card with this official database ID."
 msgstr ""
 
-#: src\commands\rush-duel.ts:86
+#: src\commands\rush-duel.ts:85
 msgctxt "command-option-description"
 msgid "Get a random Rush Duel card."
 msgstr ""
 
-#: src\commands\rush-duel.ts:91
+#: src\commands\rush-duel.ts:90
 msgctxt "command-option-description"
 msgid "Display just the art for the Rush Duel card with this name."
 msgstr ""
 
-#: src\commands\query.ts:37
+#: src\commands\query.ts:36
 msgctxt "command-option-description"
 msgid "Lucene query on YAML Yugi"
+msgstr ""
+
+#: src\commands\locale-user.ts:37
+msgctxt "command-option-description"
+msgid "Check your user-installed Bastion's locale."
+msgstr ""
+
+#: src\commands\locale-user.ts:42
+msgctxt "command-option-description"
+msgid "Configure your user-installed Bastion's locale."
+msgstr ""
+
+#: src\commands\locale-user.ts:47
+msgctxt "command-option-description"
+msgid "The new default language to use for user-installed Bastion."
+msgstr ""
+
+#: src\commands\metagame.ts:212
+msgctxt "command-option-description"
+msgid "Show the top competitive strategies in tournaments and the Master Duel ranked ladder."
+msgstr ""
+
+#: src\commands\metagame.ts:214
+msgctxt "command-option-description"
+msgid "Show the top competitive strategies in tournaments."
+msgstr ""
+
+#: src\commands\metagame.ts:235
+#: src\commands\metagame.ts:275
+msgctxt "command-option-description"
+msgid "Game region."
+msgstr ""
+
+#: src\commands\metagame.ts:242
+msgctxt "command-option-description"
+msgid "Show the most popular cards in tournaments and the Master Duel ranked ladder."
+msgstr ""
+
+#: src\commands\metagame.ts:312
+msgctxt "command-option-description"
+msgid "Limit card usage statistics to this date range. Has no effect for Master Duel."
 msgstr ""
 
 #: src\commands\art.ts:36
@@ -1163,7 +1214,7 @@ msgctxt "command-name"
 msgid "art"
 msgstr "卡圖"
 
-#: src\commands\ping.ts:23
+#: src\commands\ping.ts:25
 msgctxt "command-name"
 msgid "ping"
 msgstr ""
@@ -1178,12 +1229,12 @@ msgctxt "command-name"
 msgid "yugipedia"
 msgstr ""
 
-#: src\commands\help.ts:49
+#: src\commands\help.ts:52
 msgctxt "command-name"
 msgid "help"
 msgstr ""
 
-#: src\commands\deck.ts:119
+#: src\commands\deck.ts:80
 msgctxt "command-name"
 msgid "deck"
 msgstr ""
@@ -1198,24 +1249,34 @@ msgctxt "command-name"
 msgid "locale"
 msgstr ""
 
-#: src\commands\random.ts:44
+#: src\commands\random.ts:43
 msgctxt "command-name"
 msgid "random"
 msgstr ""
 
-#: src\commands\price.ts:89
+#: src\commands\price.ts:90
 msgctxt "command-name"
 msgid "price"
 msgstr ""
 
-#: src\commands\rush-duel.ts:58
+#: src\commands\rush-duel.ts:57
 msgctxt "command-name"
 msgid "rush-duel"
 msgstr ""
 
-#: src\commands\query.ts:30
+#: src\commands\query.ts:29
 msgctxt "command-name"
 msgid "query"
+msgstr ""
+
+#: src\commands\locale-user.ts:31
+msgctxt "command-name"
+msgid "locale-user"
+msgstr ""
+
+#: src\commands\metagame.ts:204
+msgctxt "command-name"
+msgid "metagame"
 msgstr ""
 
 #: src\commands\art.ts:37
@@ -1223,7 +1284,7 @@ msgctxt "command-description"
 msgid "Display the art for a card!"
 msgstr "顯示卡片圖。"
 
-#: src\commands\ping.ts:24
+#: src\commands\ping.ts:26
 msgctxt "command-description"
 msgid "Test latency to the new bot instance."
 msgstr "測試新bot實例的延遲"
@@ -1238,12 +1299,12 @@ msgctxt "command-description"
 msgid "Search the Yugipedia wiki for a page and link to it."
 msgstr "搜索Yugipedia頁面與鏈接"
 
-#: src\commands\help.ts:50
+#: src\commands\help.ts:53
 msgctxt "command-description"
 msgid "Get help with a Slash Command."
 msgstr ""
 
-#: src\commands\deck.ts:122
+#: src\commands\deck.ts:83
 msgctxt "command-description"
 msgid "Display a deck list from ydke:// or .ydk format, exported from a number of deck building programs."
 msgstr ""
@@ -1258,24 +1319,34 @@ msgctxt "command-description"
 msgid "Check or set Bastion's locale for this channel or server."
 msgstr ""
 
-#: src\commands\random.ts:45
+#: src\commands\random.ts:44
 msgctxt "command-description"
 msgid "Get a random Yu-Gi-Oh! card."
 msgstr ""
 
-#: src\commands\price.ts:90
+#: src\commands\price.ts:91
 msgctxt "command-description"
 msgid "Display the price for a card!"
 msgstr ""
 
-#: src\commands\rush-duel.ts:59
+#: src\commands\rush-duel.ts:58
 msgctxt "command-description"
 msgid "Find information on Rush Duel cards."
 msgstr ""
 
-#: src\commands\query.ts:31
+#: src\commands\query.ts:30
 msgctxt "command-description"
 msgid "Advanced search prototype"
+msgstr ""
+
+#: src\commands\locale-user.ts:32
+msgctxt "command-description"
+msgid "Check or set user-installed Bastion's locale."
+msgstr ""
+
+#: src\commands\metagame.ts:205
+msgctxt "command-description"
+msgid "Show statistics on the current competitive state of play."
 msgstr ""
 
 #: src\commands\locale.ts:43
@@ -1288,7 +1359,71 @@ msgctxt "command-option-choice"
 msgid "server"
 msgstr ""
 
+#: src\commands\locale-user.ts:49
 #: src\commands\locale.ts:51
 msgctxt "command-option-choice"
 msgid "Discord default"
+msgstr ""
+
+#: src\commands\metagame.ts:219
+#: src\commands\metagame.ts:251
+msgctxt "command-option-choice"
+msgid "TCG"
+msgstr ""
+
+#: src\commands\metagame.ts:220
+#: src\commands\metagame.ts:255
+msgctxt "command-option-choice"
+msgid "OCG"
+msgstr ""
+
+#: src\commands\metagame.ts:221
+#: src\commands\metagame.ts:259
+msgctxt "command-option-choice"
+msgid "OCG (Asian-English)"
+msgstr ""
+
+#: src\commands\metagame.ts:228
+msgctxt "command-option-choice"
+msgid "Master Duel Diamond+ tier list"
+msgstr ""
+
+#: src\commands\metagame.ts:261
+msgctxt "command-option-choice"
+msgid "Master Duel ranked ladder"
+msgstr ""
+
+#: src\commands\metagame.ts:283
+msgctxt "command-option-choice"
+msgid "Current format"
+msgstr ""
+
+#: src\commands\metagame.ts:287
+msgctxt "command-option-choice"
+msgid "Since last Forbidden/Limited List"
+msgstr ""
+
+#: src\commands\metagame.ts:291
+msgctxt "command-option-choice"
+msgid "Last 7 days"
+msgstr ""
+
+#: src\commands\metagame.ts:295
+msgctxt "command-option-choice"
+msgid "Last 14 days"
+msgstr ""
+
+#: src\commands\metagame.ts:299
+msgctxt "command-option-choice"
+msgid "Last 30 days"
+msgstr ""
+
+#: src\commands\metagame.ts:303
+msgctxt "command-option-choice"
+msgid "Last three months"
+msgstr ""
+
+#: src\commands\metagame.ts:307
+msgctxt "command-option-choice"
+msgid "Last six months"
 msgstr ""

--- a/translations/zh-TW.po
+++ b/translations/zh-TW.po
@@ -6,50 +6,33 @@ msgstr ""
 "MIME-Version: 1.0\n"
 "Content-Transfer-Encoding: 8bit\n"
 
-#: src\card.ts:416
-#: src\rush-duel.ts:39
+#: src\card.ts:412
+#: src\rush-duel.ts:48
 msgid "🔗 Links"
 msgstr "鏈接"
 
-#: src\card.ts:417
+#: src\card.ts:413
 #, javascript-format
 msgid "[Official Konami DB](${ official }) | [OCG Rulings](${ rulings }) | [Yugipedia](${ yugipedia }) | [YGOPRODECK](${ ygoprodeck })"
 msgstr "[K社官方數據庫](${ official }) | [事務局FAQ](${ rulings }) | [Yugipedia](${ yugipedia }) | [YGOPRODECK](${ ygoprodeck })"
 
-#: src\card.ts:420
+#: src\card.ts:416
 #, javascript-format
 msgid "[Yugipedia](${ yugipedia }) | [YGOPRODECK](${ ygoprodeck })"
 msgstr "[Yugipedia](${ yugipedia }) | [YGOPRODECK](${ ygoprodeck })"
 
-#: src\card.ts:489
-#: src\rush-duel.ts:92
+#: src\card.ts:490
+#: src\rush-duel.ts:103
 #, javascript-format
 msgid "**Type**: ${ raceIcon } ${ localizedMonsterTypeLine }"
 msgstr "**種族**: ${ raceIcon } ${ localizedMonsterTypeLine }"
 
-#: src\card.ts:491
-#: src\rush-duel.ts:94
-#, javascript-format
-msgid "**Attribute**: ${ AttributeIcon[card.attribute] } ${ localizedAttribute }"
-msgstr "**屬性**: ${ AttributeIcon[card.attribute] } ${ localizedAttribute }"
-
-#: src\card.ts:495
-#, javascript-format
-msgid "**Rank**: ${ Icon.Rank } ${ card.rank } **ATK**: ${ card.atk } **DEF**: ${ card.def }"
-msgstr "**階級**: ${ Icon.Rank } ${ card.rank } **攻擊力**: ${ card.atk } **守備力**: ${ card.def }"
-
-#: src\card.ts:498
+#: src\card.ts:500
 #, javascript-format
 msgid "**Link Rating**: ${ card.link_arrows.length } **ATK**: ${ card.atk } **Link Arrows**: ${ arrows }"
 msgstr "**連接數值**: ${ card.link_arrows.length } **攻擊力**: ${ card.atk } **連接標記**: ${ arrows }"
 
-#: src\card.ts:500
-#: src\rush-duel.ts:96
-#, javascript-format
-msgid "**Level**: ${ Icon.Level } ${ card.level } **ATK**: ${ card.atk } **DEF**: ${ card.def }"
-msgstr "**等級**: ${ Icon.Level } ${ card.level } **攻擊力**: ${ card.atk } **守備力**: ${ card.def }"
-
-#: src\card.ts:507
+#: src\card.ts:511
 #, javascript-format
 msgid "**Pendulum Scale**: ${ formattedScale }"
 msgstr "**靈擺刻度**: ${ formattedScale }"
@@ -70,7 +53,7 @@ msgid "Password: ${ card.password } | Not yet released"
 msgstr "卡片密碼: ${ card.password } | 未發行"
 
 #: src\card.ts:351
-#: src\rush-duel.ts:146
+#: src\rush-duel.ts:158
 msgid "Not yet released"
 msgstr "未發行"
 
@@ -79,64 +62,64 @@ msgstr "未發行"
 msgid "Placeholder ID: ${ card.fake_password }"
 msgstr "假卡密: ${ card.fake_password }"
 
-#: src\utils.ts:41
+#: src\utils.ts:44
 msgid "🛠️ This command is in development."
 msgstr "🛠️ 這個指令正在開發中"
 
-#: src\utils.ts:42
+#: src\utils.ts:45
 msgid "📨 Please send feedback to [our issue tracker](https://github.com/DawnbrandBots/bastion-bot) or the [support server](https://discord.gg/4aFuPyuE96)!"
 msgstr "📨 如有意見或建議請反饋至[GitHub issue](https://github.com/DawnbrandBots/bastion-bot)或者[Discord服務器](https://discord.gg/4aFuPyuE96)!"
 
-#: src\utils.ts:53
+#: src\utils.ts:56
 msgid "Please consider supporting us!"
 msgstr "請考慮捐助我們！"
 
-#: src\utils.ts:54
+#: src\utils.ts:57
 msgid "Help keep Bastion online!"
 msgstr "幫幫Bastion吧，寶寶快餓死了"
 
-#: src\utils.ts:55
+#: src\utils.ts:58
 msgid "Please help keep Bastion online!"
 msgstr "請幫幫Bastion吧，寶寶真的快餓死了"
 
-#: src\utils.ts:56
+#: src\utils.ts:59
 msgid "Was Bastion helpful? Consider supporting us!"
 msgstr "Bastion有用麼？請考慮捐助我們！"
 
-#: src\utils.ts:57
+#: src\utils.ts:60
 msgid "Was Bastion helpful? We need your support!"
 msgstr "Bastion有用麼？我們需要你的支持！"
 
-#: src\utils.ts:58
+#: src\utils.ts:61
 msgid "Did you find Bastion useful? Consider supporting us!"
 msgstr "你覺得Bastion好用麼？請考慮捐助我們！"
 
-#: src\utils.ts:59
+#: src\utils.ts:62
 msgid "Did you find Bastion useful? Help keep it online!"
 msgstr "你覺得Bastion好用麼？那幫幫TA吧，孩子快餓死了"
 
-#: src\utils.ts:60
+#: src\utils.ts:63
 msgid "Did you find Bastion useful? We need your support!"
 msgstr "你覺得Bastion好用麼？我們需要你的支持！"
 
-#: src\utils.ts:61
+#: src\utils.ts:64
 msgid "Enjoy Bastion? Help keep it online!"
 msgstr "你覺得Bastion好用麼？那幫幫TA吧，孩子快餓死了"
 
-#: src\utils.ts:62
+#: src\utils.ts:65
 msgid "Enjoy Bastion? Consider supporting us!"
 msgstr "覺得Bastion怎麼樣？請考慮捐助我們！"
 
-#: src\utils.ts:63
+#: src\utils.ts:66
 msgid "Found what you were looking for? Consider supporting us!"
 msgstr "找到你要的東西了嗎？請考慮捐助我們！"
 
 #: src\commands\art.ts:63
-#: src\commands\price.ts:131
-#: src\commands\rush-duel.ts:172
-#: src\commands\rush-duel.ts:203
+#: src\commands\price.ts:132
+#: src\commands\rush-duel.ts:171
+#: src\commands\rush-duel.ts:202
 #: src\commands\search.ts:64
-#: src\events\message-search.ts:258
+#: src\events\message-search.ts:265
 #, javascript-format
 msgid "Could not find a card matching `${ input }`!"
 msgstr "查無此卡：`${ input }`"
@@ -163,11 +146,7 @@ msgstr ""
 msgid "Discord Community locale for this server: ${ interaction.guildLocale }"
 msgstr ""
 
-#: src\commands\locale.ts:89
-#, javascript-format
-msgid "Locale override for this direct message: ${ override }"
-msgstr ""
-
+#: src\commands\locale-user.ts:76
 #: src\commands\locale.ts:92
 #, javascript-format
 msgid "Your Discord locale: ${ interaction.locale }"
@@ -205,18 +184,8 @@ msgstr ""
 msgid "Sorry, you must have the Manage Server permission to do this. If you think this is an error, contact your server admin or report a bug."
 msgstr ""
 
-#: src\commands\locale.ts:146
-#, javascript-format
-msgid "Locale for this direct message overridden with ${ locale }. Your Discord setting is ${ interaction.locale }."
-msgstr ""
-
-#: src\commands\locale.ts:150
-#, javascript-format
-msgid "Locale for this direct message reset to Discord default. Your Discord setting is ${ interaction.locale }."
-msgstr ""
-
-#: src\commands\ping.ts:40
-#: src\events\message-ping.ts:112
+#: src\commands\ping.ts:42
+#: src\events\message-ping.ts:110
 #, javascript-format
 msgid "Total latency: ${ latency } ms"
 msgstr "延遲${ latency }ms"
@@ -226,148 +195,131 @@ msgstr "延遲${ latency }ms"
 msgid "Could not find a Yugipedia page named `${ page }`."
 msgstr "Yugipedia上找不到`${ page }`"
 
-#: src\commands\deck.ts:244
+#: src\commands\deck.ts:205
 #, javascript-format
 msgid "${ counts.Monster } Monster"
 msgid_plural "${ counts.Monster } Monsters"
 msgstr[0] "${ counts.Monster }張怪獸卡"
 
-#: src\commands\deck.ts:247
+#: src\commands\deck.ts:208
 #, javascript-format
 msgid "${ counts.Spell } Spell"
 msgid_plural "${ counts.Spell } Spells"
 msgstr[0] "${ counts.Spell }張魔法卡"
 
-#: src\commands\deck.ts:250
+#: src\commands\deck.ts:211
 #, javascript-format
 msgid "${ counts.Trap } Trap"
 msgid_plural "${ counts.Trap } Traps"
 msgstr[0] "${ counts.Trap }張陷阱卡"
 
-#: src\commands\deck.ts:278
+#: src\commands\deck.ts:239
 msgid "Your Deck"
 msgstr "你的卡組"
 
-#: src\commands\deck.ts:283
+#: src\commands\deck.ts:244
 #, javascript-format
 msgid "Main Deck (${ deck.main.length } card — ${ countDetail })"
 msgid_plural "Main Deck (${ deck.main.length } cards — ${ countDetail })"
 msgstr[0] "牌組（${ deck.main.length })張 — ${ countDetail }）"
 
-#: src\commands\deck.ts:297
+#: src\commands\deck.ts:258
 #, javascript-format
 msgid "Extra Deck (${ deck.extra.length } card — ${ countDetail })"
 msgid_plural "Extra Deck (${ deck.extra.length } cards — ${ countDetail })"
 msgstr[0] "額外卡組（${ deck.extra.length }張 — ${ countDetail }）"
 
-#: src\commands\deck.ts:311
+#: src\commands\deck.ts:272
 #, javascript-format
 msgid "Side Deck (${ deck.side.length } card — ${ countDetail })"
 msgid_plural "Side Deck (${ deck.side.length } cards — ${ countDetail })"
 msgstr[0] "備牌（${ deck.side.length }張 — ${ countDetail }）"
 
-#: src\commands\deck.ts:290
+#: src\commands\deck.ts:251
 msgid "Main Deck (continued)"
 msgstr "牌組（續）"
 
-#: src\commands\deck.ts:304
+#: src\commands\deck.ts:265
 msgid "Extra Deck (continued)"
 msgstr "額外卡組（續）"
 
-#: src\commands\deck.ts:318
+#: src\commands\deck.ts:279
 msgid "Side Deck (continued)"
 msgstr "備牌（續）"
 
-#: src\commands\deck.ts:407
+#: src\commands\deck.ts:347
 msgid "Error: Your deck is empty."
 msgstr "錯誤：卡組是空的。"
 
-#: src\commands\ping.ts:36
-#: src\events\message-ping.ts:47
+#: src\commands\ping.ts:38
+#: src\events\message-ping.ts:45
 #, javascript-format
 msgid "Average WebSocket ping (new instance): ${ ping } ms"
 msgstr ""
 
-#: src\events\message-ping.ts:49
+#: src\events\message-ping.ts:47
 msgid "Free and open source _Yu-Gi-Oh!_ bot"
 msgstr "自由開源遊戲王聊天機器人"
 
-#: src\events\message-ping.ts:72
+#: src\events\message-ping.ts:70
 #, javascript-format
 msgid "Revision: ${ process.env.BOT_REVISION }."
 msgstr "修訂：${ process.env.BOT_REVISION }"
 
-#: src\commands\deck.ts:328
+#: src\commands\deck.ts:289
 msgid ".ydk files must have the .ydk extension!"
 msgstr ""
 
-#: src\commands\deck.ts:331
+#: src\commands\deck.ts:292
 msgid ".ydk files should not be larger than 1 KB!"
 msgstr ""
 
-#: src\commands\deck.ts:321
+#: src\commands\deck.ts:282
 msgid "ydke URL"
 msgstr ""
 
 #: src\card.ts:455
-#: src\rush-duel.ts:61
+#: src\rush-duel.ts:75
 #. Forbidden/Limited Lists or Limit Regulations in the OCG
 #, javascript-format
 msgid "**Limit**: ${ limitRegulationDisplay }"
 msgstr "**限制**: ${ limitRegulationDisplay }"
 
-#: src\commands\price.ts:69
+#: src\commands\price.ts:70
 msgid "TCGPlayer"
 msgstr ""
 
-#: src\commands\price.ts:70
+#: src\commands\price.ts:71
 msgid "Cardmarket"
 msgstr ""
 
-#: src\commands\price.ts:147
+#: src\commands\price.ts:148
 msgid "No market price"
 msgstr ""
 
-#: src\commands\price.ts:155
+#: src\commands\price.ts:156
 #, javascript-format
 msgid "Prices for ${ card.name[resultLanguage] } - ${ vendorName }"
 msgstr ""
 
-#: src\commands\price.ts:169
+#: src\commands\price.ts:170
 #, javascript-format
 msgid "Could not find prices for `${ name }`!"
 msgstr ""
 
-#: src\commands\deck.ts:425
-#. prepare interaction button for FTP upload
+#: src\commands\deck.ts:363
 msgid "Upload to YGOPRODECK"
 msgstr "上傳至YGOPRODECK"
 
-#: src\commands\deck.ts:483
-#. disable original button
-#. prepare row to disable button on original message
-msgid "Upload Complete"
-msgstr "上傳成功"
-
-#: src\commands\deck.ts:470
-msgid "Deck upload failed!"
-msgstr "上傳失敗"
-
-#: src\commands\deck.ts:491
-#. reply in affirmation
-#, javascript-format
-msgid "Deck successfully uploaded to <${ url }>!"
-msgstr "卡組成功上傳到<${ url }>!"
-
-#: src\events\message-search.ts:264
+#: src\events\message-search.ts:271
 msgid "💬 Translations missing?"
 msgstr "💬缺少翻譯？"
 
-#: src\events\message-search.ts:265
+#: src\events\message-search.ts:272
 msgid "Help translate Bastion at the links above."
 msgstr "在以上的網址幫忙翻譯Bastion"
 
-#: src\events\message-ping.ts:50
+#: src\events\message-ping.ts:48
 msgid ""
 "❓ Help documentation on [GitHub](https://github.com/DawnbrandBots/bastion-bot), or use `.commands` and `.help`.\n"
 "🟢 Licence: [GNU AGPL 3.0+](https://choosealicense.com/licenses/agpl-3.0/).\n"
@@ -383,27 +335,27 @@ msgid ""
 "💬 Translations missing? Help translate Bastion on [GitHub](https://github.com/DawnbrandBots/bastion-bot)."
 msgstr ""
 
-#: src\events\message-search.ts:256
-#: src\events\message-search.ts:294
+#: src\events\message-search.ts:263
+#: src\events\message-search.ts:302
 #, javascript-format
 msgid "Search type: ${ localisedType }"
 msgstr "搜索類型：${ localisedType }"
 
-#: src\events\message-search.ts:236
+#: src\events\message-search.ts:242
 #, javascript-format
 msgid "Search language: **${ localisedInputLanguage }** (${ inputLanguage }). Check defaults with </locale get:${ id }> and configure with </locale set:${ id }>"
 msgstr ""
 
-#: src\events\message-ping.ts:95
+#: src\events\message-ping.ts:93
 msgid "⚠️ You pinged me, but I am missing permissions in the channel!"
 msgstr ""
 
-#: src\events\message-ping.ts:98
-#: src\events\message-search.ts:332
+#: src\events\message-ping.ts:96
+#: src\events\message-search.ts:340
 msgid "Please have a server administrator [fix this](https://github.com/DawnbrandBots/bastion-bot#discord-permissions)."
 msgstr ""
 
-#: src\events\message-search.ts:329
+#: src\events\message-search.ts:337
 msgid "⚠️ I am missing permissions in the channel!"
 msgstr ""
 
@@ -422,48 +374,82 @@ msgstr ""
 msgid "Something went wrong searching Yugipedia for `${ page }`."
 msgstr ""
 
-#: src\rush-duel.ts:40
+#: src\rush-duel.ts:49
 #, javascript-format
 msgid "[Official Konami DB](${ official }) | [Rulings (Japanese)](${ rulings }) | [Yugipedia](${ yugipedia }) | [RushCard](${ rushcard })"
 msgstr "[K社官方數據庫](${ official }) | [事務局FAQ](${ rulings }) | [Yugipedia](${ yugipedia }) | [YGOPRODECK](${ ygoprodeck })"
 
-#: src\rush-duel.ts:43
+#: src\rush-duel.ts:52
 #, javascript-format
 msgid "[Yugipedia](${ yugipedia }) | [RushCard](${ rushcard })"
 msgstr "[Yugipedia](${ yugipedia }) | [RushCard](${ rushcard })"
 
-#: src\rush-duel.ts:57
+#: src\rush-duel.ts:71
 msgid "__**LEGEND**__"
 msgstr ""
 
-#: src\rush-duel.ts:99
+#: src\rush-duel.ts:110
 #, javascript-format
 msgid "**MAXIMUM ATK**: ${ card.maximum_atk }"
 msgstr ""
 
-#: src\rush-duel.ts:146
+#: src\rush-duel.ts:158
 #, javascript-format
 msgid "Konami ID #${ card.konami_id }"
 msgstr "官方編號${ card.konami_id }"
 
 #: src\art.ts:129
-#: src\commands\deck.ts:451
 msgid "Buttons can only be used by the user who called Bastion."
 msgstr ""
 
-#: src\card.ts:462
-#, javascript-format
-msgid "**Master Duel rarity**: ${ rarity_icon } ${ localized_rarity }"
-msgstr "**稀有度 (Master Duel)**: ${ rarity_icon } ${ localized_rarity }"
-
-#: src\rush-duel.ts:205
+#: src\rush-duel.ts:217
 #, javascript-format
 msgid "Using ${ searchTrigger }, you can search for Rush Duel cards directly in messages without autocomplete"
 msgstr ""
 
-#: src\events\message-search.ts:296
+#: src\events\message-search.ts:304
 #, javascript-format
 msgid "Could not find a Rush Duel card matching `${ input }`!"
+msgstr ""
+
+#: src\card.ts:462
+#, javascript-format
+msgid "**Master Duel rarity**: ${ rarityIcon } ${ localizedRarity }"
+msgstr ""
+
+#: src\card.ts:492
+#: src\rush-duel.ts:105
+#, javascript-format
+msgid "**Attribute**: ${ attributeIcon } ${ localizedAttribute }"
+msgstr ""
+
+#: src\card.ts:497
+#, javascript-format
+msgid "**Rank**: ${ rankIcon } ${ card.rank } **ATK**: ${ card.atk } **DEF**: ${ card.def }"
+msgstr ""
+
+#: src\card.ts:503
+#: src\rush-duel.ts:107
+#, javascript-format
+msgid "**Level**: ${ levelIcon } ${ card.level } **ATK**: ${ card.atk } **DEF**: ${ card.def }"
+msgstr ""
+
+#: src\commands\locale-user.ts:73
+#: src\commands\locale.ts:89
+#, javascript-format
+msgid "Locale override for your direct messages: ${ override }"
+msgstr ""
+
+#: src\commands\locale-user.ts:83
+#: src\commands\locale.ts:146
+#, javascript-format
+msgid "Locale for your direct messages overridden with ${ locale }. Your Discord setting is ${ interaction.locale }."
+msgstr ""
+
+#: src\commands\locale-user.ts:87
+#: src\commands\locale.ts:150
+#, javascript-format
+msgid "Locale for your direct messages reset to Discord default. Your Discord setting is ${ interaction.locale }."
 msgstr ""
 
 #: src\card.ts:40
@@ -830,60 +816,60 @@ msgctxt "master-duel-rarity"
 msgid "Ultra Rare (UR)"
 msgstr "究極稀有（ＵＲ）"
 
-#: src\card.ts:513
-#: src\card.ts:524
-#: src\rush-duel.ts:127
+#: src\card.ts:517
+#: src\card.ts:528
+#: src\rush-duel.ts:138
 msgctxt "card-embed"
 msgid "Card Text"
 msgstr "卡片文本"
 
-#: src\card.ts:518
+#: src\card.ts:522
 msgctxt "card-embed"
 msgid "Pendulum Effect"
 msgstr "靈擺效果"
 
-#: src\card.ts:539
+#: src\card.ts:545
 msgctxt "card-embed"
 msgid "Card Effect"
 msgstr "卡片效果"
 
-#: src\rush-duel.ts:118
-#: src\rush-duel.ts:139
+#: src\rush-duel.ts:129
+#: src\rush-duel.ts:151
 msgctxt "card-embed"
 msgid "[REQUIREMENT]"
 msgstr "【條件】"
 
-#: src\rush-duel.ts:119
-#: src\rush-duel.ts:140
+#: src\rush-duel.ts:130
+#: src\rush-duel.ts:152
 msgctxt "card-embed"
 msgid "[EFFECT]"
 msgstr "【效果】"
 
-#: src\rush-duel.ts:121
+#: src\rush-duel.ts:132
 msgctxt "card-embed"
 msgid "[CONTINUOUS EFFECT]"
 msgstr "【永續效果】"
 
-#: src\rush-duel.ts:123
+#: src\rush-duel.ts:134
 msgctxt "card-embed"
 msgid "[MULTI-CHOICE EFFECT]"
 msgstr "【選擇效果】"
 
-#: src\locale.ts:71
+#: src\locale.ts:74
 msgctxt "command-option"
 msgid "result-language"
 msgstr "查詢結果語言"
 
-#: src\locale.ts:131
+#: src\locale.ts:140
 msgctxt "command-option"
 msgid "input-language"
 msgstr "輸入語言"
 
-#: src\commands\rush-duel.ts:68
-#: src\commands\rush-duel.ts:80
-#: src\locale.ts:147
-#: src\locale.ts:165
-#: src\locale.ts:181
+#: src\commands\rush-duel.ts:67
+#: src\commands\rush-duel.ts:79
+#: src\locale.ts:156
+#: src\locale.ts:174
+#: src\locale.ts:190
 msgctxt "command-option"
 msgid "input"
 msgstr "輸入"
@@ -898,59 +884,61 @@ msgctxt "command-option"
 msgid "page"
 msgstr ""
 
-#: src\commands\help.ts:52
+#: src\commands\help.ts:55
 msgctxt "command-option"
 msgid "command"
 msgstr ""
 
-#: src\commands\deck.ts:126
+#: src\commands\deck.ts:87
 msgctxt "command-option"
 msgid "url"
 msgstr ""
 
-#: src\commands\deck.ts:132
+#: src\commands\deck.ts:93
 msgctxt "command-option"
 msgid "file"
 msgstr ""
 
-#: src\commands\deck.ts:138
-#: src\commands\deck.ts:144
+#: src\commands\deck.ts:99
+#: src\commands\deck.ts:105
 msgctxt "command-option"
 msgid "deck"
 msgstr ""
 
-#: src\commands\deck.ts:150
+#: src\commands\deck.ts:111
 msgctxt "command-option"
 msgid "public"
 msgstr ""
 
-#: src\commands\deck.ts:157
+#: src\commands\deck.ts:118
 msgctxt "command-option"
 msgid "stacked"
 msgstr ""
 
-#: src\locale.ts:142
+#: src\locale.ts:151
 msgctxt "command-option"
 msgid "name"
 msgstr ""
 
-#: src\locale.ts:160
+#: src\locale.ts:169
 msgctxt "command-option"
 msgid "password"
 msgstr ""
 
-#: src\commands\rush-duel.ts:73
-#: src\events\message-search.ts:293
-#: src\locale.ts:176
+#: src\commands\rush-duel.ts:72
+#: src\events\message-search.ts:301
+#: src\locale.ts:185
 msgctxt "command-option"
 msgid "konami-id"
 msgstr ""
 
+#: src\commands\locale-user.ts:36
 #: src\commands\locale.ts:30
 msgctxt "command-option"
 msgid "get"
 msgstr ""
 
+#: src\commands\locale-user.ts:41
 #: src\commands\locale.ts:35
 msgctxt "command-option"
 msgid "set"
@@ -961,42 +949,64 @@ msgctxt "command-option"
 msgid "scope"
 msgstr ""
 
+#: src\commands\locale-user.ts:46
 #: src\commands\locale.ts:48
 msgctxt "command-option"
 msgid "locale"
 msgstr ""
 
-#: src\commands\price.ts:94
+#: src\commands\price.ts:95
 msgctxt "command-option"
 msgid "vendor"
 msgstr ""
 
-#: src\commands\rush-duel.ts:63
+#: src\commands\rush-duel.ts:62
 msgctxt "command-option"
 msgid "search"
 msgstr ""
 
-#: src\commands\rush-duel.ts:85
+#: src\commands\rush-duel.ts:84
 msgctxt "command-option"
 msgid "random"
 msgstr ""
 
-#: src\commands\rush-duel.ts:90
+#: src\commands\rush-duel.ts:89
 msgctxt "command-option"
 msgid "art"
 msgstr ""
 
-#: src\commands\query.ts:36
+#: src\commands\query.ts:35
 msgctxt "command-option"
 msgid "lucene"
 msgstr ""
 
-#: src\locale.ts:74
+#: src\commands\metagame.ts:209
+msgctxt "command-option"
+msgid "strategies"
+msgstr ""
+
+#: src\commands\metagame.ts:234
+#: src\commands\metagame.ts:274
+msgctxt "command-option"
+msgid "format"
+msgstr ""
+
+#: src\commands\metagame.ts:240
+msgctxt "command-option"
+msgid "cards"
+msgstr ""
+
+#: src\commands\metagame.ts:310
+msgctxt "command-option"
+msgid "date-range"
+msgstr ""
+
+#: src\locale.ts:77
 msgctxt "command-option-description"
 msgid "The output language for the card embed, overriding other settings."
 msgstr "卡片查詢結果的語言，覆蓋其他設置"
 
-#: src\locale.ts:132
+#: src\locale.ts:141
 msgctxt "command-option-description"
 msgid "The language to search in, defaulting to the result language."
 msgstr "查詢用的語言，默認與查詢結果語言相同"
@@ -1006,37 +1016,37 @@ msgctxt "command-option-description"
 msgid "The name of the Yugipedia page you want to search for."
 msgstr "你想要查詢的Yugipedia頁面的名字"
 
-#: src\commands\help.ts:55
+#: src\commands\help.ts:58
 msgctxt "command-option-description"
 msgid "The name of a specific Slash Command."
 msgstr ""
 
-#: src\commands\deck.ts:129
+#: src\commands\deck.ts:90
 msgctxt "command-option-description"
 msgid "View a deck by entering a ydke:// URL."
 msgstr ""
 
-#: src\commands\deck.ts:135
+#: src\commands\deck.ts:96
 msgctxt "command-option-description"
 msgid "View a deck by uploading a .ydk file."
 msgstr ""
 
-#: src\commands\deck.ts:141
+#: src\commands\deck.ts:102
 msgctxt "command-option-description"
 msgid "The ydke:// URL of the deck you want to view."
 msgstr ""
 
-#: src\commands\deck.ts:147
+#: src\commands\deck.ts:108
 msgctxt "command-option-description"
 msgid "The .ydk file of the deck you want to view."
 msgstr ""
 
-#: src\commands\deck.ts:153
+#: src\commands\deck.ts:114
 msgctxt "command-option-description"
 msgid "Whether to display the deck details publicly in chat. This is false by default."
 msgstr ""
 
-#: src\commands\deck.ts:160
+#: src\commands\deck.ts:121
 msgctxt "command-option-description"
 msgid "Whether to display the deck sections as one stacked column. This is false (side-by-side) by default."
 msgstr ""
@@ -1046,8 +1056,8 @@ msgctxt "command-option-description"
 msgid "Display the art for the card with this name."
 msgstr ""
 
-#: src\commands\rush-duel.ts:69
-#: src\locale.ts:148
+#: src\commands\rush-duel.ts:68
+#: src\locale.ts:157
 msgctxt "command-option-description"
 msgid "Card name, fuzzy matching supported."
 msgstr ""
@@ -1057,7 +1067,7 @@ msgctxt "command-option-description"
 msgid "Display the art for the card with this password."
 msgstr ""
 
-#: src\locale.ts:167
+#: src\locale.ts:176
 msgctxt "command-option-description"
 msgid "Card password, the eight-digit number printed on the bottom left corner."
 msgstr ""
@@ -1067,8 +1077,8 @@ msgctxt "command-option-description"
 msgid "Display the art for the card with this official database ID."
 msgstr ""
 
-#: src\commands\rush-duel.ts:81
-#: src\locale.ts:182
+#: src\commands\rush-duel.ts:80
+#: src\locale.ts:191
 msgctxt "command-option-description"
 msgid "Konami's official card database identifier."
 msgstr ""
@@ -1108,22 +1118,22 @@ msgctxt "command-option-description"
 msgid "The new default language to use in this channel or server."
 msgstr ""
 
-#: src\commands\price.ts:98
+#: src\commands\price.ts:99
 msgctxt "command-option-description"
 msgid "Display the price for the card with this name."
 msgstr ""
 
-#: src\commands\price.ts:102
+#: src\commands\price.ts:103
 msgctxt "command-option-description"
 msgid "Display the price for the card with this password."
 msgstr ""
 
-#: src\commands\price.ts:105
+#: src\commands\price.ts:106
 msgctxt "command-option-description"
 msgid "Display the price for the card with this official database ID."
 msgstr ""
 
-#: src\commands\price.ts:95
+#: src\commands\price.ts:96
 msgctxt "command-option-description"
 msgid "The vendor to fetch the price data from."
 msgstr ""
@@ -1133,29 +1143,70 @@ msgctxt "command-option-description"
 msgid "The English name of the card you're looking for."
 msgstr ""
 
-#: src\commands\rush-duel.ts:64
+#: src\commands\rush-duel.ts:63
 msgctxt "command-option-description"
 msgid "Find all information for the Rush Duel card with this name."
 msgstr ""
 
-#: src\commands\rush-duel.ts:75
+#: src\commands\rush-duel.ts:74
 msgctxt "command-option-description"
 msgid "Find all information for the Rush Duel card with this official database ID."
 msgstr ""
 
-#: src\commands\rush-duel.ts:86
+#: src\commands\rush-duel.ts:85
 msgctxt "command-option-description"
 msgid "Get a random Rush Duel card."
 msgstr ""
 
-#: src\commands\rush-duel.ts:91
+#: src\commands\rush-duel.ts:90
 msgctxt "command-option-description"
 msgid "Display just the art for the Rush Duel card with this name."
 msgstr ""
 
-#: src\commands\query.ts:37
+#: src\commands\query.ts:36
 msgctxt "command-option-description"
 msgid "Lucene query on YAML Yugi"
+msgstr ""
+
+#: src\commands\locale-user.ts:37
+msgctxt "command-option-description"
+msgid "Check your user-installed Bastion's locale."
+msgstr ""
+
+#: src\commands\locale-user.ts:42
+msgctxt "command-option-description"
+msgid "Configure your user-installed Bastion's locale."
+msgstr ""
+
+#: src\commands\locale-user.ts:47
+msgctxt "command-option-description"
+msgid "The new default language to use for user-installed Bastion."
+msgstr ""
+
+#: src\commands\metagame.ts:212
+msgctxt "command-option-description"
+msgid "Show the top competitive strategies in tournaments and the Master Duel ranked ladder."
+msgstr ""
+
+#: src\commands\metagame.ts:214
+msgctxt "command-option-description"
+msgid "Show the top competitive strategies in tournaments."
+msgstr ""
+
+#: src\commands\metagame.ts:235
+#: src\commands\metagame.ts:275
+msgctxt "command-option-description"
+msgid "Game region."
+msgstr ""
+
+#: src\commands\metagame.ts:242
+msgctxt "command-option-description"
+msgid "Show the most popular cards in tournaments and the Master Duel ranked ladder."
+msgstr ""
+
+#: src\commands\metagame.ts:312
+msgctxt "command-option-description"
+msgid "Limit card usage statistics to this date range. Has no effect for Master Duel."
 msgstr ""
 
 #: src\commands\art.ts:36
@@ -1163,7 +1214,7 @@ msgctxt "command-name"
 msgid "art"
 msgstr "卡圖"
 
-#: src\commands\ping.ts:23
+#: src\commands\ping.ts:25
 msgctxt "command-name"
 msgid "ping"
 msgstr ""
@@ -1178,12 +1229,12 @@ msgctxt "command-name"
 msgid "yugipedia"
 msgstr ""
 
-#: src\commands\help.ts:49
+#: src\commands\help.ts:52
 msgctxt "command-name"
 msgid "help"
 msgstr ""
 
-#: src\commands\deck.ts:119
+#: src\commands\deck.ts:80
 msgctxt "command-name"
 msgid "deck"
 msgstr ""
@@ -1198,24 +1249,34 @@ msgctxt "command-name"
 msgid "locale"
 msgstr ""
 
-#: src\commands\random.ts:44
+#: src\commands\random.ts:43
 msgctxt "command-name"
 msgid "random"
 msgstr ""
 
-#: src\commands\price.ts:89
+#: src\commands\price.ts:90
 msgctxt "command-name"
 msgid "price"
 msgstr ""
 
-#: src\commands\rush-duel.ts:58
+#: src\commands\rush-duel.ts:57
 msgctxt "command-name"
 msgid "rush-duel"
 msgstr ""
 
-#: src\commands\query.ts:30
+#: src\commands\query.ts:29
 msgctxt "command-name"
 msgid "query"
+msgstr ""
+
+#: src\commands\locale-user.ts:31
+msgctxt "command-name"
+msgid "locale-user"
+msgstr ""
+
+#: src\commands\metagame.ts:204
+msgctxt "command-name"
+msgid "metagame"
 msgstr ""
 
 #: src\commands\art.ts:37
@@ -1223,7 +1284,7 @@ msgctxt "command-description"
 msgid "Display the art for a card!"
 msgstr "顯示卡片圖。"
 
-#: src\commands\ping.ts:24
+#: src\commands\ping.ts:26
 msgctxt "command-description"
 msgid "Test latency to the new bot instance."
 msgstr "測試新bot實例的延遲"
@@ -1238,12 +1299,12 @@ msgctxt "command-description"
 msgid "Search the Yugipedia wiki for a page and link to it."
 msgstr "搜索Yugipedia頁面與鏈接"
 
-#: src\commands\help.ts:50
+#: src\commands\help.ts:53
 msgctxt "command-description"
 msgid "Get help with a Slash Command."
 msgstr ""
 
-#: src\commands\deck.ts:122
+#: src\commands\deck.ts:83
 msgctxt "command-description"
 msgid "Display a deck list from ydke:// or .ydk format, exported from a number of deck building programs."
 msgstr ""
@@ -1258,24 +1319,34 @@ msgctxt "command-description"
 msgid "Check or set Bastion's locale for this channel or server."
 msgstr ""
 
-#: src\commands\random.ts:45
+#: src\commands\random.ts:44
 msgctxt "command-description"
 msgid "Get a random Yu-Gi-Oh! card."
 msgstr ""
 
-#: src\commands\price.ts:90
+#: src\commands\price.ts:91
 msgctxt "command-description"
 msgid "Display the price for a card!"
 msgstr ""
 
-#: src\commands\rush-duel.ts:59
+#: src\commands\rush-duel.ts:58
 msgctxt "command-description"
 msgid "Find information on Rush Duel cards."
 msgstr ""
 
-#: src\commands\query.ts:31
+#: src\commands\query.ts:30
 msgctxt "command-description"
 msgid "Advanced search prototype"
+msgstr ""
+
+#: src\commands\locale-user.ts:32
+msgctxt "command-description"
+msgid "Check or set user-installed Bastion's locale."
+msgstr ""
+
+#: src\commands\metagame.ts:205
+msgctxt "command-description"
+msgid "Show statistics on the current competitive state of play."
 msgstr ""
 
 #: src\commands\locale.ts:43
@@ -1288,7 +1359,71 @@ msgctxt "command-option-choice"
 msgid "server"
 msgstr ""
 
+#: src\commands\locale-user.ts:49
 #: src\commands\locale.ts:51
 msgctxt "command-option-choice"
 msgid "Discord default"
+msgstr ""
+
+#: src\commands\metagame.ts:219
+#: src\commands\metagame.ts:251
+msgctxt "command-option-choice"
+msgid "TCG"
+msgstr ""
+
+#: src\commands\metagame.ts:220
+#: src\commands\metagame.ts:255
+msgctxt "command-option-choice"
+msgid "OCG"
+msgstr ""
+
+#: src\commands\metagame.ts:221
+#: src\commands\metagame.ts:259
+msgctxt "command-option-choice"
+msgid "OCG (Asian-English)"
+msgstr ""
+
+#: src\commands\metagame.ts:228
+msgctxt "command-option-choice"
+msgid "Master Duel Diamond+ tier list"
+msgstr ""
+
+#: src\commands\metagame.ts:261
+msgctxt "command-option-choice"
+msgid "Master Duel ranked ladder"
+msgstr ""
+
+#: src\commands\metagame.ts:283
+msgctxt "command-option-choice"
+msgid "Current format"
+msgstr ""
+
+#: src\commands\metagame.ts:287
+msgctxt "command-option-choice"
+msgid "Since last Forbidden/Limited List"
+msgstr ""
+
+#: src\commands\metagame.ts:291
+msgctxt "command-option-choice"
+msgid "Last 7 days"
+msgstr ""
+
+#: src\commands\metagame.ts:295
+msgctxt "command-option-choice"
+msgid "Last 14 days"
+msgstr ""
+
+#: src\commands\metagame.ts:299
+msgctxt "command-option-choice"
+msgid "Last 30 days"
+msgstr ""
+
+#: src\commands\metagame.ts:303
+msgctxt "command-option-choice"
+msgid "Last three months"
+msgstr ""
+
+#: src\commands\metagame.ts:307
+msgctxt "command-option-choice"
+msgid "Last six months"
 msgstr ""

--- a/translations/zh-TW.po
+++ b/translations/zh-TW.po
@@ -6,33 +6,50 @@ msgstr ""
 "MIME-Version: 1.0\n"
 "Content-Transfer-Encoding: 8bit\n"
 
-#: src\card.ts:412
-#: src\rush-duel.ts:48
+#: src\card.ts:416
+#: src\rush-duel.ts:39
 msgid "🔗 Links"
 msgstr "鏈接"
 
-#: src\card.ts:413
+#: src\card.ts:417
 #, javascript-format
 msgid "[Official Konami DB](${ official }) | [OCG Rulings](${ rulings }) | [Yugipedia](${ yugipedia }) | [YGOPRODECK](${ ygoprodeck })"
 msgstr "[K社官方數據庫](${ official }) | [事務局FAQ](${ rulings }) | [Yugipedia](${ yugipedia }) | [YGOPRODECK](${ ygoprodeck })"
 
-#: src\card.ts:416
+#: src\card.ts:420
 #, javascript-format
 msgid "[Yugipedia](${ yugipedia }) | [YGOPRODECK](${ ygoprodeck })"
 msgstr "[Yugipedia](${ yugipedia }) | [YGOPRODECK](${ ygoprodeck })"
 
-#: src\card.ts:490
-#: src\rush-duel.ts:103
+#: src\card.ts:489
+#: src\rush-duel.ts:92
 #, javascript-format
 msgid "**Type**: ${ raceIcon } ${ localizedMonsterTypeLine }"
 msgstr "**種族**: ${ raceIcon } ${ localizedMonsterTypeLine }"
 
-#: src\card.ts:500
+#: src\card.ts:491
+#: src\rush-duel.ts:94
+#, javascript-format
+msgid "**Attribute**: ${ AttributeIcon[card.attribute] } ${ localizedAttribute }"
+msgstr "**屬性**: ${ AttributeIcon[card.attribute] } ${ localizedAttribute }"
+
+#: src\card.ts:495
+#, javascript-format
+msgid "**Rank**: ${ Icon.Rank } ${ card.rank } **ATK**: ${ card.atk } **DEF**: ${ card.def }"
+msgstr "**階級**: ${ Icon.Rank } ${ card.rank } **攻擊力**: ${ card.atk } **守備力**: ${ card.def }"
+
+#: src\card.ts:498
 #, javascript-format
 msgid "**Link Rating**: ${ card.link_arrows.length } **ATK**: ${ card.atk } **Link Arrows**: ${ arrows }"
 msgstr "**連接數值**: ${ card.link_arrows.length } **攻擊力**: ${ card.atk } **連接標記**: ${ arrows }"
 
-#: src\card.ts:511
+#: src\card.ts:500
+#: src\rush-duel.ts:96
+#, javascript-format
+msgid "**Level**: ${ Icon.Level } ${ card.level } **ATK**: ${ card.atk } **DEF**: ${ card.def }"
+msgstr "**等級**: ${ Icon.Level } ${ card.level } **攻擊力**: ${ card.atk } **守備力**: ${ card.def }"
+
+#: src\card.ts:507
 #, javascript-format
 msgid "**Pendulum Scale**: ${ formattedScale }"
 msgstr "**靈擺刻度**: ${ formattedScale }"
@@ -53,7 +70,7 @@ msgid "Password: ${ card.password } | Not yet released"
 msgstr "卡片密碼: ${ card.password } | 未發行"
 
 #: src\card.ts:351
-#: src\rush-duel.ts:158
+#: src\rush-duel.ts:146
 msgid "Not yet released"
 msgstr "未發行"
 
@@ -62,64 +79,64 @@ msgstr "未發行"
 msgid "Placeholder ID: ${ card.fake_password }"
 msgstr "假卡密: ${ card.fake_password }"
 
-#: src\utils.ts:44
+#: src\utils.ts:41
 msgid "🛠️ This command is in development."
 msgstr "🛠️ 這個指令正在開發中"
 
-#: src\utils.ts:45
+#: src\utils.ts:42
 msgid "📨 Please send feedback to [our issue tracker](https://github.com/DawnbrandBots/bastion-bot) or the [support server](https://discord.gg/4aFuPyuE96)!"
 msgstr "📨 如有意見或建議請反饋至[GitHub issue](https://github.com/DawnbrandBots/bastion-bot)或者[Discord服務器](https://discord.gg/4aFuPyuE96)!"
 
-#: src\utils.ts:56
+#: src\utils.ts:53
 msgid "Please consider supporting us!"
 msgstr "請考慮捐助我們！"
 
-#: src\utils.ts:57
+#: src\utils.ts:54
 msgid "Help keep Bastion online!"
 msgstr "幫幫Bastion吧，寶寶快餓死了"
 
-#: src\utils.ts:58
+#: src\utils.ts:55
 msgid "Please help keep Bastion online!"
 msgstr "請幫幫Bastion吧，寶寶真的快餓死了"
 
-#: src\utils.ts:59
+#: src\utils.ts:56
 msgid "Was Bastion helpful? Consider supporting us!"
 msgstr "Bastion有用麼？請考慮捐助我們！"
 
-#: src\utils.ts:60
+#: src\utils.ts:57
 msgid "Was Bastion helpful? We need your support!"
 msgstr "Bastion有用麼？我們需要你的支持！"
 
-#: src\utils.ts:61
+#: src\utils.ts:58
 msgid "Did you find Bastion useful? Consider supporting us!"
 msgstr "你覺得Bastion好用麼？請考慮捐助我們！"
 
-#: src\utils.ts:62
+#: src\utils.ts:59
 msgid "Did you find Bastion useful? Help keep it online!"
 msgstr "你覺得Bastion好用麼？那幫幫TA吧，孩子快餓死了"
 
-#: src\utils.ts:63
+#: src\utils.ts:60
 msgid "Did you find Bastion useful? We need your support!"
 msgstr "你覺得Bastion好用麼？我們需要你的支持！"
 
-#: src\utils.ts:64
+#: src\utils.ts:61
 msgid "Enjoy Bastion? Help keep it online!"
 msgstr "你覺得Bastion好用麼？那幫幫TA吧，孩子快餓死了"
 
-#: src\utils.ts:65
+#: src\utils.ts:62
 msgid "Enjoy Bastion? Consider supporting us!"
 msgstr "覺得Bastion怎麼樣？請考慮捐助我們！"
 
-#: src\utils.ts:66
+#: src\utils.ts:63
 msgid "Found what you were looking for? Consider supporting us!"
 msgstr "找到你要的東西了嗎？請考慮捐助我們！"
 
 #: src\commands\art.ts:63
-#: src\commands\price.ts:132
-#: src\commands\rush-duel.ts:171
-#: src\commands\rush-duel.ts:202
+#: src\commands\price.ts:131
+#: src\commands\rush-duel.ts:172
+#: src\commands\rush-duel.ts:203
 #: src\commands\search.ts:64
-#: src\events\message-search.ts:265
+#: src\events\message-search.ts:258
 #, javascript-format
 msgid "Could not find a card matching `${ input }`!"
 msgstr "查無此卡：`${ input }`"
@@ -146,7 +163,11 @@ msgstr ""
 msgid "Discord Community locale for this server: ${ interaction.guildLocale }"
 msgstr ""
 
-#: src\commands\locale-user.ts:76
+#: src\commands\locale.ts:89
+#, javascript-format
+msgid "Locale override for this direct message: ${ override }"
+msgstr ""
+
 #: src\commands\locale.ts:92
 #, javascript-format
 msgid "Your Discord locale: ${ interaction.locale }"
@@ -184,8 +205,18 @@ msgstr ""
 msgid "Sorry, you must have the Manage Server permission to do this. If you think this is an error, contact your server admin or report a bug."
 msgstr ""
 
-#: src\commands\ping.ts:42
-#: src\events\message-ping.ts:110
+#: src\commands\locale.ts:146
+#, javascript-format
+msgid "Locale for this direct message overridden with ${ locale }. Your Discord setting is ${ interaction.locale }."
+msgstr ""
+
+#: src\commands\locale.ts:150
+#, javascript-format
+msgid "Locale for this direct message reset to Discord default. Your Discord setting is ${ interaction.locale }."
+msgstr ""
+
+#: src\commands\ping.ts:40
+#: src\events\message-ping.ts:112
 #, javascript-format
 msgid "Total latency: ${ latency } ms"
 msgstr "延遲${ latency }ms"
@@ -195,131 +226,148 @@ msgstr "延遲${ latency }ms"
 msgid "Could not find a Yugipedia page named `${ page }`."
 msgstr "Yugipedia上找不到`${ page }`"
 
-#: src\commands\deck.ts:205
+#: src\commands\deck.ts:244
 #, javascript-format
 msgid "${ counts.Monster } Monster"
 msgid_plural "${ counts.Monster } Monsters"
 msgstr[0] "${ counts.Monster }張怪獸卡"
 
-#: src\commands\deck.ts:208
+#: src\commands\deck.ts:247
 #, javascript-format
 msgid "${ counts.Spell } Spell"
 msgid_plural "${ counts.Spell } Spells"
 msgstr[0] "${ counts.Spell }張魔法卡"
 
-#: src\commands\deck.ts:211
+#: src\commands\deck.ts:250
 #, javascript-format
 msgid "${ counts.Trap } Trap"
 msgid_plural "${ counts.Trap } Traps"
 msgstr[0] "${ counts.Trap }張陷阱卡"
 
-#: src\commands\deck.ts:239
+#: src\commands\deck.ts:278
 msgid "Your Deck"
 msgstr "你的卡組"
 
-#: src\commands\deck.ts:244
+#: src\commands\deck.ts:283
 #, javascript-format
 msgid "Main Deck (${ deck.main.length } card — ${ countDetail })"
 msgid_plural "Main Deck (${ deck.main.length } cards — ${ countDetail })"
 msgstr[0] "牌組（${ deck.main.length })張 — ${ countDetail }）"
 
-#: src\commands\deck.ts:258
+#: src\commands\deck.ts:297
 #, javascript-format
 msgid "Extra Deck (${ deck.extra.length } card — ${ countDetail })"
 msgid_plural "Extra Deck (${ deck.extra.length } cards — ${ countDetail })"
 msgstr[0] "額外卡組（${ deck.extra.length }張 — ${ countDetail }）"
 
-#: src\commands\deck.ts:272
+#: src\commands\deck.ts:311
 #, javascript-format
 msgid "Side Deck (${ deck.side.length } card — ${ countDetail })"
 msgid_plural "Side Deck (${ deck.side.length } cards — ${ countDetail })"
 msgstr[0] "備牌（${ deck.side.length }張 — ${ countDetail }）"
 
-#: src\commands\deck.ts:251
+#: src\commands\deck.ts:290
 msgid "Main Deck (continued)"
 msgstr "牌組（續）"
 
-#: src\commands\deck.ts:265
+#: src\commands\deck.ts:304
 msgid "Extra Deck (continued)"
 msgstr "額外卡組（續）"
 
-#: src\commands\deck.ts:279
+#: src\commands\deck.ts:318
 msgid "Side Deck (continued)"
 msgstr "備牌（續）"
 
-#: src\commands\deck.ts:347
+#: src\commands\deck.ts:407
 msgid "Error: Your deck is empty."
 msgstr "錯誤：卡組是空的。"
 
-#: src\commands\ping.ts:38
-#: src\events\message-ping.ts:45
+#: src\commands\ping.ts:36
+#: src\events\message-ping.ts:47
 #, javascript-format
 msgid "Average WebSocket ping (new instance): ${ ping } ms"
 msgstr ""
 
-#: src\events\message-ping.ts:47
+#: src\events\message-ping.ts:49
 msgid "Free and open source _Yu-Gi-Oh!_ bot"
 msgstr "自由開源遊戲王聊天機器人"
 
-#: src\events\message-ping.ts:70
+#: src\events\message-ping.ts:72
 #, javascript-format
 msgid "Revision: ${ process.env.BOT_REVISION }."
 msgstr "修訂：${ process.env.BOT_REVISION }"
 
-#: src\commands\deck.ts:289
+#: src\commands\deck.ts:328
 msgid ".ydk files must have the .ydk extension!"
 msgstr ""
 
-#: src\commands\deck.ts:292
+#: src\commands\deck.ts:331
 msgid ".ydk files should not be larger than 1 KB!"
 msgstr ""
 
-#: src\commands\deck.ts:282
+#: src\commands\deck.ts:321
 msgid "ydke URL"
 msgstr ""
 
 #: src\card.ts:455
-#: src\rush-duel.ts:75
+#: src\rush-duel.ts:61
 #. Forbidden/Limited Lists or Limit Regulations in the OCG
 #, javascript-format
 msgid "**Limit**: ${ limitRegulationDisplay }"
 msgstr "**限制**: ${ limitRegulationDisplay }"
 
-#: src\commands\price.ts:70
+#: src\commands\price.ts:69
 msgid "TCGPlayer"
 msgstr ""
 
-#: src\commands\price.ts:71
+#: src\commands\price.ts:70
 msgid "Cardmarket"
 msgstr ""
 
-#: src\commands\price.ts:148
+#: src\commands\price.ts:147
 msgid "No market price"
 msgstr ""
 
-#: src\commands\price.ts:156
+#: src\commands\price.ts:155
 #, javascript-format
 msgid "Prices for ${ card.name[resultLanguage] } - ${ vendorName }"
 msgstr ""
 
-#: src\commands\price.ts:170
+#: src\commands\price.ts:169
 #, javascript-format
 msgid "Could not find prices for `${ name }`!"
 msgstr ""
 
-#: src\commands\deck.ts:363
+#: src\commands\deck.ts:425
+#. prepare interaction button for FTP upload
 msgid "Upload to YGOPRODECK"
 msgstr "上傳至YGOPRODECK"
 
-#: src\events\message-search.ts:271
+#: src\commands\deck.ts:483
+#. disable original button
+#. prepare row to disable button on original message
+msgid "Upload Complete"
+msgstr "上傳成功"
+
+#: src\commands\deck.ts:470
+msgid "Deck upload failed!"
+msgstr "上傳失敗"
+
+#: src\commands\deck.ts:491
+#. reply in affirmation
+#, javascript-format
+msgid "Deck successfully uploaded to <${ url }>!"
+msgstr "卡組成功上傳到<${ url }>!"
+
+#: src\events\message-search.ts:264
 msgid "💬 Translations missing?"
 msgstr "💬缺少翻譯？"
 
-#: src\events\message-search.ts:272
+#: src\events\message-search.ts:265
 msgid "Help translate Bastion at the links above."
 msgstr "在以上的網址幫忙翻譯Bastion"
 
-#: src\events\message-ping.ts:48
+#: src\events\message-ping.ts:50
 msgid ""
 "❓ Help documentation on [GitHub](https://github.com/DawnbrandBots/bastion-bot), or use `.commands` and `.help`.\n"
 "🟢 Licence: [GNU AGPL 3.0+](https://choosealicense.com/licenses/agpl-3.0/).\n"
@@ -335,27 +383,27 @@ msgid ""
 "💬 Translations missing? Help translate Bastion on [GitHub](https://github.com/DawnbrandBots/bastion-bot)."
 msgstr ""
 
-#: src\events\message-search.ts:263
-#: src\events\message-search.ts:302
+#: src\events\message-search.ts:256
+#: src\events\message-search.ts:294
 #, javascript-format
 msgid "Search type: ${ localisedType }"
 msgstr "搜索類型：${ localisedType }"
 
-#: src\events\message-search.ts:242
+#: src\events\message-search.ts:236
 #, javascript-format
 msgid "Search language: **${ localisedInputLanguage }** (${ inputLanguage }). Check defaults with </locale get:${ id }> and configure with </locale set:${ id }>"
 msgstr ""
 
-#: src\events\message-ping.ts:93
+#: src\events\message-ping.ts:95
 msgid "⚠️ You pinged me, but I am missing permissions in the channel!"
 msgstr ""
 
-#: src\events\message-ping.ts:96
-#: src\events\message-search.ts:340
+#: src\events\message-ping.ts:98
+#: src\events\message-search.ts:332
 msgid "Please have a server administrator [fix this](https://github.com/DawnbrandBots/bastion-bot#discord-permissions)."
 msgstr ""
 
-#: src\events\message-search.ts:337
+#: src\events\message-search.ts:329
 msgid "⚠️ I am missing permissions in the channel!"
 msgstr ""
 
@@ -374,82 +422,48 @@ msgstr ""
 msgid "Something went wrong searching Yugipedia for `${ page }`."
 msgstr ""
 
-#: src\rush-duel.ts:49
+#: src\rush-duel.ts:40
 #, javascript-format
 msgid "[Official Konami DB](${ official }) | [Rulings (Japanese)](${ rulings }) | [Yugipedia](${ yugipedia }) | [RushCard](${ rushcard })"
 msgstr "[K社官方數據庫](${ official }) | [事務局FAQ](${ rulings }) | [Yugipedia](${ yugipedia }) | [YGOPRODECK](${ ygoprodeck })"
 
-#: src\rush-duel.ts:52
+#: src\rush-duel.ts:43
 #, javascript-format
 msgid "[Yugipedia](${ yugipedia }) | [RushCard](${ rushcard })"
 msgstr "[Yugipedia](${ yugipedia }) | [RushCard](${ rushcard })"
 
-#: src\rush-duel.ts:71
+#: src\rush-duel.ts:57
 msgid "__**LEGEND**__"
 msgstr ""
 
-#: src\rush-duel.ts:110
+#: src\rush-duel.ts:99
 #, javascript-format
 msgid "**MAXIMUM ATK**: ${ card.maximum_atk }"
 msgstr ""
 
-#: src\rush-duel.ts:158
+#: src\rush-duel.ts:146
 #, javascript-format
 msgid "Konami ID #${ card.konami_id }"
 msgstr "官方編號${ card.konami_id }"
 
 #: src\art.ts:129
+#: src\commands\deck.ts:451
 msgid "Buttons can only be used by the user who called Bastion."
-msgstr ""
-
-#: src\rush-duel.ts:217
-#, javascript-format
-msgid "Using ${ searchTrigger }, you can search for Rush Duel cards directly in messages without autocomplete"
-msgstr ""
-
-#: src\events\message-search.ts:304
-#, javascript-format
-msgid "Could not find a Rush Duel card matching `${ input }`!"
 msgstr ""
 
 #: src\card.ts:462
 #, javascript-format
-msgid "**Master Duel rarity**: ${ rarityIcon } ${ localizedRarity }"
+msgid "**Master Duel rarity**: ${ rarity_icon } ${ localized_rarity }"
+msgstr "**稀有度 (Master Duel)**: ${ rarity_icon } ${ localized_rarity }"
+
+#: src\rush-duel.ts:205
+#, javascript-format
+msgid "Using ${ searchTrigger }, you can search for Rush Duel cards directly in messages without autocomplete"
 msgstr ""
 
-#: src\card.ts:492
-#: src\rush-duel.ts:105
+#: src\events\message-search.ts:296
 #, javascript-format
-msgid "**Attribute**: ${ attributeIcon } ${ localizedAttribute }"
-msgstr ""
-
-#: src\card.ts:497
-#, javascript-format
-msgid "**Rank**: ${ rankIcon } ${ card.rank } **ATK**: ${ card.atk } **DEF**: ${ card.def }"
-msgstr ""
-
-#: src\card.ts:503
-#: src\rush-duel.ts:107
-#, javascript-format
-msgid "**Level**: ${ levelIcon } ${ card.level } **ATK**: ${ card.atk } **DEF**: ${ card.def }"
-msgstr ""
-
-#: src\commands\locale-user.ts:73
-#: src\commands\locale.ts:89
-#, javascript-format
-msgid "Locale override for your direct messages: ${ override }"
-msgstr ""
-
-#: src\commands\locale-user.ts:83
-#: src\commands\locale.ts:146
-#, javascript-format
-msgid "Locale for your direct messages overridden with ${ locale }. Your Discord setting is ${ interaction.locale }."
-msgstr ""
-
-#: src\commands\locale-user.ts:87
-#: src\commands\locale.ts:150
-#, javascript-format
-msgid "Locale for your direct messages reset to Discord default. Your Discord setting is ${ interaction.locale }."
+msgid "Could not find a Rush Duel card matching `${ input }`!"
 msgstr ""
 
 #: src\card.ts:40
@@ -816,60 +830,60 @@ msgctxt "master-duel-rarity"
 msgid "Ultra Rare (UR)"
 msgstr "究極稀有（ＵＲ）"
 
-#: src\card.ts:517
-#: src\card.ts:528
-#: src\rush-duel.ts:138
+#: src\card.ts:513
+#: src\card.ts:524
+#: src\rush-duel.ts:127
 msgctxt "card-embed"
 msgid "Card Text"
 msgstr "卡片文本"
 
-#: src\card.ts:522
+#: src\card.ts:518
 msgctxt "card-embed"
 msgid "Pendulum Effect"
 msgstr "靈擺效果"
 
-#: src\card.ts:545
+#: src\card.ts:539
 msgctxt "card-embed"
 msgid "Card Effect"
 msgstr "卡片效果"
 
-#: src\rush-duel.ts:129
-#: src\rush-duel.ts:151
+#: src\rush-duel.ts:118
+#: src\rush-duel.ts:139
 msgctxt "card-embed"
 msgid "[REQUIREMENT]"
 msgstr "【條件】"
 
-#: src\rush-duel.ts:130
-#: src\rush-duel.ts:152
+#: src\rush-duel.ts:119
+#: src\rush-duel.ts:140
 msgctxt "card-embed"
 msgid "[EFFECT]"
 msgstr "【效果】"
 
-#: src\rush-duel.ts:132
+#: src\rush-duel.ts:121
 msgctxt "card-embed"
 msgid "[CONTINUOUS EFFECT]"
 msgstr "【永續效果】"
 
-#: src\rush-duel.ts:134
+#: src\rush-duel.ts:123
 msgctxt "card-embed"
 msgid "[MULTI-CHOICE EFFECT]"
 msgstr "【選擇效果】"
 
-#: src\locale.ts:74
+#: src\locale.ts:71
 msgctxt "command-option"
 msgid "result-language"
 msgstr "查詢結果語言"
 
-#: src\locale.ts:140
+#: src\locale.ts:131
 msgctxt "command-option"
 msgid "input-language"
 msgstr "輸入語言"
 
-#: src\commands\rush-duel.ts:67
-#: src\commands\rush-duel.ts:79
-#: src\locale.ts:156
-#: src\locale.ts:174
-#: src\locale.ts:190
+#: src\commands\rush-duel.ts:68
+#: src\commands\rush-duel.ts:80
+#: src\locale.ts:147
+#: src\locale.ts:165
+#: src\locale.ts:181
 msgctxt "command-option"
 msgid "input"
 msgstr "輸入"
@@ -884,61 +898,59 @@ msgctxt "command-option"
 msgid "page"
 msgstr ""
 
-#: src\commands\help.ts:55
+#: src\commands\help.ts:52
 msgctxt "command-option"
 msgid "command"
 msgstr ""
 
-#: src\commands\deck.ts:87
+#: src\commands\deck.ts:126
 msgctxt "command-option"
 msgid "url"
 msgstr ""
 
-#: src\commands\deck.ts:93
+#: src\commands\deck.ts:132
 msgctxt "command-option"
 msgid "file"
 msgstr ""
 
-#: src\commands\deck.ts:99
-#: src\commands\deck.ts:105
+#: src\commands\deck.ts:138
+#: src\commands\deck.ts:144
 msgctxt "command-option"
 msgid "deck"
 msgstr ""
 
-#: src\commands\deck.ts:111
+#: src\commands\deck.ts:150
 msgctxt "command-option"
 msgid "public"
 msgstr ""
 
-#: src\commands\deck.ts:118
+#: src\commands\deck.ts:157
 msgctxt "command-option"
 msgid "stacked"
 msgstr ""
 
-#: src\locale.ts:151
+#: src\locale.ts:142
 msgctxt "command-option"
 msgid "name"
 msgstr ""
 
-#: src\locale.ts:169
+#: src\locale.ts:160
 msgctxt "command-option"
 msgid "password"
 msgstr ""
 
-#: src\commands\rush-duel.ts:72
-#: src\events\message-search.ts:301
-#: src\locale.ts:185
+#: src\commands\rush-duel.ts:73
+#: src\events\message-search.ts:293
+#: src\locale.ts:176
 msgctxt "command-option"
 msgid "konami-id"
 msgstr ""
 
-#: src\commands\locale-user.ts:36
 #: src\commands\locale.ts:30
 msgctxt "command-option"
 msgid "get"
 msgstr ""
 
-#: src\commands\locale-user.ts:41
 #: src\commands\locale.ts:35
 msgctxt "command-option"
 msgid "set"
@@ -949,64 +961,42 @@ msgctxt "command-option"
 msgid "scope"
 msgstr ""
 
-#: src\commands\locale-user.ts:46
 #: src\commands\locale.ts:48
 msgctxt "command-option"
 msgid "locale"
 msgstr ""
 
-#: src\commands\price.ts:95
+#: src\commands\price.ts:94
 msgctxt "command-option"
 msgid "vendor"
 msgstr ""
 
-#: src\commands\rush-duel.ts:62
+#: src\commands\rush-duel.ts:63
 msgctxt "command-option"
 msgid "search"
 msgstr ""
 
-#: src\commands\rush-duel.ts:84
+#: src\commands\rush-duel.ts:85
 msgctxt "command-option"
 msgid "random"
 msgstr ""
 
-#: src\commands\rush-duel.ts:89
+#: src\commands\rush-duel.ts:90
 msgctxt "command-option"
 msgid "art"
 msgstr ""
 
-#: src\commands\query.ts:35
+#: src\commands\query.ts:36
 msgctxt "command-option"
 msgid "lucene"
 msgstr ""
 
-#: src\commands\metagame.ts:209
-msgctxt "command-option"
-msgid "strategies"
-msgstr ""
-
-#: src\commands\metagame.ts:234
-#: src\commands\metagame.ts:274
-msgctxt "command-option"
-msgid "format"
-msgstr ""
-
-#: src\commands\metagame.ts:240
-msgctxt "command-option"
-msgid "cards"
-msgstr ""
-
-#: src\commands\metagame.ts:310
-msgctxt "command-option"
-msgid "date-range"
-msgstr ""
-
-#: src\locale.ts:77
+#: src\locale.ts:74
 msgctxt "command-option-description"
 msgid "The output language for the card embed, overriding other settings."
 msgstr "卡片查詢結果的語言，覆蓋其他設置"
 
-#: src\locale.ts:141
+#: src\locale.ts:132
 msgctxt "command-option-description"
 msgid "The language to search in, defaulting to the result language."
 msgstr "查詢用的語言，默認與查詢結果語言相同"
@@ -1016,37 +1006,37 @@ msgctxt "command-option-description"
 msgid "The name of the Yugipedia page you want to search for."
 msgstr "你想要查詢的Yugipedia頁面的名字"
 
-#: src\commands\help.ts:58
+#: src\commands\help.ts:55
 msgctxt "command-option-description"
 msgid "The name of a specific Slash Command."
 msgstr ""
 
-#: src\commands\deck.ts:90
+#: src\commands\deck.ts:129
 msgctxt "command-option-description"
 msgid "View a deck by entering a ydke:// URL."
 msgstr ""
 
-#: src\commands\deck.ts:96
+#: src\commands\deck.ts:135
 msgctxt "command-option-description"
 msgid "View a deck by uploading a .ydk file."
 msgstr ""
 
-#: src\commands\deck.ts:102
+#: src\commands\deck.ts:141
 msgctxt "command-option-description"
 msgid "The ydke:// URL of the deck you want to view."
 msgstr ""
 
-#: src\commands\deck.ts:108
+#: src\commands\deck.ts:147
 msgctxt "command-option-description"
 msgid "The .ydk file of the deck you want to view."
 msgstr ""
 
-#: src\commands\deck.ts:114
+#: src\commands\deck.ts:153
 msgctxt "command-option-description"
 msgid "Whether to display the deck details publicly in chat. This is false by default."
 msgstr ""
 
-#: src\commands\deck.ts:121
+#: src\commands\deck.ts:160
 msgctxt "command-option-description"
 msgid "Whether to display the deck sections as one stacked column. This is false (side-by-side) by default."
 msgstr ""
@@ -1056,8 +1046,8 @@ msgctxt "command-option-description"
 msgid "Display the art for the card with this name."
 msgstr ""
 
-#: src\commands\rush-duel.ts:68
-#: src\locale.ts:157
+#: src\commands\rush-duel.ts:69
+#: src\locale.ts:148
 msgctxt "command-option-description"
 msgid "Card name, fuzzy matching supported."
 msgstr ""
@@ -1067,7 +1057,7 @@ msgctxt "command-option-description"
 msgid "Display the art for the card with this password."
 msgstr ""
 
-#: src\locale.ts:176
+#: src\locale.ts:167
 msgctxt "command-option-description"
 msgid "Card password, the eight-digit number printed on the bottom left corner."
 msgstr ""
@@ -1077,8 +1067,8 @@ msgctxt "command-option-description"
 msgid "Display the art for the card with this official database ID."
 msgstr ""
 
-#: src\commands\rush-duel.ts:80
-#: src\locale.ts:191
+#: src\commands\rush-duel.ts:81
+#: src\locale.ts:182
 msgctxt "command-option-description"
 msgid "Konami's official card database identifier."
 msgstr ""
@@ -1118,22 +1108,22 @@ msgctxt "command-option-description"
 msgid "The new default language to use in this channel or server."
 msgstr ""
 
-#: src\commands\price.ts:99
+#: src\commands\price.ts:98
 msgctxt "command-option-description"
 msgid "Display the price for the card with this name."
 msgstr ""
 
-#: src\commands\price.ts:103
+#: src\commands\price.ts:102
 msgctxt "command-option-description"
 msgid "Display the price for the card with this password."
 msgstr ""
 
-#: src\commands\price.ts:106
+#: src\commands\price.ts:105
 msgctxt "command-option-description"
 msgid "Display the price for the card with this official database ID."
 msgstr ""
 
-#: src\commands\price.ts:96
+#: src\commands\price.ts:95
 msgctxt "command-option-description"
 msgid "The vendor to fetch the price data from."
 msgstr ""
@@ -1143,70 +1133,29 @@ msgctxt "command-option-description"
 msgid "The English name of the card you're looking for."
 msgstr ""
 
-#: src\commands\rush-duel.ts:63
+#: src\commands\rush-duel.ts:64
 msgctxt "command-option-description"
 msgid "Find all information for the Rush Duel card with this name."
 msgstr ""
 
-#: src\commands\rush-duel.ts:74
+#: src\commands\rush-duel.ts:75
 msgctxt "command-option-description"
 msgid "Find all information for the Rush Duel card with this official database ID."
 msgstr ""
 
-#: src\commands\rush-duel.ts:85
+#: src\commands\rush-duel.ts:86
 msgctxt "command-option-description"
 msgid "Get a random Rush Duel card."
 msgstr ""
 
-#: src\commands\rush-duel.ts:90
+#: src\commands\rush-duel.ts:91
 msgctxt "command-option-description"
 msgid "Display just the art for the Rush Duel card with this name."
 msgstr ""
 
-#: src\commands\query.ts:36
+#: src\commands\query.ts:37
 msgctxt "command-option-description"
 msgid "Lucene query on YAML Yugi"
-msgstr ""
-
-#: src\commands\locale-user.ts:37
-msgctxt "command-option-description"
-msgid "Check your user-installed Bastion's locale."
-msgstr ""
-
-#: src\commands\locale-user.ts:42
-msgctxt "command-option-description"
-msgid "Configure your user-installed Bastion's locale."
-msgstr ""
-
-#: src\commands\locale-user.ts:47
-msgctxt "command-option-description"
-msgid "The new default language to use for user-installed Bastion."
-msgstr ""
-
-#: src\commands\metagame.ts:212
-msgctxt "command-option-description"
-msgid "Show the top competitive strategies in tournaments and the Master Duel ranked ladder."
-msgstr ""
-
-#: src\commands\metagame.ts:214
-msgctxt "command-option-description"
-msgid "Show the top competitive strategies in tournaments."
-msgstr ""
-
-#: src\commands\metagame.ts:235
-#: src\commands\metagame.ts:275
-msgctxt "command-option-description"
-msgid "Game region."
-msgstr ""
-
-#: src\commands\metagame.ts:242
-msgctxt "command-option-description"
-msgid "Show the most popular cards in tournaments and the Master Duel ranked ladder."
-msgstr ""
-
-#: src\commands\metagame.ts:312
-msgctxt "command-option-description"
-msgid "Limit card usage statistics to this date range. Has no effect for Master Duel."
 msgstr ""
 
 #: src\commands\art.ts:36
@@ -1214,7 +1163,7 @@ msgctxt "command-name"
 msgid "art"
 msgstr "卡圖"
 
-#: src\commands\ping.ts:25
+#: src\commands\ping.ts:23
 msgctxt "command-name"
 msgid "ping"
 msgstr ""
@@ -1229,12 +1178,12 @@ msgctxt "command-name"
 msgid "yugipedia"
 msgstr ""
 
-#: src\commands\help.ts:52
+#: src\commands\help.ts:49
 msgctxt "command-name"
 msgid "help"
 msgstr ""
 
-#: src\commands\deck.ts:80
+#: src\commands\deck.ts:119
 msgctxt "command-name"
 msgid "deck"
 msgstr ""
@@ -1249,34 +1198,24 @@ msgctxt "command-name"
 msgid "locale"
 msgstr ""
 
-#: src\commands\random.ts:43
+#: src\commands\random.ts:44
 msgctxt "command-name"
 msgid "random"
 msgstr ""
 
-#: src\commands\price.ts:90
+#: src\commands\price.ts:89
 msgctxt "command-name"
 msgid "price"
 msgstr ""
 
-#: src\commands\rush-duel.ts:57
+#: src\commands\rush-duel.ts:58
 msgctxt "command-name"
 msgid "rush-duel"
 msgstr ""
 
-#: src\commands\query.ts:29
+#: src\commands\query.ts:30
 msgctxt "command-name"
 msgid "query"
-msgstr ""
-
-#: src\commands\locale-user.ts:31
-msgctxt "command-name"
-msgid "locale-user"
-msgstr ""
-
-#: src\commands\metagame.ts:204
-msgctxt "command-name"
-msgid "metagame"
 msgstr ""
 
 #: src\commands\art.ts:37
@@ -1284,7 +1223,7 @@ msgctxt "command-description"
 msgid "Display the art for a card!"
 msgstr "顯示卡片圖。"
 
-#: src\commands\ping.ts:26
+#: src\commands\ping.ts:24
 msgctxt "command-description"
 msgid "Test latency to the new bot instance."
 msgstr "測試新bot實例的延遲"
@@ -1299,12 +1238,12 @@ msgctxt "command-description"
 msgid "Search the Yugipedia wiki for a page and link to it."
 msgstr "搜索Yugipedia頁面與鏈接"
 
-#: src\commands\help.ts:53
+#: src\commands\help.ts:50
 msgctxt "command-description"
 msgid "Get help with a Slash Command."
 msgstr ""
 
-#: src\commands\deck.ts:83
+#: src\commands\deck.ts:122
 msgctxt "command-description"
 msgid "Display a deck list from ydke:// or .ydk format, exported from a number of deck building programs."
 msgstr ""
@@ -1319,34 +1258,24 @@ msgctxt "command-description"
 msgid "Check or set Bastion's locale for this channel or server."
 msgstr ""
 
-#: src\commands\random.ts:44
+#: src\commands\random.ts:45
 msgctxt "command-description"
 msgid "Get a random Yu-Gi-Oh! card."
 msgstr ""
 
-#: src\commands\price.ts:91
+#: src\commands\price.ts:90
 msgctxt "command-description"
 msgid "Display the price for a card!"
 msgstr ""
 
-#: src\commands\rush-duel.ts:58
+#: src\commands\rush-duel.ts:59
 msgctxt "command-description"
 msgid "Find information on Rush Duel cards."
 msgstr ""
 
-#: src\commands\query.ts:30
+#: src\commands\query.ts:31
 msgctxt "command-description"
 msgid "Advanced search prototype"
-msgstr ""
-
-#: src\commands\locale-user.ts:32
-msgctxt "command-description"
-msgid "Check or set user-installed Bastion's locale."
-msgstr ""
-
-#: src\commands\metagame.ts:205
-msgctxt "command-description"
-msgid "Show statistics on the current competitive state of play."
 msgstr ""
 
 #: src\commands\locale.ts:43
@@ -1359,71 +1288,7 @@ msgctxt "command-option-choice"
 msgid "server"
 msgstr ""
 
-#: src\commands\locale-user.ts:49
 #: src\commands\locale.ts:51
 msgctxt "command-option-choice"
 msgid "Discord default"
-msgstr ""
-
-#: src\commands\metagame.ts:219
-#: src\commands\metagame.ts:251
-msgctxt "command-option-choice"
-msgid "TCG"
-msgstr ""
-
-#: src\commands\metagame.ts:220
-#: src\commands\metagame.ts:255
-msgctxt "command-option-choice"
-msgid "OCG"
-msgstr ""
-
-#: src\commands\metagame.ts:221
-#: src\commands\metagame.ts:259
-msgctxt "command-option-choice"
-msgid "OCG (Asian-English)"
-msgstr ""
-
-#: src\commands\metagame.ts:228
-msgctxt "command-option-choice"
-msgid "Master Duel Diamond+ tier list"
-msgstr ""
-
-#: src\commands\metagame.ts:261
-msgctxt "command-option-choice"
-msgid "Master Duel ranked ladder"
-msgstr ""
-
-#: src\commands\metagame.ts:283
-msgctxt "command-option-choice"
-msgid "Current format"
-msgstr ""
-
-#: src\commands\metagame.ts:287
-msgctxt "command-option-choice"
-msgid "Since last Forbidden/Limited List"
-msgstr ""
-
-#: src\commands\metagame.ts:291
-msgctxt "command-option-choice"
-msgid "Last 7 days"
-msgstr ""
-
-#: src\commands\metagame.ts:295
-msgctxt "command-option-choice"
-msgid "Last 14 days"
-msgstr ""
-
-#: src\commands\metagame.ts:299
-msgctxt "command-option-choice"
-msgid "Last 30 days"
-msgstr ""
-
-#: src\commands\metagame.ts:303
-msgctxt "command-option-choice"
-msgid "Last three months"
-msgstr ""
-
-#: src\commands\metagame.ts:307
-msgctxt "command-option-choice"
-msgid "Last six months"
 msgstr ""


### PR DESCRIPTION
User-install and direct messages are governed by a user-specific table. The same setting applies to all of these contexts. This means that in a server without Bastion, using user-installed Bastion commands will use the user's locale, the same as their direct messages, including group chats. Very few users had a locale override configured for direct messages and those will be manually migrated to the new user-based table from the channel-based one.

Points of improvement:
- remove async/await from LocaleProvider entirely
- expose the new modular LocaleScope API instead of specific methods
- logic is reproduced in three locations: LocaleProvider, /locale, and /locale-user